### PR TITLE
Fix softlink as parent group

### DIFF
--- a/tables/node.py
+++ b/tables/node.py
@@ -204,6 +204,10 @@ class Node(object):
         # Remember to assign these values in the root group constructor
         # as it does not use this method implementation!
 
+        # if the parent node is a softlink, dereference it
+        if isinstance(parentnode, class_name_dict['SoftLink']):
+            parentnode = parentnode.dereference()
+
         self._v_file = None
         """The hosting File instance (see :ref:`FileClassDescr`)."""
 

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -343,6 +343,15 @@ class SoftLinkTestCase(common.TempFileMixin, TestCase):
         l_lgroup1.arr2[0] = -1
         self.assertTrue(arr2[:] == [-1, 2, 3])
 
+    def test14_child_of_softlink_to_group(self):
+        """Create an array whose parent is a softlink to another group"""
+
+        group1 = self.h5file.get_node('/group1')
+        lgroup1 = self.h5file.get_node('/lgroup1')
+        new_arr = self.h5file.create_array(lgroup1, 'new_arr', obj=[1, 2, 3])
+        new_arr2 = self.h5file.get_node('/group1/new_arr')
+        self.assertTrue(new_arr2[:] == [1, 2, 3])
+
     def test_str(self):
         s = str(self.h5file)
         self.assertEqual(len(re.findall('\(SoftLink\)', s)), 3)


### PR DESCRIPTION
I just noticed that it's not currently possible to create a new node whose parent is a softlink to another group:

```python
In [1]: tmpf = tables.open_file('/tmp/test.hdf5', 'w')

In [2]: g1 = tmpf.create_group('/', 'group1')                                                                                                                                                                        

In [3]: link_g1 = tmpf.create_soft_link('/', 'link_group1', g1)                                                                                                                                                      

In [4]: arr = tmpf.create_array(link_g1, 'test', obj=[1, 2, 3])                                                                                                                                      
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-c51f3a997beb> in <module>()
----> 1 arr = tmpf.create_array(link_g1, 'test', obj=[1, 2, 3])

/home/alistair/.venvs/core/local/lib/python2.7/site-packages/tables/file.pyc in create_array(self, where, name, obj, title, byteorder, createparents, atom, shape)
   1150         parentnode = self._get_or_create_path(where, createparents)
   1151         return Array(parentnode, name,
-> 1152                      obj=obj, title=title, byteorder=byteorder)
   1153 
   1154     createArray = previous_api(create_array)

/home/alistair/.venvs/core/local/lib/python2.7/site-packages/tables/array.pyc in __init__(self, parentnode, name, obj, title, byteorder, _log, _atom)
    185         # Ordinary arrays have no filters: leaf is created with default ones.
    186         super(Array, self).__init__(parentnode, name, new, Filters(),
--> 187                                     byteorder, _log)
    188 
    189     def _g_create(self):

/home/alistair/.venvs/core/local/lib/python2.7/site-packages/tables/leaf.pyc in __init__(self, parentnode, name, new, filters, byteorder, _log)
    260         # is a lazy property that automatically handles their loading.
    261 
--> 262         super(Leaf, self).__init__(parentnode, name, _log)
    263 
    264     def __len__(self):

/home/alistair/.venvs/core/local/lib/python2.7/site-packages/tables/node.pyc in __init__(self, parentnode, name, _log)
    243 
    244         # Is the parent node a group?  Is it open?
--> 245         self._g_check_group(parentnode)
    246         parentnode._g_check_open()
    247         file_ = parentnode._v_file

/home/alistair/.venvs/core/local/lib/python2.7/site-packages/tables/node.pyc in _g_check_group(self, node)
    852         if not isinstance(node, class_name_dict['Group']):
    853             raise TypeError("new parent node ``%s`` is not a group"
--> 854                             % node._v_pathname)
    855 
    856     _g_checkGroup = previous_api(_g_check_group)

TypeError: new parent node ``/link_group1`` is not a group
```

I think this can be fixed quite easily in `Node.__init__` by checking whether the parent node is a softlink and dereferencing it if this is the case.