### PR TITLE
Update atexit_hook cookbook to be backward compatible

### DIFF
--- a/doc/source/cookbook/tailoring_atexit_hooks.rst
+++ b/doc/source/cookbook/tailoring_atexit_hooks.rst
@@ -26,8 +26,16 @@ For example, if you  register this function::
         if verbose and are_open_files:
             sys.stderr.write("Closing remaining open files:")
 
-        # make a copy of the open_files.handlers container for the iteration
-        handlers = list(open_files.handlers)
+        if StrictVersion(tables.__version__) >= StrictVersion("3.1.0"):
+            # make a copy of the open_files.handlers container for the iteration
+            handlers = list(open_files.handlers)
+        else:
+            # for older versions of pytables, setup the handlers list from the
+            # keys
+            keys = open_files.keys()
+            handlers = []
+            for key in keys:
+                handlers.append(open_files[key])
 
         for fileh in handlers:
             if verbose:
@@ -42,6 +50,7 @@ For example, if you  register this function::
             sys.stderr.write("\n")
 
     import sys, atexit
+    from distutils.version import StrictVersion
     atexit.register(my_close_open_files, False)
 
 then, you won't get the closing messages anymore because the new registered


### PR DESCRIPTION
The API has changed, and I did update to pytables 3.1.1 only today. My atexit_hook in my app was broken ...

I then saw that the cookbook has been updated, which is nice (and it's python 3 compatible), but it is not backward compatible with pytables 3.0.0 or 2.x.

I added the missing code to make it backward compatible.

Note: I did not modify the revision number (on top of the page) for the cookbook, the previous commit by @avalentino did also not modify it, so I don't know if this needs to be changed ?
BTW, the page on the website is not up to date and displays the old version: http://www.pytables.org/moin/UserDocuments/AtexitHooks
