### PR TITLE
ENH: direct copy from filesystem to filenode and vice versa

### DIFF
--- a/doc/source/usersguide/libref/filenode_classes.rst
+++ b/doc/source/usersguide/libref/filenode_classes.rst
@@ -23,6 +23,10 @@ Module functions
 
 .. autofunction:: open_node
 
+.. autofunction:: read_from_filenode
+
+.. autofunction:: save_to_filenode
+
 
 The RawPyTablesIO base class
 ----------------------------


### PR DESCRIPTION
I'm still new to pytables, so maybe some things could be done more elegantly than I did them.

Docstrings are still missing, as is the passthrough of kwargs in write_to_filenode.

closes #341
