### PR TITLE
Setup.py requires now setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
 
 install:
   - pip install -r requirements.txt
+  - pip install cython
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 
 script: make check

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ and bzip2 compression libraries support you will also need recent
 versions of them. LZO and bzip2 compression libraries are, however,
 optional.
 
-We've tested this PyTables version with HDF5 1.8.11/1.8.12, NumPy
+We've tested this PyTables version with HDF5 1.8.4/1.8.12, NumPy
 1.7.1/1.8.0 and Numexpr 2.4, and you *need* to use these versions, or
 higher, to make use of PyTables.
 
@@ -103,7 +103,7 @@ available in Chapter 2 of the User's Manual (``doc/usersguide.pdf`` or
 http://pytables.github.io/usersguide/introduction.html).
 
 1. First, make sure that you have HDF5, NumPy and Numexpr installed
-   (you will need at least HDF5 >= 1.8.7, NumPy 1.7.1 and Numexpr
+   (you will need at least HDF5 >= 1.8.4, NumPy 1.7.1 and Numexpr
    2.3).  If don't, get them from http://www.hdfgroup.org/HDF5/,
    http://www.numpy.org and https://github.com/pydata/numexpr and
    install them.

--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ and bzip2 compression libraries support you will also need recent
 versions of them. LZO and bzip2 compression libraries are, however,
 optional.
 
-We've tested this PyTables version with HDF5 1.8.11/1.8.12, NumPy 1.7.1/1.8.0
-and Numexpr 2.2.2, and you *need* to use these versions, or higher, to
-make use of PyTables.
+We've tested this PyTables version with HDF5 1.8.11/1.8.12, NumPy
+1.7.1/1.8.0 and Numexpr 2.4, and you *need* to use these versions, or
+higher, to make use of PyTables.
 
 Installation
 ------------
@@ -103,16 +103,14 @@ available in Chapter 2 of the User's Manual (``doc/usersguide.pdf`` or
 http://pytables.github.io/usersguide/introduction.html).
 
 1. First, make sure that you have HDF5, NumPy and Numexpr installed
-   (you will need at least HDF5 1.8.4, HDF5 >= 1.8.7 is strongly recommended,
-   NumPy 1.4.1 and Numexpr 2.0).
-   If don't, get them from http://www.hdfgroup.org/HDF5/,
-   http://www.numpy.org and http://code.google.com/p/numexpr.
-   Compile/install them.
+   (you will need at least HDF5 >= 1.8.7, NumPy 1.7.1 and Numexpr
+   2.3).  If don't, get them from http://www.hdfgroup.org/HDF5/,
+   http://www.numpy.org and https://github.com/pydata/numexpr and
+   install them.
 
-   Optionally, consider to install the excellent LZO compression
-   library from http://www.oberhumer.com/opensource/.  You can also
-   install the high-performance bzip2 compression library, available
-   at http://www.bzip.org/.
+   Optionally, consider to install the LZO compression library from
+   http://www.oberhumer.com/opensource/.  You can also install the
+   bzip2 compression library, available at http://www.bzip.org/.
 
 2. From the main PyTables distribution directory run this command,
    (plus any extra flags needed as discussed above)::

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -14,63 +14,91 @@ Changes from 3.1.1 to 3.2.0
 Improvements
 ------------
 
+- setup.py has been largely simplified and now it requires *setuptools*.
+  Although we think this is a good step, please keep us informed this is
+  breaking some installation in a very bad manner.
+
 - It is now possible to create a new node whose parent is a softlink to another
   group (see :issue:`422`). Thanks to Alistair Muldal.
+
 - :class:`link.SoftLink` objects no longer need to be explicitly dereferenced.
   Methods and attributes of the linked object are now automatically accessed
   when the user acts on a soft-link (see :issue:`399`).
   Thanks to Alistair Muldal.
+
 - Now :program:`ptrepack` recognizes hardlinks and replicates them in the
   output (*repacked*) file. This saves disk space and makes repacked files
   more conformal to the original one. Closes :issue:`380`.
+
 - New :program:`pttree` script for printing HDF5 file contents as a pretty
   ASCII tree (closes :issue:`400`). Thanks to Alistair Muldal.
+
 - The internal Blosc_ library has been downgraded to version 1.4.1.
   This is in order to still allow using multiple threads *inside* Blosc, even
   on multithreaded applications (see :issue:`411` and :issue:`412`).  This
   issue can (and should) be removed in the future.
   The new version of Blosc_ also includes a couple of security fixes and
   support for architectures requiring strict access alignment.
+
 - The :func:`print_versions` function now also reports the version of
-  compression libraries used by blosc
+  compression libraries used by blosc.
+
 - Now the :file:`setup.py` tries to use the '-march=native' C flag by
   default. In falls back on '-msse2' if '-march=native' is not supported
   by the compiler. Closes :issue:`379`.
+
 - Fixed a spurious unicode comparison warning (closes :issue:`372` and
   :issue:`373`).
+
 - Improved handling of empty string attributes. In previous versions of
   PyTables empty string were stored as scalar HDF5 attributes having size 1
   and value '\0' (an empty null terminated string).
   Now empty string are stored as HDF5 attributes having zero size
+
 - Added a new cookbook recipe and a couple of examples for simple threading
   with PyTables.
+
 - The redundant :func:`utilsextension.get_indices` function has been
   eliminated (replaced by :meth:`slice.indices`). Closes :issue:`195`.
+
 - Allow negative indices in point selection (closes :issue:`360`)
+
 - Index wasn't being used if it claimed there were no results.
   Closes :issue:`351` (see also :issue:`353`)
+
 - Atoms and Col types are no longer generated dynamically so now it is easier
   for IDEs and static analysis tool to handle them (closes :issue:`345`)
+
 - The keysort functions in idx-opt.c have been cythonised using fused types.
   The perfomance is mostly unchanged, but the code is much more simpler now.
   Thanks to Andrea Bedini.
+
 - Small unit tests re-factoring:
 
   * :func:`print_versions` and :func:`tests.common.print_heavy` functions
      moved to the :mod:`tests.common` module
+
   * always use :func:`print_versions` when test modules are called as scripts
+
   * use the unittest2_ package in Python 2.6.x
+
   * removed internal machinery used to replicate unittest2_ features
+
   * always use :class:`tests.common.PyTablesTestCase` as base class for all
     test cases
+
   * code of the old :func:`tasts.common.cleanup` function has been moved to
     :meth:`tests.common.PyTablesTestCase.tearDown` method
+
   * new implementation of :meth:`tests.common.PyTablesTestCase.assertWarns`
     compatible with the one provided by the standard :mod:`unittest` module
     in Python >= 3.2
+
   * use :meth:`tests.common.PyTablesTestCase.assertWarns` as context manager
     when appropriate
+
   * use the :func:`unittest.skipIf` decorator when appropriate
+
   * new :class:tests.comon.TestFileMixin: class
 
 
@@ -82,28 +110,41 @@ Bugs fixed
 
 - Fixed compatibility problems with numpy 1.9 and 1.10-dev
   (closes :issue:`362` and :issue:`366`)
+
 - Fixed compatibility with Cython_ >= 0.20 (closes :issue:`386` and
   :issue:`387`)
+
 - Fixed support for unicode node names in LRU cache (only Python 2 was
   affected). Closes :issue:`367` and :issue:`369`.
+
 - Fixed support for unicode node titles (only Python 2 was affected).
   Closes :issue:`370` and :issue:`374`.
+
 - Fixed a bug that caused the silent truncation of unicode attributes
   containing the '\0' character. Closes :issue:`371`.
+
 - Fixed :func:`descr_from_dtype` to work as expected with complex types.
   Closes :issue:`381`.
+
 - Fixed the :class:`tests.test_basics.ThreadingTestCase` test case.
   Closes :issue:`359`.
+
 - Fix incomplete results when performing the same query twice and exhausting
   the second iterator before the first. The first one writes incomplete
   results to *seqcache* (:issue:`353`)
+
 - Fix false results potentially going to *seqcache* if
   :meth:`tableextension.Row.update` is used during iteration
   (see :issue:`353`)
+
 - Fix :meth:`Column.create_csindex` when there's NaNs
+
 - Fixed handling of unicode file names on windows (closes :issue:`389`)
+
 - No longer not modify :data:`sys.argv` at import time (closes :issue:`405`)
+
 - Fixed a performance issue on NFS (closes :issue:`402`)
+
 - Fixed a nasty problem affecting results of indexed queries.
   Closes :issue:`319` and probably :issue:`419` too.
 
@@ -111,14 +152,12 @@ Bugs fixed
 Other changes
 -------------
 
-- The minimum Cython_ version is now 0.14.
+- Cython is not a hard dependency anymore (although developers will need it
+  so as to generated the C extension code).
+
 - The number of threads used by default for numexpr and blosc operation that
   was set to the number of available cores have been reduced to 2.  This is
   a much more reasonable setting for not creating too much overhead.
-
-
-.. _Cython: http://cython.org
-
 
 
   **Enjoy data!**

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -49,9 +49,9 @@ Prerequisites
 First, make sure that you have
 
 * Python_ >= 2.6 including Python 3.x
-* HDF5_ >= 1.8.4 (>=1.8.7 is strongly recommended),
-* NumPy_ >= 1.4.1,
-* Numexpr_ >= 2.0 and
+* HDF5_ >= 1.8.7
+* NumPy_ >= 1.7.1,
+* Numexpr_ >= 2.4 and
 * Cython_ >= 0.14
 * c-blosc_ >= 1.3.0 (it is bundled with PyTables sources but the user can
   use an external version of sources using the :envvar:`BLOSC_DIR` environment
@@ -60,7 +60,7 @@ First, make sure that you have
 * unittest2_ (only Python 2.6)
 
 installed (for testing purposes, we are using HDF5_ 1.8.12, NumPy_ 1.8.0
-and Numexpr_ 2.2.2 currently). If you don't, fetch and install them before
+and Numexpr_ 2.4.1 currently). If you don't, fetch and install them before
 proceeding.
 
 .. _Python: http://www.python.org
@@ -71,12 +71,6 @@ proceeding.
 .. _c-blosc: http://blosc.org
 .. _argparse: http://code.google.com/p/argparse
 .. _unittest2: http://pypi.python.org/pypi/unittest2
-
-.. note::
-
-    HDF5 versions < 1.8.7 are supported with some limitations.
-    It is not possible to open the same file multiple times (simultaneously),
-    even in read-only mode.
 
 .. note::
 

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -49,7 +49,7 @@ Prerequisites
 First, make sure that you have
 
 * Python_ >= 2.6 including Python 3.x
-* HDF5_ >= 1.8.7
+* HDF5_ >= 1.8.4
 * NumPy_ >= 1.7.1,
 * Numexpr_ >= 2.4 and
 * Cython_ >= 0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy>=1.4.1
-numexpr>=2.0
-cython>=0.14
+numpy>=1.7.1
+numexpr>=2.4

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -17,4 +17,4 @@
 # Minimum recommended versions for mandatory packages
 min_numpy_version = '1.7.1'
 min_numexpr_version = '2.4'
-min_hdf5_version = (1, 8, 7)
+min_hdf5_version = (1, 8, 4)

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -10,15 +10,11 @@
 
 """Required versions for PyTables dependencies."""
 
-#***************************************************************
-#  Keep these in sync with setup.py and user's guide and README
-#***************************************************************
+#**********************************************************************
+#  Keep these in sync with requirements.txt and user's guide and README
+#**********************************************************************
 
 # Minimum recommended versions for mandatory packages
-min_numpy_version = '1.4.1'
-min_numexpr_version = '2.0.0'
-min_cython_version = '0.14'
-
-# The THG team has decided to fix an API inconsistency in the definition
-# of the H5Z_class_t structure in version 1.8.3
-min_hdf5_version = (1, 8, 4)  # necessary for allowing 1.8.10 > 1.8.5
+min_numpy_version = '1.7.1'
+min_numexpr_version = '2.4'
+min_hdf5_version = (1, 8, 7)


### PR DESCRIPTION
Also, Cython is not a requirement anymore and minimum versions for hdf5/numpy/numexpr have been bumped up to 1.8.7, 1.7.1. and 2.4.1 respectively.

This is just for some quick discussions, as I would like to merge it pretty quick.