### PR TITLE
Cast selection indices to integer

### DIFF
--- a/tables/array.py
+++ b/tables/array.py
@@ -12,6 +12,7 @@
 
 """Here is defined the Array class."""
 
+import operator
 import sys
 
 import numpy
@@ -394,6 +395,8 @@ class Array(hdf5extension.Array, Leaf):
                 raise IndexError("Too many indices for object '%s'" %
                                  self._v_pathname)
             elif is_idx(key):
+                key = operator.index(key)
+
                 # Protection for index out of range
                 if key >= self.shape[dim]:
                     raise IndexError("Index out of range")

--- a/tables/index.py
+++ b/tables/index.py
@@ -13,13 +13,15 @@
 """Here is defined the Index class."""
 
 from __future__ import print_function
-import sys
-from time import time, clock
+import math
+import operator
 import os
 import os.path
+import sys
 import tempfile
-import math
 import warnings
+
+from time import time, clock
 
 import numpy
 
@@ -1787,6 +1789,8 @@ class Index(NotLoggedMixin, indexesextension.Index, Group):
         """
 
         if is_idx(key):
+            key = operator.index(key)
+
             if key < 0:
                 # To support negative values
                 key += self.nelements

--- a/tables/table.py
+++ b/tables/table.py
@@ -12,12 +12,14 @@
 
 """Here is defined the Table class."""
 
-import sys
 import math
-import warnings
+import operator
 import os.path
-from time import time
+import sys
+import warnings
+
 from functools import reduce as _reduce
+from time import time
 
 import numpy
 import numexpr
@@ -2104,6 +2106,8 @@ class Table(tableextension.Table, Leaf):
         self._g_check_open()
 
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= self.nrows:
                 raise IndexError("Index out of range")
@@ -2173,6 +2177,8 @@ class Table(tableextension.Table, Leaf):
         self._v_file._check_writable()
 
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= self.nrows:
                 raise IndexError("Index out of range")
@@ -3211,6 +3217,8 @@ class Cols(object):
         table = self._v_table
         nrows = table.nrows
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= nrows:
                 raise IndexError("Index out of range")
@@ -3268,6 +3276,8 @@ class Cols(object):
         table = self._v_table
         nrows = table.nrows
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= nrows:
                 raise IndexError("Index out of range")
@@ -3515,6 +3525,8 @@ class Column(object):
             key = key[0]
 
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= table.nrows:
                 raise IndexError("Index out of range")
@@ -3587,6 +3599,8 @@ class Column(object):
             key = key[0]
 
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= table.nrows:
                 raise IndexError("Index out of range")

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -2577,6 +2577,19 @@ class GetItemTestCase(common.TempFileMixin, TestCase):
         result = table[np.array(self.expectedrows-1)]
         self.assertEqual(result["var2"], self.expectedrows - 1)
 
+    def test01f_singleItem(self):
+        """Checking __getitem__ method with single parameter (np.uint64)"""
+
+        if common.verbose:
+            print('\n', '-=' * 30)
+            print("Running %s.test01f_singleItem..." % self.__class__.__name__)
+
+        self.h5file = tables.open_file(self.h5fname, "r")
+        table = self.h5file.root.table0
+
+        result = table[np.uint64(2)]
+        self.assertEqual(result["var2"], 2)
+
     def test02_twoItems(self):
         """Checking __getitem__ method with start, stop parameters."""
 

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -12,6 +12,7 @@
 
 """Here is defined the VLArray class."""
 
+import operator
 import sys
 
 import numpy
@@ -660,6 +661,8 @@ class VLArray(hdf5extension.VLArray, Leaf):
 
         self._g_check_open()
         if is_idx(key):
+            key = operator.index(key)
+
             # Index out of range protection
             if key >= self.nrows:
                 raise IndexError("Index out of range")


### PR DESCRIPTION
This is a bit weird, it was prompted by #475 and #43.

The problem (or part of it) lies in that if

    key  = numpy.uint64(10)

`is_idx(key)` will return `True` but then

    self._process_range(key, key + 1, 1)

fails because `key + 1 == 11.0` (try it yourself).

The uptake is that indices need to be casted in some way. I decided to use
`operator.index` because that's what Python uses internally when something is
used as an index.

Interestingly enough #43 got fixed accidentally: `Array._interpret_indexing`
fails because `_process_range` fails, just like above. But then
`Array.__getitem__` goes on trying different strategies and finally
`_fancy_selection` does the cast.

This PR is for the upcoming 3.2.2

Closes #475, #43