### PR TITLE
Update link to NumFOCUS projects page

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -68,4 +68,4 @@ Helpful Links
 
 .. _github: https://github.com/PyTables/PyTables
 .. _`mailing list`: https://groups.google.com/group/pytables-users
-.. _`NumFOCUS project`: http://numfocus.org/projects
+.. _`NumFOCUS project`: http://www.numfocus.org/open-source-projects.html


### PR DESCRIPTION
The previous link got a 404.