### PR TITLE
Fix test_indexvalues --heavy testcases that use illegal chunksize

### DIFF
--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -105,6 +105,8 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
         if self.buffersize:
             # Change the buffersize by default
             table1.nrowsinbuf = self.buffersize
+            # Make sure nrowsinbuf is a multiple of chunkshape
+            table1.nrowsinbuf -= table1.nrowsinbuf % self.chunkshape
         # Index all entries:
         for col in six.itervalues(table1.colinstances):
             indexrows = col.create_index(


### PR DESCRIPTION
Make sure the tests in test_indexvalues.py use buffersizes (number of rows in buffer, table.nrowsinbuf) that are a multiple of ```chunkshape[0]```

fixes #538 

This affects the TestCases below, which may have been *designed* for ```buffersize % chunksize != 0```: 
```
TestCase10b
TestCase13a
TestCase14a
```