### PR TITLE
Fix pillow/PIL import. Fix test02_UseImageAsFile

### DIFF
--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -394,7 +394,7 @@ class ReadFileTestCase(common.TempFileMixin, TestCase):
         """Using a file node with Python Imaging Library."""
 
         try:
-            import Image
+            from PIL import Image
 
             Image.open(self.fnode)
         except ImportError:


### PR DESCRIPTION
Small fix to allow all tests to pass on current `master` 

`import Image` does not work. Use `from PIL import Image` instead.
http://stackoverflow.com/questions/19230991