### PR TITLE
Initialize compname so that blosc_compress_ctx can use a default

### DIFF
--- a/c-blosc/hdf5/blosc_filter.c
+++ b/c-blosc/hdf5/blosc_filter.c
@@ -175,7 +175,7 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
     int doshuffle = 1;             /* Shuffle default */
     int compcode;                  /* Blosc compressor */
     int code;
-    char *compname = NULL;
+    char *compname = "blosclz";
     char *complist;
     char errmsg[256];
 


### PR DESCRIPTION
This creates problems when using an external blosc library that is >= 1.5.