### PR TITLE
Allow absence of condition for append_where

### DIFF
--- a/tables/table.py
+++ b/tables/table.py
@@ -1538,7 +1538,7 @@ class Table(tableextension.Table, Leaf):
         return self.read_coordinates(coords, field)
 
 
-    def append_where(self, dstTable, condition, condvars=None,
+    def append_where(self, dstTable, condition=None, condvars=None,
                      start=None, stop=None, step=None):
         """Append rows fulfilling the condition to the dstTable table.
 
@@ -1565,7 +1565,11 @@ class Table(tableextension.Table, Leaf):
         colNames = [colName for colName in self.colpathnames]
         dstRow = dstTable.row
         nrows = 0
-        for srcRow in self._where(condition, condvars, start, stop, step):
+        if condition is not None:
+            srcRows = self._where(condition, condvars, start, stop, step)
+        else:
+            srcRows = self.iterrows(start, stop, step)
+        for srcRow in srcRows:
             for colName in colNames:
                 dstRow[colName] = srcRow[colName]
             dstRow.append()

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -5368,6 +5368,26 @@ class WhereAppendTestCase(common.TempFileMixin, TestCase):
             if os.path.exists(h5fname2):
                 os.remove(h5fname2)
 
+    def test06_wholeTable(self):
+        """Append whole table."""
+
+        DstTblDesc = self.SrcTblDesc
+
+        tbl1 = self.h5file.root.test
+        tbl2 = self.h5file.create_table('/', 'test2', DstTblDesc)
+
+        tbl1.append_where(tbl2)
+
+        # Rows resulting from the query are those in the new table.
+        it2 = iter(tbl2)
+        for r1 in tbl1.__iter__():
+            r2 = next(it2)
+            self.assertTrue(r1['id'] == r2['id'] and r1['v1'] == r2['v1']
+                            and r1['v2'] == r2['v2'])
+
+        # There are no more rows.
+        self.assertRaises(StopIteration, it2.next)
+
 
 class DerivedTableTestCase(common.TempFileMixin, TestCase):
     def setUp(self):


### PR DESCRIPTION
Without a condition the entire table is appended to the destination
table.
Includes test for appending without a condition.
Fixes #376