### PR TITLE
DOC: 'blosc' is a valid input to which_lib_version

### DIFF
--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -703,7 +703,7 @@ def which_lib_version(str name):
   as a string, and the version date as a string. If the library is not
   available, None is returned.
 
-  The currently supported library names are hdf5, zlib, lzo and bzip2. If
+  The currently supported library names are hdf5, zlib, lzo, bzip2, and blosc. If
   another name is given, a ValueError is raised.
 
   """


### PR DESCRIPTION
Minor doc fix.