### PR TITLE
Remove duplicate `hdf5_version` in Top-level docs

### DIFF
--- a/doc/source/usersguide/libref/top_level.rst
+++ b/doc/source/usersguide/libref/top_level.rst
@@ -10,8 +10,6 @@ Global variables
 
 .. autodata:: hdf5_version
 
-.. autodata:: hdf5_version
-
 
 Global functions
 ----------------


### PR DESCRIPTION
The global variable `hdf5_version` appeared twice in the docs.
This removes one of the copies.