### PR TITLE
+ caveat on Row.update (doesn't work with break)

### DIFF
--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -1065,6 +1065,8 @@ is meant to be used in table iterators. Look at the next example::
     to be both convenient and efficient. Please make sure to use it
     extensively.
 
+*Caveat emptor*: Currently, :meth:`Row.update` will not work (your tables 
+will not be updated) if the loop is broken with ``break`` statement.
 
 Modifying data in arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added a caveat that Row.update does not work if the loop is broken with break statement. Related to Issue #404