### PR TITLE
Python3 Unicode string support in Atom.from_dtype

### DIFF
--- a/doc/source/MIGRATING_TO_3.x.rst
+++ b/doc/source/MIGRATING_TO_3.x.rst
@@ -35,7 +35,7 @@ In Python 3, all strings are natively in Unicode. This introduces some
 difficulties, as the native HDF5 string format is not Unicode-compatible. 
 To minimize explicit conversion troubles when writing, especially :ref:`when 
 creating data sets from existing Python objects <create-signatures>`, string 
-objects are implicitly casted to non-Unicode for HDF5 storage. To make you
+objects are implicitly cast to non-Unicode for HDF5 storage. To make you
 aware of this, a warning is raised when this happens.
 
 This is certainly no true Unicode compatibility, but mainly for convenience 

--- a/doc/source/MIGRATING_TO_3.x.rst
+++ b/doc/source/MIGRATING_TO_3.x.rst
@@ -4,6 +4,7 @@ Migrating from PyTables 2.x to 3.x
 
 :Author: Antonio Valentino
 :Author: Anthony Scopatz
+:Author: Thomas Provoost
 
 This document describes the major changes in PyTables in going from the
 2.x to 3.x series and what you need to know when migrating downstream
@@ -27,6 +28,20 @@ Additionally, the ``tables.netcdf3`` module has been removed. Please refer
 to the `netcdf4-python`_ project for further support. Lastly, the older
 HDF5 1.6 API is no longer supported.  Please upgrade to HDF5 1.8+.
 
+Unicode all the strings!
+========================
+
+In Python 3, all strings are natively in Unicode. This introduces some 
+difficulties, as the native HDF5 string format is not Unicode-compatible. 
+To minimize explicit conversion troubles when writing, especially :ref:`when 
+creating data sets from existing Python objects <create-signatures>`, string 
+objects are implicitly casted to non-Unicode for HDF5 storage. To make you
+aware of this, a warning is raised when this happens.
+
+This is certainly no true Unicode compatibility, but mainly for convenience 
+with the pure-Unicode Python 3 string type. Any string that is not castable 
+as ascii upon creation of your data set, will hence still raise an error. 
+For true Unicode support, look into the ``VLUnicodeAtom`` class.
 
 Major API Changes
 =================
@@ -108,6 +123,8 @@ plan for the warning types:
 
 The current plan is to maintain the old APIs for at least 2 years, though this
 is subject to change.
+
+.. _create-signatures:
 
 Consistent ``create_xxx()`` Signatures
 ***************************************

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -372,7 +372,7 @@ class Atom(object):
         if basedtype.shape != ():
             raise ValueError("nested data types are not supported: %r"
                              % dtype)
-        if basedtype.kind == 'S':  # can not reuse something like 'string80'
+        if basedtype.kind in ('S', 'U'):  # can not reuse something like 'string80'
             itemsize = basedtype.itemsize
             return class_.from_kind('string', itemsize, dtype.shape, dflt)
         # Most NumPy types have direct correspondence with PyTables types.

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -367,6 +367,16 @@ class Atom(object):
             >>> Atom.from_dtype(numpy.dtype('Float64'))
             Float64Atom(shape=(), dflt=0.0)
 
+        Note: for easier use in Python 3, where all strings lead to the
+        Unicode dtype, this dtype will also generate a StringAtom. Since
+        this is only viable for strings that are castable as ascii, a
+        warning is issued.
+
+            >>> Atom.from_dtype(numpy.dtype('U20'))
+            Atom.py:392: FlavorWarning: support for unicode type is very limited,
+                and only works for strings that can be casted as ascii
+            StringAtom(itemsize=20, shape=(), dflt=b'')
+
         """
         basedtype = dtype.base
         if basedtype.names:

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -382,7 +382,7 @@ class Atom(object):
             # workaround for unicode type (standard string type in Python 3)
             warnings.warn("support for unicode type is very limited, "
                           "and only works for strings that can be casted as ascii", DataTypeWarning)
-            itemsize = basedtype.itemsize / 4
+            itemsize = basedtype.itemsize // 4
             assert str(itemsize) in basedtype.str, "something went wrong in handling unicode."
             return class_.from_kind('string', itemsize, dtype.shape, dflt)
         # Most NumPy types have direct correspondence with PyTables types.

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -27,7 +27,7 @@ from tables.misc.enum import Enum
 from tables._past import previous_api
 
 import warnings
-from tables.exceptions import DataTypeWarning
+from tables.exceptions import FlavorWarning
 
 # Public variables
 # ================
@@ -381,7 +381,7 @@ class Atom(object):
         elif basedtype.kind == 'U':
             # workaround for unicode type (standard string type in Python 3)
             warnings.warn("support for unicode type is very limited, "
-                          "and only works for strings that can be casted as ascii", DataTypeWarning)
+                          "and only works for strings that can be casted as ascii", FlavorWarning)
             itemsize = basedtype.itemsize // 4
             assert str(itemsize) in basedtype.str, "something went wrong in handling unicode."
             return class_.from_kind('string', itemsize, dtype.shape, dflt)

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -374,7 +374,7 @@ class Atom(object):
 
             >>> Atom.from_dtype(numpy.dtype('U20')) # doctest: +SKIP
             Atom.py:392: FlavorWarning: support for unicode type is very limited,
-                and only works for strings that can be casted as ascii
+                and only works for strings that can be cast as ascii
             StringAtom(itemsize=20, shape=(), dflt=b'')
 
         """
@@ -391,7 +391,7 @@ class Atom(object):
         elif basedtype.kind == 'U':
             # workaround for unicode type (standard string type in Python 3)
             warnings.warn("support for unicode type is very limited, "
-                          "and only works for strings that can be casted as ascii", FlavorWarning)
+                          "and only works for strings that can be cast as ascii", FlavorWarning)
             itemsize = basedtype.itemsize // 4
             assert str(itemsize) in basedtype.str, "something went wrong in handling unicode."
             return class_.from_kind('string', itemsize, dtype.shape, dflt)

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -372,7 +372,7 @@ class Atom(object):
         this is only viable for strings that are castable as ascii, a
         warning is issued.
 
-            >>> Atom.from_dtype(numpy.dtype('U20'))
+            >>> Atom.from_dtype(numpy.dtype('U20')) # doctest: +SKIP
             Atom.py:392: FlavorWarning: support for unicode type is very limited,
                 and only works for strings that can be casted as ascii
             StringAtom(itemsize=20, shape=(), dflt=b'')

--- a/tables/description.py
+++ b/tables/description.py
@@ -804,7 +804,7 @@ def descr_from_dtype(dtype_):
                     "are not supported yet, sorry")
             fbyteorder = byteorder
         # Non-nested column
-        if kind in 'biufSc':
+        if kind in 'biufSUc':
             col = Col.from_dtype(dtype, pos=pos)
         # Nested column
         elif kind == 'V' and dtype.shape in [(), (1,)]:

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -379,12 +379,28 @@ def _numpy_contiguous(convfunc):
 def _conv_numpy_to_numpy(array):
     # Passes contiguous arrays through and converts scalars into
     # scalar arrays.
-    return numpy.asarray(array)
+    nparr = numpy.asarray(array)
+    if nparr.dtype.kind == 'U':
+        # from Python 3 loads of common strings are disguised as Unicode
+        try:
+            # try to convert to basic 'S' type
+            return nparr.astype('S')
+        except UnicodeEncodeError:
+            pass  # pass on true Unicode arrays downstream in case it can be handled in the future
+    return nparr
 
 
 @_numpy_contiguous
 def _conv_python_to_numpy(array):
-    return numpy.array(array)
+    nparr = numpy.array(array)
+    if nparr.dtype.kind == 'U':
+        # from Python 3 loads of common strings are disguised as Unicode
+        try:
+            # try to convert to basic 'S' type
+            return nparr.astype('S')
+        except UnicodeEncodeError:
+            pass  # pass on true Unicode arrays downstream in case it can be handled in the future
+    return nparr
 
 
 def _conv_numpy_to_python(array):

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -268,8 +268,10 @@ class AtomTestCase(TestCase):
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_03(self):
-        atom1 = Atom.from_dtype(numpy.dtype('U5'), dflt=b'hello')
-        atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
+        dt = numpy.dtype('U5')
+        atom1 = Atom.from_dtype(dt, dflt=b'hello')
+        # Unicode itemsize is 4 * equivalent String itemsize
+        atom2 = StringAtom(itemsize=dt.base.itemsize, shape=(), dflt=b'hello')
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -268,10 +268,9 @@ class AtomTestCase(TestCase):
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_03(self):
-        dt = numpy.dtype('U5')
-        atom1 = Atom.from_dtype(dt, dflt=b'hello')
-        # Unicode itemsize is 4 * equivalent String itemsize
-        atom2 = StringAtom(itemsize=dt.base.itemsize, shape=(), dflt=b'hello')
+        with self.assertWarns(UserWarning):
+            atom1 = Atom.from_dtype(numpy.dtype('U5'), dflt=b'hello')
+        atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -268,7 +268,7 @@ class AtomTestCase(TestCase):
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_03(self):
-        with self.assertWarns(UserWarning):
+        with self.assertWarns(Warning):
             atom1 = Atom.from_dtype(numpy.dtype('U5'), dflt=b'hello')
         atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
         self.assertEqual(atom1, atom2)

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -268,6 +268,12 @@ class AtomTestCase(TestCase):
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_03(self):
+        atom1 = Atom.from_dtype(numpy.dtype('U5'), dflt=b'hello')
+        atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
+        self.assertEqual(atom1, atom2)
+        self.assertEqual(str(atom1), str(atom2))
+
+    def test_from_dtype_04(self):
         atom1 = Atom.from_dtype(numpy.dtype('Float64'))
         atom2 = Float64Atom(shape=(), dflt=0.0)
         self.assertEqual(atom1, atom2)


### PR DESCRIPTION
In Python3 strings show up as dtype e.g. `'<U50'`. The current code only looks for a Python2-style `'S'`-kind, resulting in
```python
    ValueError: unknown type: 'str1600'
```
upon calling e.g. `create_array` with a string array as `obj=` argument, since this case currently gets handed over to `from_type`.