### PR TITLE
get rid of -native

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -738,7 +738,7 @@ if 'BLOSC' not in optional_libs:
         finally:
             os.remove(fd.name)
 
-    try_flags = ["-march=native", "-msse2"]
+    try_flags = ["-msse2"]
     for ff in try_flags:
         if compiler_has_flags(compiler, [ff]):
             print("Setting compiler flag: " + ff)


### PR DESCRIPTION
VirtualBox does not support SSE4 or POPCNT yet, so this will prevent a build on a new machine from inserting newish instructions.  Fixes #458
