### PR TITLE
Add to vlarray the method get_row_size. Closes #24.

### DIFF
--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -239,6 +239,18 @@ class BasicTestCase(unittest.TestCase):
             self.assertEqual(row3, [7, 8, 9, 10])
         self.assertEqual(len(row3), 4)
 
+    def test04_get_row_size(self):
+        """Checking get_row_size method."""
+
+        self.fileh = open_file(self.file, "a")
+        vlarray = self.fileh.get_node("/vlarray1")
+
+        self.assertEqual(vlarray.get_row_size(0), 2 * vlarray.atom.size)
+        self.assertEqual(vlarray.get_row_size(1), 3 * vlarray.atom.size)
+        self.assertEqual(vlarray.get_row_size(2), 0 * vlarray.atom.size)
+        self.assertEqual(vlarray.get_row_size(3), 4 * vlarray.atom.size)
+        self.assertEqual(vlarray.get_row_size(4), 5 * vlarray.atom.size)
+
 
 class BasicNumPyTestCase(BasicTestCase):
     flavor = "numpy"


### PR DESCRIPTION
get_row_size return the total size in bytes of a given row in a
vlarray. Having this feature may allow users to know whether a read
would take a lot of memory and time or not.

Please note that this is not always indicative of how many elements
are contained in the row as there are atom of non-fixed size, e.g.
Objects. For atoms of fixed size this is equivalent to the number of
elements times the size.
