### PR TITLE
Automatically disable extended float support for broken HDF5

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -43,7 +43,7 @@ Bugs fixed
   :issue:`299`)
 - Automatically disable extended float support if a buggy version of HDF5
   is detected (see also `Issues with H5T_NATIVE_LDOUBLE`_).
-  Closes :issue:`275` and :issue:`290`.
+  See also :issue:`275` and :issue:`290`.
 
 .. _pip: http://www.pip-installer.org
 .. _Anaconda: https://store.continuum.io/cshop/anaconda

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -188,8 +188,8 @@ if 'Float16Atom' in locals():
     __all__.extend(('Float16Atom', 'Float16Col'))
 
 
-from tables.utilsextension import _broken_hdf5_extended_float
-if not _broken_hdf5_extended_float():
+from tables.utilsextension import _broken_hdf5_long_double
+if not _broken_hdf5_long_double():
     if 'Float96Atom' in locals():
         __all__.extend(('Float96Atom', 'Float96Col'))
         __all__.extend(('Complex192Atom', 'Complex192Col'))    # XXX check
@@ -213,4 +213,4 @@ else:
         _atom.all_types.discard('complex256')
         _atom.ComplexAtom._isizes.remove(32)
     del _atom, _description
-del _broken_hdf5_extended_float
+del _broken_hdf5_long_double

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -224,8 +224,8 @@ class ReadFloatTestCase(common.PyTablesTestCase):
                                       getattr, self.fileh.root, dtype)
                 self.assertTrue(isinstance(ds, UnImplemented))
             except AssertionError:
-                from tables.utilsextension import _broken_hdf5_extended_float
-                if not _broken_hdf5_extended_float():
+                from tables.utilsextension import _broken_hdf5_long_double
+                if not _broken_hdf5_long_double():
                     ds = getattr(self.fileh.root, dtype)
                     self.assertEqual(ds.dtype, "float64")
 

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -383,7 +383,7 @@ silenceHDF5Messages = previous_api(silence_hdf5_messages)
 silence_hdf5_messages()
 
 
-def _broken_hdf5_extended_float():
+def _broken_hdf5_long_double():
     # HDF5 < 1.8.12 has a bug that prevents correct identification of the
     # long double data type when the code is built with gcc 4.8.
     # See also: http://hdf-forum.184993.n3.nabble.com/Issues-with-H5T-NATIVE-LDOUBLE-tt4026450.html


### PR DESCRIPTION
HDF5 < 1.8.12 has a bug that prevents correct identification of the long double data type when the code is built with gcc 4.8.

See also: http://hdf-forum.184993.n3.nabble.com/Issues-with-H5T-NATIVE-LDOUBLE-tt4026450.html

This PR automatically disable extended float support if a buggy version of HDF5 is detected.
