### PR TITLE
Fixes segfaults in a number of test cases that use index.Index

### DIFF
--- a/tables/index.py
+++ b/tables/index.py
@@ -106,7 +106,7 @@ def _table_column_pathname_of_index(indexpathname):
 
 
 
-class Index(NotLoggedMixin, indexesextension.Index, Group):
+class Index(NotLoggedMixin, Group, indexesextension.Index):
     """Represents the index of a column in a table.
 
     This class is used to keep the indexing information for columns in a Table


### PR DESCRIPTION
Tested with cython 0.23.4+git4-g7eed8d8-1 from Debian.
The Cython documentation suggests that cdef classes can't
inherit from Python classes, perhaps this had an effect in the
case of multiple inheritance.

Fixes #532