### PR TITLE
adding warning about cython 0.21 to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ make use of PyTables.
 
 Installation
 ------------
+**Warning:  The the currrent release of PyTables is incompatible with cython 0.21.  See issues #386 and #387**
 
 The Python Distutils are used to build and install PyTables, so it is
 fairly simple to get things ready to go. Following are very simple


### PR DESCRIPTION
I think it would be helpful to let people know that PyTables isn't working with Cython 0.21 right now.  I looked at the README first and couldn't find any information there.  All the issues #391, #388, #386, #387 are marked closed so they don't show up at first glance either.  