### PR TITLE
bugfix huge buffers

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -372,7 +372,7 @@ class Leaf(Node):
         # equal to the chunksize.
         # See gh-206 and gh-238
         if self.chunkshape is not None:
-            chunksize = numpy.asarray(self.chunkshape).prod()
+            chunksize = self.chunkshape[0]
             if nrowsinbuf < chunksize:
                 nrowsinbuf = chunksize
 


### PR DESCRIPTION
Previously, the number of rows in the buffer was equal to the number of
elements in the chunk, which can be pretty big. In combination with a
big enough rowsize, at iteration time (i.e. in array.next()), a huge
array might try to be allocated. This operation sometime fails with a
MemoryError, and increases the memory footprint of the application when
it doesn't. According to gh-206, this operation was meant to satisfy the
assertion in tableextension.pyx, but chunksize is defined there as
chunkshape[0], not as chunshape.prod() (perhaps it is a bit of a
misnomer)
