### PR TITLE
fix read_where() query with functions when numexpr uses Intel MKL

### DIFF
--- a/tables/conditions.py
+++ b/tables/conditions.py
@@ -34,7 +34,7 @@ from __future__ import absolute_import
 import re
 from numexpr.necompiler import typecode_to_kind
 from numexpr.necompiler import expressionToAST, typeCompileAst
-from numexpr.necompiler import stringToExpression, NumExpr
+from numexpr.necompiler import stringToExpression, NumExpr, getExprNames
 from numexpr.expressions import ExpressionNode
 
 from .utilsextension import get_nested_field
@@ -333,7 +333,7 @@ class CompiledCondition(object):
                 idxvars.append(idxvar)
         return frozenset(idxvars)
 
-    def __init__(self, func, params, idxexprs, strexpr):
+    def __init__(self, func, params, idxexprs, strexpr, **kwargs):
         self.function = func
         """The compiled function object corresponding to this condition."""
         self.parameters = params
@@ -342,6 +342,8 @@ class CompiledCondition(object):
         """A list of expressions in the form ``(var, (ops), (limits))``."""
         self.string_expression = strexpr
         """The indexable expression in string format."""
+        self.kwargs = kwargs
+        """NumExpr kwargs (used to pass ex_uses_vml to numexpr)"""
 
     def __repr__(self):
         return ("idxexprs: %s\nstrexpr: %s\nidxvars: %s"
@@ -370,7 +372,8 @@ class CompiledCondition(object):
             exprs2.append((var, ops, tuple(limit_values)))
         # Create a new container for the converted values
         newcc = CompiledCondition(
-            self.function, self.parameters, exprs2, self.string_expression)
+            self.function, self.parameters, exprs2, self.string_expression,
+            **self.kwargs)
         return newcc
 
 
@@ -432,13 +435,16 @@ def compile_condition(condition, typemap, indexedcols):
     except NotImplementedError as nie:
         # Try to make this Numexpr error less cryptic.
         raise _unsupported_operation_error(nie)
+
+    _, ex_uses_vml = getExprNames(condition, {})
+    kwargs = {'ex_uses_vml': ex_uses_vml}
+
     params = varnames
-
     # This is more comfortable to handle about than a tuple.
-    return CompiledCondition(func, params, idxexprs, strexpr)
+    return CompiledCondition(func, params, idxexprs, strexpr, **kwargs)
 
 
-def call_on_recarr(func, params, recarr, param2arg=None):
+def call_on_recarr(func, params, recarr, param2arg=None, **kwargs):
     """Call `func` with `params` over `recarr`.
 
     The `param2arg` function, when specified, is used to get an argument
@@ -457,4 +463,4 @@ def call_on_recarr(func, params, recarr, param2arg=None):
         if hasattr(arg, 'pathname'):  # looks like a column
             arg = get_nested_field(recarr, arg.pathname)
         args.append(arg)
-    return func(*args)
+    return func(*args, **kwargs)

--- a/tables/table.py
+++ b/tables/table.py
@@ -1515,7 +1515,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             chunkmap = None  # default to an in-kernel query
 
         args = [condvars[param] for param in compiled.parameters]
-        self._where_condition = (compiled.function, args)
+        self._where_condition = (compiled.function, args, compiled.kwargs)
         row = tableextension.Row(self)
         if profile:
             show_stats("Exiting table._where", tref)

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -724,7 +724,7 @@ cdef class Row:
   cdef object  wrec, wreccpy
   cdef object  wfields, rfields
   cdef object  coords
-  cdef object  condfunc, condargs
+  cdef object  condfunc, condargs, condkwargs
   cdef object  mod_elements, colenums
   cdef object  rfieldscache, wfieldscache
   cdef object  iterseq
@@ -857,7 +857,8 @@ cdef class Row:
 
     if table._where_condition:
       self.wherecond = 1
-      self.condfunc, self.condargs = table._where_condition
+      #self.condkwargs = {'ex_uses_vml': True}
+      self.condfunc, self.condargs, self.condkwargs = table._where_condition
       table._where_condition = None
 
     if table._use_index:
@@ -957,7 +958,7 @@ cdef class Row:
 
         self.table._convert_types(iobuf, len(iobuf), 1)
         self.indexvalid = call_on_recarr(
-          self.condfunc, self.condargs, iobuf)
+          self.condfunc, self.condargs, iobuf, **self.condkwargs)
         self.index_valid_data = <char *>self.indexvalid.data
         # Get the valid coordinates
         self.indexvalues = self.bufcoords[:recout][self.indexvalid]
@@ -1086,7 +1087,7 @@ cdef class Row:
 
         # Evaluate the condition on this table fragment.
         self.indexvalid = call_on_recarr(
-          self.condfunc, self.condargs, self.iobuf[:recout] )
+          self.condfunc, self.condargs, self.iobuf[:recout], **self.condkwargs)
         self.index_valid_data = <char *>self.indexvalid.data
 
         # Is there any interesting information in this buffer?

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -28,6 +28,8 @@ from tables.tests.common import verbosePrint as vprint
 from tables.tests.common import PyTablesTestCase as TestCase
 import six
 from six.moves import range
+from numpy import (log10, exp, log, abs, sqrt, sin, cos, tan,
+                   arcsin, arccos, arctan)
 
 
 # Data parameters
@@ -70,6 +72,14 @@ type_info = {
     'string': ('S%s' % _strlen, numpy.string_),  # just for these tests
 }
 """NumPy and Numexpr type for each PyTables type that will be tested."""
+
+# globals dict for eval()
+func_info = {'log10': log10, 'log': log, 'exp': exp,
+             'abs': abs, 'sqrt': sqrt,
+             'sin': sin, 'cos': cos, 'tan': tan,
+             'arcsin': arcsin, 'arccos': arccos, 'arctan': arctan}
+"""functions and NumPy.ufunc() for each function that will be tested."""
+
 
 if hasattr(numpy, 'float16'):
     type_info['float16'] = (numpy.float16, float)
@@ -316,6 +326,8 @@ left_bound = row_period // 4
 """Operand of left side operator in comparisons with operator pairs."""
 right_bound = row_period * 3 // 4
 """Operand of right side operator in comparisons with operator pairs."""
+func_bound = 0.8  # must be <1 for trig functions to be able to fail
+"""Operand of right side operator in comparisons with functions. """
 extra_conditions = [
     '',                     # uses one index
     '& ((c_extra + 1) < 0)',  # uses one index
@@ -338,13 +350,14 @@ class TableDataTestCase(BaseTableQueryTestCase):
     _testfmt_heavy = 'test_h%04d'
 
 
-def create_test_method(type_, op, extracond):
+def create_test_method(type_, op, extracond, func=None):
     sctype = sctype_from_type[type_]
 
     # Compute the value of bounds.
     condvars = {'bound': right_bound,
                 'lbound': left_bound,
-                'rbound': right_bound}
+                'rbound': right_bound,
+                'func_bound': func_bound}
     for (bname, bvalue) in six.iteritems(condvars):
         if type_ == 'string':
             bvalue = str_format % bvalue
@@ -360,12 +373,14 @@ def create_test_method(type_, op, extracond):
         cond = colname
     elif op == '~':  # unary
         cond = '~(%s)' % colname
-    elif op == '<':  # binary variable-constant
+    elif op == '<' and func is None:  # binary variable-constant
         cond = '%s %s %s' % (colname, op, repr(condvars['bound']))
     elif isinstance(op, tuple):  # double binary variable-constant
         cond = ('(lbound %s %s) & (%s %s rbound)'
                 % (op[0], colname, colname, op[1]))
-    else:  # binary variable-variable
+    elif func is not None:
+        cond = '%s(%s) %s func_bound' % (func, colname, op)
+    else:  # function or binary variable-variable
         cond = '%s %s bound' % (colname, op)
     if extracond:
         cond = '(%s) %s' % (cond, extracond)
@@ -410,7 +425,7 @@ def create_test_method(type_, op, extracond):
                 pyvars['c_extra'] = row['c_extra']
                 pyvars['c_idxextra'] = row['c_idxextra']
                 try:
-                    isvalidrow = eval(pycond, {}, pyvars)
+                    isvalidrow = eval(pycond, func_info, pyvars)
                 except TypeError:
                     raise SilentlySkipTest(
                         "The Python type does not support the operation.")
@@ -466,33 +481,42 @@ def create_test_method(type_, op, extracond):
     test_method.__doc__ = "Testing ``%s``." % cond
     return test_method
 
+
+def add_test_method(type_, op, extracond='', func=None):
+    global testn
+    # Decide to which set the test belongs.
+    heavy = type_ in heavy_types or op in heavy_operators
+    if heavy:
+        testfmt = TableDataTestCase._testfmt_heavy
+        numfmt = ' [#H%d]'
+    else:
+        testfmt = TableDataTestCase._testfmt_light
+        numfmt = ' [#L%d]'
+    tmethod = create_test_method(type_, op, extracond, func)
+    # The test number is appended to the docstring to help
+    # identify failing methods in non-verbose mode.
+    tmethod.__name__ = testfmt % testn
+    # tmethod.__doc__ += numfmt % testn
+    tmethod.__doc__ += testfmt % testn
+    if sys.version_info[0] < 3:
+        imethod = types.MethodType(tmethod, None, TableDataTestCase)
+    else:
+        imethod = tmethod
+    setattr(TableDataTestCase, tmethod.__name__, imethod)
+    testn += 1
+
 # Create individual tests.  You may restrict which tests are generated
 # by replacing the sequences in the ``for`` statements.  For instance:
 testn = 0
 for type_ in type_info:  # for type_ in ['string']:
     for op in operators:  # for op in ['!=']:
-        # Decide to which set the test belongs.
-        heavy = type_ in heavy_types or op in heavy_operators
-        if heavy:
-            testfmt = TableDataTestCase._testfmt_heavy
-            numfmt = ' [#H%d]'
-        else:
-            testfmt = TableDataTestCase._testfmt_light
-            numfmt = ' [#L%d]'
         for extracond in extra_conditions:  # for extracond in ['']:
-            tmethod = create_test_method(type_, op, extracond)
-            # The test number is appended to the docstring to help
-            # identify failing methods in non-verbose mode.
-            tmethod.__name__ = testfmt % testn
-            # tmethod.__doc__ += numfmt % testn
-            tmethod.__doc__ += testfmt % testn
-            if sys.version_info[0] < 3:
-                imethod = types.MethodType(tmethod, None, TableDataTestCase)
-            else:
-                imethod = tmethod
-            setattr(TableDataTestCase, tmethod.__name__, imethod)
-            testn += 1
+            add_test_method(type_, op, extracond)
 
+for type_ in ['float32', 'float64']:
+    for func in func_info:  # i for func in ['log10']:
+        for op in operators:
+            add_test_method(type_, op, func=func)
 
 # Base classes for non-indexed queries.
 NX_BLOCK_SIZE1 = 128  # from ``interpreter.c`` in Numexpr


### PR DESCRIPTION
When using numexpr with the Intel MKL (default for conda packages for numexpr>2.4.6) ALL ```table.read_where()``` queries which use functions are broken.

Issue: #534 
See also: pydata/numexpr#210 

numexpr (with MKL support) uses VML functions which require contiguous memory. tables are non-continguous so a copy operation is needed. Therefore the ex_uses_vml kwargs needs to be passed by ```conditions.call_on_recarr()```.

This fixes my testcase.

~~This breaks many unittests~~ 

ToDo:
- [x] Figure out if ```numexpr.GetContext``` needs to be called before ```numexpr.GetExprNames```
- [x] fix L428 of conditions.py
- [x] Fix other call_on_recarray() call
- [x] Investigate and fix failing unittest: test_queries.ScalarTableUsageTestCase.test_unsupported_op
- [x] Add unittest
- [x] flake8 / PEP8
