### PR TITLE
Make _calc_nrowsinbuf in tables/leaf.py also check for classes inheriting Table

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -370,8 +370,7 @@ class Leaf(Node):
         buffersize = params['IO_BUFFER_SIZE']
         if rowsize != 0:
             nrowsinbuf = buffersize // rowsize
-            if (self.__class__.__name__ == "Table" or
-                "Table" in [base.__name__ for base in self.__class__.__bases__]):
+            if self.__class__.__name__ == "Table":
                 # The number of rows in buffer needs to be an exact multiple of
                 # chunkshape[0] for queries using indexed columns.
                 # Fixes #319 and probably #409 too.
@@ -383,8 +382,7 @@ class Leaf(Node):
         # to make sure nrowsinbuf is greater than or
         # equal to the chunksize.
         # See gh-206 and gh-238
-        if (self.chunkshape is not None and (self.__class__.__name__ == "Table" or
-            "Table" in [base.__name__ for base in self.__class__.__bases__])):
+        if self.chunkshape is not None and self.__class__.__name__ == "Table":
             if nrowsinbuf < self.chunkshape[0]:
                 nrowsinbuf = self.chunkshape[0]
 

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -370,21 +370,8 @@ class Leaf(Node):
         buffersize = params['IO_BUFFER_SIZE']
         if rowsize != 0:
             nrowsinbuf = buffersize // rowsize
-            if self.__class__.__name__ == "Table":
-                # The number of rows in buffer needs to be an exact multiple of
-                # chunkshape[0] for queries using indexed columns.
-                # Fixes #319 and probably #409 too.
-                nrowsinbuf -= nrowsinbuf % self.chunkshape[0]
         else:
             nrowsinbuf = 1
-
-        # tableextension.pyx performs an assertion
-        # to make sure nrowsinbuf is greater than or
-        # equal to the chunksize.
-        # See gh-206 and gh-238
-        if self.chunkshape is not None and self.__class__.__name__ == "Table":
-            if nrowsinbuf < self.chunkshape[0]:
-                nrowsinbuf = self.chunkshape[0]
 
         # Safeguard against row sizes being extremely large
         if nrowsinbuf == 0:

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -370,7 +370,8 @@ class Leaf(Node):
         buffersize = params['IO_BUFFER_SIZE']
         if rowsize != 0:
             nrowsinbuf = buffersize // rowsize
-            if self.__class__.__name__ == "Table":
+            if (self.__class__.__name__ == "Table" or
+                "Table" in [base.__name__ for base in self.__class__.__bases__]):
                 # The number of rows in buffer needs to be an exact multiple of
                 # chunkshape[0] for queries using indexed columns.
                 # Fixes #319 and probably #409 too.
@@ -382,7 +383,8 @@ class Leaf(Node):
         # to make sure nrowsinbuf is greater than or
         # equal to the chunksize.
         # See gh-206 and gh-238
-        if self.chunkshape is not None and self.__class__.__name__ == "Table":
+        if (self.chunkshape is not None and (self.__class__.__name__ == "Table" or
+            "Table" in [base.__name__ for base in self.__class__.__bases__])):
             if nrowsinbuf < self.chunkshape[0]:
                 nrowsinbuf = self.chunkshape[0]
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -942,7 +942,7 @@ class Table(tableextension.Table, Leaf):
             maxrowsize = params['BUFFER_TIMES'] * buffersize
             if rowsize > maxrowsize:
                 warnings.warn("""\
-The Leaf ``%s`` is exceeding the maximum recommended rowsize (%d bytes);
+The Table ``%s`` is exceeding the maximum recommended rowsize (%d bytes);
 be ready to see PyTables asking for *lots* of memory and possibly slow
 I/O.  You may want to reduce the rowsize by trimming the value of
 dimensions that are orthogonal (and preferably close) to the *main*

--- a/tables/table.py
+++ b/tables/table.py
@@ -910,7 +910,47 @@ class Table(tableextension.Table, Leaf):
             self._unsaved_indexedrows = self.nrows - self._indexedrows
             # Put the autoindex value in a cache variable
             self._autoindex = self.autoindex
+    
+    def _calc_nrowsinbuf(self):
+        """Calculate the number of rows that fits on a PyTables buffer."""
 
+        params = self._v_file.params
+        # Compute the nrowsinbuf
+        rowsize = self.rowsize
+        buffersize = params['IO_BUFFER_SIZE']
+        if rowsize != 0:
+            nrowsinbuf = buffersize // rowsize
+            # The number of rows in buffer needs to be an exact multiple of
+            # chunkshape[0] for queries using indexed columns.
+            # Fixes #319 and probably #409 too.
+            nrowsinbuf -= nrowsinbuf % self.chunkshape[0]
+        else:
+            nrowsinbuf = 1
+
+        # tableextension.pyx performs an assertion
+        # to make sure nrowsinbuf is greater than or
+        # equal to the chunksize.
+        # See gh-206 and gh-238
+        if self.chunkshape is not None:
+            if nrowsinbuf < self.chunkshape[0]:
+                nrowsinbuf = self.chunkshape[0]
+
+        # Safeguard against row sizes being extremely large
+        if nrowsinbuf == 0:
+            nrowsinbuf = 1
+            # If rowsize is too large, issue a Performance warning
+            maxrowsize = params['BUFFER_TIMES'] * buffersize
+            if rowsize > maxrowsize:
+                warnings.warn("""\
+The Leaf ``%s`` is exceeding the maximum recommended rowsize (%d bytes);
+be ready to see PyTables asking for *lots* of memory and possibly slow
+I/O.  You may want to reduce the rowsize by trimming the value of
+dimensions that are orthogonal (and preferably close) to the *main*
+dimension of this leave.  Alternatively, in case you have specified a
+very small/large chunksize, you may want to increase/decrease it."""
+                              % (self._v_pathname, maxrowsize),
+                              PerformanceWarning)
+        return nrowsinbuf
 
     def _getemptyarray(self, dtype):
         # Acts as a cache for empty arrays


### PR DESCRIPTION
A previous fix (for issues #319 and #409) for the size of nrowsinbuf calculated in _calc_nrowsinbuf was already checking specifically for the Table class. However, classes inheriting from Table encounter the same problem. This commit also fixes nrowsinbuf size for classes inheriting Table (issue #477).