### PR TITLE
Travis container build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - liblzo2-dev
 
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -U unittest2 --use-mirrors; fi
+  - pip install -r requirements.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -U unittest2; fi
 
 script: make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
   apt_packages:
     - libhdf5-serial-dev
     - liblzo2-dev
-    - python3-numpy
 
 install:
   - pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ sudo: false
 
 addons:
   apt_packages:
+    - libbz2-dev
     - libhdf5-serial-dev
     - liblzo2-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     - liblzo2-dev
 
 install:
-  - pip install -U -r requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -U unittest2; fi
+  - pip install -r requirements.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 
 script: make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,15 @@ python:
   - 3.3
   - 3.4
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libhdf5-serial-dev liblzo2-dev libbz2-dev python3-numpy
+sudo: false
+
+addons:
+  apt_packages:
+    - libhdf5-serial-dev
+    - liblzo2-dev
+    - python3-numpy
+
+install:
   - pip install -r requirements.txt --use-mirrors
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -U unittest2 --use-mirrors; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - liblzo2-dev
 
 install:
-  - pip install -r requirements.txt
+  - pip install -U -r requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -U unittest2; fi
 
 script: make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 python:
   - 2.6
   - 2.7
-  - "2.7_with_system_site_packages"
   - 3.2
-  - "3.2_with_system_site_packages"
   - 3.3
   - 3.4
 


### PR DESCRIPTION
Hi,

this patch changes the current `.travis.yml` build script to enable the use of TravisCI new container infrastructure. It is pretty straightforward as apt packages can be installed without using sudo by listing them in the configuration file.
I also did some cleanup. The environments "with_system_site_packages" seems not be in use anymore on travis (I can't find any documentation for them), and they  seem not to make any difference. Also we don't need to install `python3-numpy` because `numpy` is always already installed in the virtualenvs that TravisCI provides.