### PR TITLE
Fix docstring for create_table keyword obj

### DIFF
--- a/tables/file.py
+++ b/tables/file.py
@@ -1016,8 +1016,7 @@ class File(hdf5extension.File, object):
             (not done by default).
         obj : python object
             The recarray to be saved.  Accepted types are NumPy record
-            arrays, as well as native Python sequences convertible to numpy
-            record arrays.
+            arrays.
 
             The *obj* parameter is optional and it can be provided in
             alternative to the *description* parameter.


### PR DESCRIPTION
It is not true that native Python sequences are accepted.
Only numpy.ndarray arrays with named dtypes are allowed.

See the if statement after the docstring:

```python
if not isinstance(obj, numpy.ndarray):
    raise TypeError('invalid obj parameter %r' % obj)
```