### PR TITLE
Fixes bug with completely sorted indexes where nrowsinbuf must be equal ...

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -366,7 +366,7 @@ class Leaf(Node):
         # to make sure nrowsinbuf is greater than or
         # equal to the chunksize.
         chunksize = numpy.asarray(self.chunkshape).prod()
-        if nrowsinbuf < chunksize:
+        if chunksize is not None and nrowsinbuf < chunksize:
             nrowsinbuf = chunksize
 
         # Safeguard against row sizes being extremely large


### PR DESCRIPTION
...to or greater than the chunksize. refs issue #206 on https://github.com/PyTables/PyTables/issues/206
