### PR TITLE
Fix VLArray to host more than 32-bit long rows

### DIFF
--- a/src/H5VLARRAY.c
+++ b/src/H5VLARRAY.c
@@ -197,7 +197,7 @@ out:
 
 herr_t H5VLARRAYappend_records( hid_t dataset_id,
                                 hid_t type_id,
-                                int nobjects,
+                                size_t nobjects,
                                 hsize_t nrecords,
                                 const void *data )
 {
@@ -275,7 +275,7 @@ out:
 herr_t H5VLARRAYmodify_records( hid_t dataset_id,
                                 hid_t type_id,
                                 hsize_t nrow,
-                                int nobjects,
+                                size_t nobjects,
                                 const void *data )
 {
 

--- a/src/H5VLARRAY.h
+++ b/src/H5VLARRAY.h
@@ -23,14 +23,14 @@ herr_t H5VLARRAYmake( hid_t loc_id,
 
 herr_t H5VLARRAYappend_records( hid_t dataset_id,
                                 hid_t type_id,
-                                int nobjects,
+                                size_t nobjects,
                                 hsize_t nrecords,
                                 const void *data );
 
 herr_t H5VLARRAYmodify_records( hid_t dataset_id,
                                 hid_t type_id,
                                 hsize_t nrow,
-                                int nobjects,
+                                size_t nobjects,
                                 const void *data );
 
 herr_t H5VLARRAYget_info( hid_t   dataset_id,

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1972,7 +1972,7 @@ cdef class VLArray(Leaf):
     return self.dataset_id, SizeType(nrecords), (SizeType(chunksize),), atom
 
 
-  def _append(self, ndarray nparr, int nobjects):
+  def _append(self, ndarray nparr, size_t nobjects):
     cdef int ret
     cdef void *rbuf
 
@@ -1995,7 +1995,7 @@ cdef class VLArray(Leaf):
 
     self.nrecords = self.nrecords + 1
 
-  def _modify(self, hsize_t nrow, ndarray nparr, int nobjects):
+  def _modify(self, hsize_t nrow, ndarray nparr, size_t nobjects):
     cdef int ret
     cdef void *rbuf
 

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -9,7 +9,7 @@ import numpy.testing as npt
 
 import tables
 from tables import (
-    Atom, StringAtom, BoolAtom, IntAtom, Int16Atom, Int32Atom,
+    Atom, StringAtom, BoolAtom, IntAtom, Int8Atom, Int16Atom, Int32Atom,
     ObjectAtom, VLStringAtom, VLUnicodeAtom,
 )
 from tables.tests import common
@@ -255,6 +255,30 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(vlarray.get_row_size(3), 4 * vlarray.atom.size)
         self.assertEqual(vlarray.get_row_size(4), 5 * vlarray.atom.size)
 
+    @unittest.skipIf(True,
+                     'This requires 8 GB of RAM, so this is meant to '
+                     'be run manually in big machines only')
+    def test05_large_append(self):
+        """Checking vlarray witgh a large number of appends."""
+        import numpy.lib.stride_tricks
+
+        if common.verbose:
+            print('\n', '-=' * 30)
+            print("Running %s.test05_large_append..." % self.__class__.__name__)
+
+        N = int(2**32 + 1)  # > 2**32
+        h5file = tables.open_file(self.h5fname, "a")
+        vlarray = h5file.create_vlarray(h5file.root, 'vlarray2',
+                                        atom=Int8Atom(),
+                                        filters=None,
+                                        expectedrows=N)
+
+        # Append a large number of rows
+        x = numpy.zeros(N, dtype="i1")
+        vlarray.append(x)
+        x2 = vlarray[0]
+        #print("vlarray:", x2, len(x2))
+        self.assertTrue(allequal(x2, x))
 
 class BasicNumPyTestCase(BasicTestCase):
     flavor = "numpy"


### PR DESCRIPTION
This is still preliminary because it segfaults when the number of elements is > 2**32.  Any volunteer to look into this?