### PR TITLE
Fix compatibility with hdf5-1.8.15-pre7

### DIFF
--- a/c-blosc/hdf5/blosc_filter.c
+++ b/c-blosc/hdf5/blosc_filter.c
@@ -20,7 +20,7 @@
 
 #if H5Epush_vers == 2
 /* 1.8.x */
-#define PUSH_ERR(func, minor, str) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, str)
+#define PUSH_ERR(func, minor, str...) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, str)
 #else
 /* 1.6.x */
 #define PUSH_ERR(func, minor, str) H5Epush(__FILE__, func, __LINE__, H5E_PLINE, minor, str)
@@ -195,11 +195,18 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
         complist = blosc_list_compressors();
 	code = blosc_compcode_to_compname(compcode, &compname);
 	if (code == -1) {
+#if H5Epush_vers == 2
+            PUSH_ERR("blosc_filter", H5E_CALLBACK,
+                     "this Blosc library does not have support for "
+                     "the '%s' compressor, but only for: %s",
+                     compname, complist);
+#else
 	    sprintf(errmsg, "this Blosc library does not have support for "
                     "the '%s' compressor, but only for: %s",
 		    compname, complist);
             PUSH_ERR("blosc_filter", H5E_CALLBACK, errmsg);
             goto failed;
+#endif
 	}
     }
 


### PR DESCRIPTION
The implementation of H5Epush function has been modified in hdf5-1.8.15.
Now it raises an compilation warning that is turned into an error in Ubuntu 15.04 (and probably in Debian) due to compilation flags used to build the interpreter.
In the specific `-Werror=format-security`.
This PR addresses issue #443 by modifying the `blosc_filter.c` code.

Another option is to add `-Wno-format-security` to the C flags of utilsextension, hdf5extension and tableextension extensions:

```
extra_compile_args=CFLAGS + ['-Wno-format-security']
```

Note: this PR has still not been submitted upstream because I currently have a build problem with c-blosc and can't test the patch properly against the upstream master.
