### PR TITLE
Fix two typos in docstrings.

### DIFF
--- a/tables/link.py
+++ b/tables/link.py
@@ -165,6 +165,7 @@ class SoftLink(linkextension.SoftLink, Link):
     --------
 
     ::
+
         >>> f = tables.open_file('/tmp/test_softlink.h5', 'w')
         >>> a = f.create_array('/', 'A', np.arange(10))
         >>> link_a = f.create_soft_link('/', 'link_A', target='/A')

--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -400,7 +400,7 @@ memory or on file.
 DRIVER_CORE_IMAGE = None
 """String containing an HDF5 file image.
 
-If this oprion is passed to the :func:`tables.open_file` function then the
+If this option is passed to the :func:`tables.open_file` function then the
 returned file object is set up using the specified image.
 
 A file image can be retrieved from an existing (and opened) file object


### PR DESCRIPTION
The missing blank line prevented proper syntax highlighting in the docs.