### PR TITLE
pkg-config support

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -25,6 +25,12 @@ Improvements
   Although we think this is a good step, please keep us informed this is
   breaking some installation in a very bad manner.
 
+- setup.py now is able to used *pkg-config*, if available, to locate required
+  libraries (hdf5, bzip2, etc.). The use of *pkg-config* can be controlled
+  via setup.py command line flags or via environment variables.
+  Please refer to the installation guide (in the *User Manual*) for details.
+  Closes :issue:`442`.
+
 - It is now possible to create a new node whose parent is a softlink to another
   group (see :issue:`422`). Thanks to Alistair Muldal.
 

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -48,7 +48,7 @@ Prerequisites
 
 First, make sure that you have
 
-* Python_ >= 2.6 including Python 3.x
+* Python_ >= 2.6 including Python 3.x (Python >= 2.7 is highly recommended)
 * HDF5_ >= 1.8.4 (>=1.8.7 is strongly recommended)
 * NumPy_ >= 1.7.1
 * Numexpr_ >= 2.4
@@ -153,6 +153,25 @@ worry too much ;)
 
           $ C_INCLUDE_PATH=/usr/lib/openmpi/include pip install --upgrade tables
 
+    Since PyTables 3.2 can also query the *pkg-config* database to find the
+    required packages. If available, pkg-config is used by default unless 
+    another flag like `--hdf5`, `--bzip2`, etc. has been specified.
+    To force the use of *pkg-config* the `--use-pkgconfig` flag can be used::
+
+      $ python setup.py build --hdf5=/custom/hdf5/path --use-pkgconfig
+
+    or use the :envvar:`USE-PKGCONFIG` environment variable::
+
+      $ env USE_PKGCONFIG=TRUE python setup.py build --hdf5=/custom/hdf5/path
+
+    To suppress the use of *pkg-config*::
+
+      $ python setup.py build --use-pkgconfig=FALSE
+
+    or use the :envvar:`USE-PKGCONFIG` environment variable::
+
+      $ env USE_PKGCONFIG=FALSE python setup.py build
+
 **Windows**
 
     You can get ready-to-use Windows binaries and other development files for
@@ -214,6 +233,11 @@ you can proceed with the PyTables package itself.
    any extra command line arguments as discussed above::
 
       $ python setup.py build
+
+   If the HDF5 installation is in a custom path, e.g. $HOME/hdf5-1.8.15pre7,
+   one of the following commands can be used::
+
+      $ python setup.py build --hdf5=$HOME/hdf5-1.8.15pre7
 
 #. To run the test suite, execute any of these commands.
 
@@ -319,6 +343,15 @@ you can proceed with the PyTables package itself.
 
       $ python setup.py install
 
+   Again if one needs to point to libraries installed in custom paths, then
+   specific setup.py options can be used::
+
+      $ python setup.py install --hdf5=/hdf5/custom/path
+
+   or::
+
+      $ env HDF5_DIR=/hdf5/custom/path python setup.py install
+
    Of course, you will need super-user privileges if you want to install
    PyTables on a system-protected area. You can select, though, a different
    place to install the package using the :option:`--prefix` flag::
@@ -358,10 +391,19 @@ installed at system level::
 
   $ pip install --user --upgrade tables
 
-The `--user` option tels to the :program:`pip` tool to install the package in
+The `--user` option tells to the :program:`pip` tool to install the package in
 the user folder (``$HOME/.local`` on GNU/Linux and Unix systems), while the
 `--upgrade` option forces the installation of the latest version even if an
 older version of the package is already installed.
+
+Additional options for the setup.py script can be specified using them
+`--install-option`::
+
+  $ pip install --install-option='--hdf5=/custom/path/to/hdf5' tables
+
+or::
+
+  $ env HDF5_DIR=/custom/path/to/hdf5 pip install tables
 
 The :program:`pip` tool can also be used to install packages from a source
 tar-ball::
@@ -387,6 +429,29 @@ can be used by :program:`pip` to install the PyTables dependencies::
 Of course the :file:`requirements.txt` file can be used to install only
 python packages.  Other dependencies like the HDF5 library of compression
 libraries have to be installed by the user.
+
+.. note::
+
+   Recent versions of Debian_ and Ubuntu_ the HDF5 library is installed in
+   with a very peculiar layout that allows to have both the serial and MPI
+   versions installed at the same time.
+
+   PyTables >= 3.2 natively supports the new layout via *pkg-config* (that
+   is expected to be installed on the system at build time).
+
+   If *pkg-config* is not available or PyTables is older that verison 3.2,
+   then the following command can be used::
+
+     $ env CPPFLAGS=-I/usr/include/hdf5/serial \
+     LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial python3 setup.py install
+
+   or::
+
+     $ env CPPFLAGS=-I/usr/include/hdf5/serial \
+     LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial pip install tables
+
+.. _Debian: https://www.debian.org
+.. _Ubuntu: http://www.ubuntu.com
 
 
 .. _binaryInstallationDescr:

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -153,9 +153,9 @@ worry too much ;)
 
           $ C_INCLUDE_PATH=/usr/lib/openmpi/include pip install --upgrade tables
 
-    Since PyTables 3.2 can also query the *pkg-config* database to find the
-    required packages. If available, pkg-config is used by default unless 
-    another flag like `--hdf5`, `--bzip2`, etc. has been specified.
+    Starting from PyTables 3.2 can also query the *pkg-config* database to
+    find the required packages. If available, pkg-config is used by default
+    unless another flag like `--hdf5`, `--bzip2`, etc. has been specified.
     To force the use of *pkg-config* the `--use-pkgconfig` flag can be used::
 
       $ python setup.py build --hdf5=/custom/hdf5/path --use-pkgconfig

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -155,14 +155,7 @@ worry too much ;)
 
     Starting from PyTables 3.2 can also query the *pkg-config* database to
     find the required packages. If available, pkg-config is used by default
-    unless another flag like `--hdf5`, `--bzip2`, etc. has been specified.
-    To force the use of *pkg-config* the `--use-pkgconfig` flag can be used::
-
-      $ python setup.py build --hdf5=/custom/hdf5/path --use-pkgconfig
-
-    or use the :envvar:`USE-PKGCONFIG` environment variable::
-
-      $ env USE_PKGCONFIG=TRUE python setup.py build --hdf5=/custom/hdf5/path
+    unless explicitly disabled.
 
     To suppress the use of *pkg-config*::
 

--- a/setup.py
+++ b/setup.py
@@ -84,15 +84,6 @@ if sys.version_info >= (3,):
     setuptools_kwargs['use_2to3_fixers'] = []
     setuptools_kwargs['use_2to3_exclude_fixers'] = exclude_fixers
 
-# The minimum required versions
-min_python_version = (2, 6)
-# Check for Python
-if sys.version_info < min_python_version:
-    exit_with_error("You need Python 2.6 or greater to install PyTables!")
-print("* Using Python %s" % sys.version.splitlines()[0])
-
-# Minumum equired versions for numpy, numexpr and HDF5
-exec(open(os.path.join('tables', 'req_versions.py')).read())
 
 # Some functions for showing errors and warnings.
 def _print_admonition(kind, head, body):
@@ -110,6 +101,18 @@ def exit_with_error(head, body=''):
 
 def print_warning(head, body=''):
     _print_admonition('warning', head, body)
+
+
+# The minimum required versions
+min_python_version = (2, 6)
+# Check for Python
+if sys.version_info < min_python_version:
+    exit_with_error("You need Python 2.6 or greater to install PyTables!")
+print("* Using Python %s" % sys.version.splitlines()[0])
+
+# Minumum equired versions for numpy, numexpr and HDF5
+min_hdf5_version = None
+exec(open(os.path.join('tables', 'req_versions.py')).read())
 
 
 VERSION = open('VERSION').read().strip()

--- a/setup.py
+++ b/setup.py
@@ -432,7 +432,7 @@ LFLAGS = os.environ.get('LFLAGS', '').split()
 # is not a good idea.
 CFLAGS = os.environ.get('CFLAGS', '').split()
 LIBS = os.environ.get('LIBS', '').split()
-USE_PKGCONFIG = None
+USE_PKGCONFIG = os.environ.get('USE_PKGCONFIG', 'TRUE')
 
 # ...then the command line.
 # Handle --hdf5=[PATH] --lzo=[PATH] --bzip2=[PATH] --blosc=[PATH]
@@ -442,27 +442,21 @@ for arg in args:
     if arg.find('--hdf5=') == 0:
         HDF5_DIR = expanduser(arg.split('=')[1])
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--lzo=') == 0:
         LZO_DIR = expanduser(arg.split('=')[1])
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--bzip2=') == 0:
         BZIP2_DIR = expanduser(arg.split('=')[1])
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--blosc=') == 0:
         BLOSC_DIR = expanduser(arg.split('=')[1])
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--lflags=') == 0:
         LFLAGS = arg.split('=')[1].split()
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--cflags=') == 0:
         CFLAGS = arg.split('=')[1].split()
         sys.argv.remove(arg)
-        USE_PKGCONFIG = False if USE_PKGCONFIG is None else USE_PKGCONFIG
     elif arg.find('--debug') == 0:
         # For debugging (mainly compression filters)
         if os.name != 'nt':  # to prevent including dlfcn.h by utils.c!!!
@@ -477,8 +471,6 @@ for arg in args:
             USE_PKGCONFIG = arg.split('=')[1]
 
 
-if USE_PKGCONFIG is None:
-    USE_PKGCONFIG = os.environ.get('USE_PKGCONFIG', 'TRUE')
 if isinstance(USE_PKGCONFIG, str):
     if USE_PKGCONFIG.upper() in ('TRUE', 'YES', '1', 'ON', 'OK'):
         USE_PKGCONFIG = True

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ from setuptools.command.build_ext import build_ext
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
-numpy_requirement = [ r for r in requirements if 'numpy' in r ]
+numpy_requirement = [r for r in requirements if 'numpy' in r]
+
 
 class BuildExtensions(build_ext):
     """Subclass setuptools build_ext command
@@ -51,7 +52,7 @@ class BuildExtensions(build_ext):
 
         for ext in self.extensions:
             if (hasattr(ext, 'include_dirs') and
-                numpy_incl not in ext.include_dirs):
+                    numpy_incl not in ext.include_dirs):
                 ext.include_dirs.append(numpy_incl)
 
         build_ext.run(self)
@@ -357,7 +358,7 @@ blosc_package = _Package("blosc", 'BLOSC', 'blosc', *_platdep['BLOSC'])
 blosc_package.target_function = 'blosc_list_compressors'  # Blosc >= 1.3
 
 
-#-----------------------------------------------------------------
+# -----------------------------------------------------------------
 
 def_macros = [('NDEBUG', 1)]
 # Define macros for Windows platform


### PR DESCRIPTION
This PR adds to the `setup.py` script the ability to use the pkg-config package to find dependencies.
By default pkg-config is always used (if available), unless explicitly disabled.

This PR should also fix #442.
