### PR TITLE
Do not create a temporary array when obj is not specified in create_array

### DIFF
--- a/tables/file.py
+++ b/tables/file.py
@@ -1135,7 +1135,11 @@ class File(hdf5extension.File, object):
                                 '(or None) then both the atom and shape '
                                 'parametes should be provided.')
             else:
-                obj = numpy.zeros(shape, atom.dtype)
+                # Making strides=(0,...) below is a trick to create the
+                # array fast and without memory consumption
+                dflt = numpy.zeros((), dtype=atom.dtype)
+                obj = numpy.ndarray(shape, dtype=atom.dtype, buffer=dflt,
+                                    strides=(0,)*len(shape))
         else:
             flavor = flavor_of(obj)
             # use a temporary object because converting obj at this stage

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -357,11 +357,17 @@ def _is_numpy(array):
 
 
 def _numpy_contiguous(convfunc):
-    """Decorate `convfunc` to return a *contiguous* NumPy array."""
+    """Decorate `convfunc` to return a *contiguous* NumPy array.
+
+    Note: When arrays are 0-strided, the copy is avoided.  This allows
+    to use `array` to still carry info about the dtype and shape.
+    """
 
     def conv_to_numpy(array):
         nparr = convfunc(array)
-        if hasattr(nparr, 'flags') and not nparr.flags.contiguous:
+        if (hasattr(nparr, 'flags') and
+            not nparr.flags.contiguous and
+            sum(nparr.strides) != 0):
             nparr = nparr.copy()  # copying the array makes it contiguous
         return nparr
     conv_to_numpy.__name__ = convfunc.__name__

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1206,7 +1206,13 @@ cdef class Array(Leaf):
     self.rank = len(shape)
     self.dims = npy_malloc_dims(self.rank, <npy_intp *>(dims.data))
     # Get the pointer to the buffer data area
-    rbuf = nparr.data
+    strides = (<object>nparr).strides
+    # When the object is not a 0-d ndarray and its strides == 0, that
+    # means that the array does not contain actual data
+    if strides != () and sum(strides) == 0:
+      rbuf = NULL
+    else:
+      rbuf = nparr.data
     # Save the array
     complib = (self.filters.complib or '').encode('utf-8')
     version = self._v_version.encode('utf-8')


### PR DESCRIPTION
This is a solution for avoiding the creation of temporaries when creating a regular Array object when specifying  the atom and shape only.  Fixes #337.

Memory consumption is now similar to h5py, and by running the examples in [this post](https://groups.google.com/forum/#!topic/h5py/_8-bTZuwbdE) (but with n = 50000 to make things a bit faster), we get:

with h5py:

```
$ rm test.h5; time python benchmark-h5py.py
Creating HDF5 file...
0 1 2 3 4 5 6 7 8 9 Elapsed: 0.02 s
Bandwidth: 77.6 MB/s

real    0m4.284s
user    0m3.854s
sys     0m0.420s
```

with PyTables:

```
$ rm test.h5; time python benchmark-tables.py
Creating HDF5 file...
0 1 2 3 4 5 6 7 8 9 Elapsed: 0.01 s
Bandwidth: 225.7 MB/s

real    0m3.825s
user    0m3.283s
sys     0m0.535s
```

which is pretty much faster than h5py (don't know exactly why).
