### PR TITLE
Ensure cache entries are removed if fewer than 10 entries in the cache - fix for #529

### DIFF
--- a/tables/utils.py
+++ b/tables/utils.py
@@ -428,7 +428,7 @@ class NailedDict(object):
         # Protection against growing the cache too much
         if len(cache) > self.maxentries:
             # Remove a 10% of (arbitrary) elements from the cache
-            entries_to_remove = self.maxentries // 10
+            entries_to_remove = max(self.maxentries // 10, 1)
             for k in list(cache.keys())[:entries_to_remove]:
                 del cache[k]
         cache[key] = value


### PR DESCRIPTION
Set ```entries_to_remove``` to ```1``` if ```self.maxentries // 10 < 0``` (using ```max```)