### PR TITLE
select multiple rows by 1-d array of indices

### DIFF
--- a/tables/array.py
+++ b/tables/array.py
@@ -650,7 +650,10 @@ class Array(hdf5extension.Array, Leaf):
             # Then, try with a point-wise selection
             try:
                 coords = self._point_selection(key)
-                arr = self._read_coords(coords)
+                if coords.ndim == 1 and self.ndim != 1:
+                    arr = self[key, ...]
+                else:
+                    arr = self._read_coords(coords)
             except TypeError:
                 # Finally, try with a fancy selection
                 selection, reorder, shape = self._fancy_selection(key)
@@ -717,7 +720,10 @@ class Array(hdf5extension.Array, Leaf):
             # Then, try with a point-wise selection
             try:
                 coords = self._point_selection(key)
-                self._write_coords(coords, nparr)
+                if coords.ndim == 1 and self.ndim != 1:
+                    self[coords, ...] = nparr
+                else:  
+                    self._write_coords(coords, nparr)
             except TypeError:
                 selection, reorder, shape = self._fancy_selection(key)
                 self._write_selection(selection, reorder, shape, nparr)


### PR DESCRIPTION
not sure if the best solution, but it makes a[i] work as a[i,...]. without this patch a[i] crashes if a has more than 1 dimension
