### PR TITLE
ViTables Was Failing To Start

### DIFF
--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -315,27 +315,29 @@ def _register_all():
 
 def _deregister_aliases(flavor):
     """Deregister aliases of a given `flavor` (no checks)."""
-
+    rm_aliases = []
     for (an_alias, a_flavor) in alias_map.iteritems():
         if a_flavor == flavor:
-            del alias_map[an_alias]
+            rm_aliases.append(an_alias)
+    for an_alias in rm_aliases:
+        del alias_map[an_alias]
 
 def _deregister_description(flavor):
     """Deregister description of a given `flavor` (no checks)."""
-
     del description_map[flavor]
 
 def _deregister_identifier(flavor):
     """Deregister identifier function of a given `flavor` (no checks)."""
-
     del identifier_map[flavor]
 
 def _deregister_converters(flavor):
     """Deregister converter functions of a given `flavor` (no checks)."""
-
+    rm_flavor_pairs = []
     for flavor_pair in converter_map:
         if flavor in flavor_pair:
-            del converter_map[flavor_pair]
+            rm_flavor_pairs.append(flavor_pair)
+    for flavor_pair in rm_flavor_pairs:
+        del converter_map[flavor_pair]
 
 def _disable_flavor(flavor):
     """Completely disable the given `flavor` (no checks)."""


### PR DESCRIPTION
Because the flavor deregistration was trying to modify dictionaries in place.  This is a small fix which allows ViTables to start.
