### PR TITLE
Fix problems that can arise cythonizing linkExtension (gh-77)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,7 @@ def get_cython_extfiles(extnames):
             # For some reason, setup in setuptools does not compile
             # Cython files (!)  Do that manually...
             print "cythoning %s to %s" % (extpfile, extcfile)
-            retcode = subprocess.call(["cython", extpfile])
+            retcode = subprocess.call(["python", "-m", "cython", extpfile])
             if retcode > 0:
                 print "cython aborted compilation with retcode:", retcode
                 sys.exit()


### PR DESCRIPTION
The version specific pyx ext are now copied before performing cythonization checks
