### PR TITLE
Python 3: Allow binary strings in VLStringAtom() 

### DIFF
--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1119,7 +1119,8 @@ class VLStringAtom(_BufferedAtom):
     base = UInt8Atom()
 
     def _tobuffer(self, object_):
-        if not isinstance(object_, six.string_types):
+        if not isinstance(object_, six.string_types) and \
+                not isinstance(object_, six.binary_type):
             raise TypeError("object is not a string: %r" % (object_,))
         return numpy.string_(object_)
 


### PR DESCRIPTION
Fixes #552

Add  six.binary_types to allowed strings in VLStringAtom()

six.binary_types is 'str' in Python 2 and 'bytes' in Python 3.