### PR TITLE
Fix vlstringatom on python3 after lib2to3

### DIFF
--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1167,7 +1167,7 @@ class VLUnicodeAtom(_BufferedAtom):
         elif isinstance(object_, bytes):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
-            return numpy.string_(object_)
+            return numpy.unicode_(object_)
         else:
             raise TypeError("object is not a string: %r" % (object_,))
 

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1143,7 +1143,7 @@ class VLUnicodeAtom(_BufferedAtom):
         # NumPy ticket #525).  Since ``_tobuffer()`` can't return an
         # array, we must override ``toarray()`` itself.
         def toarray(self, object_):
-            if not isinstance(object_, bytes):
+            if not isinstance(object_, basestring):
                 raise TypeError("object is not a string: %r" % (object_,))
             ustr = unicode(object_)
             uarr = numpy.array(ustr, dtype='U')

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1103,7 +1103,7 @@ class VLStringAtom(_BufferedAtom):
 
     def _tobuffer(self, object_):
         if not isinstance(object_, bytes) and \
-                not isinstance(object_, str):
+                not isinstance(object_, unicode):
             raise TypeError("object is not a string: %r" % (object_,))
         return numpy.string_(object_)
 

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1098,14 +1098,12 @@ class VLStringAtom(_BufferedAtom):
     base = UInt8Atom()
 
     def _tobuffer(self, object_):
-        if isinstance(object_, bytes):
-            return numpy.string_(object_)
-        elif isinstance(object_, unicode):
+        if isinstance(object_, unicode):
             warnings.warn("Storing non bytestrings in VLStringAtom is "
                           "deprecated.", DeprecationWarning)
-            return numpy.string_(object_)
-        else:
+        elif not isinstance(object_, bytes):
             raise TypeError("object is not a string: %r" % (object_,))
+        return numpy.string_(object_)
 
     def fromarray(self, array):
         return array.tostring()
@@ -1143,33 +1141,26 @@ class VLUnicodeAtom(_BufferedAtom):
         # NumPy ticket #525).  Since ``_tobuffer()`` can't return an
         # array, we must override ``toarray()`` itself.
         def toarray(self, object_):
-            if isinstance(object_, unicode):
-                ustr = unicode(object_)
-                uarr = numpy.array(ustr, dtype='U')
-                return numpy.ndarray(
-                    buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
-            elif isinstance(object_, bytes):
+            if isinstance(object_, bytes):
                 warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                               "deprecated.", DeprecationWarning)
-                ustr = unicode(object_)
-                uarr = numpy.array(ustr, dtype='U')
-                return numpy.ndarray(
-                    buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
-            else:
+            elif not isinstance(object_, unicode):
                 raise TypeError("object is not a string: %r" % (object_,))
+            ustr = unicode(object_)
+            uarr = numpy.array(ustr, dtype='U')
+            return numpy.ndarray(
+                buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
 
     def _tobuffer(self, object_):
         # This works (and is used) only with UCS-4 builds of Python,
         # where the width of the internal representation of a
         # character matches that of the base atoms.
-        if isinstance(object_, unicode):
-            return numpy.unicode_(object_)
-        elif isinstance(object_, bytes):
+        if isinstance(object_, bytes):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
-            return numpy.unicode_(object_)
-        else:
+        elif not isinstance(object_, unicode):
             raise TypeError("object is not a string: %r" % (object_,))
+        return numpy.unicode_(object_)
 
     def fromarray(self, array):
         length = len(array)

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1081,12 +1081,7 @@ class VLStringAtom(_BufferedAtom):
 
         >>> s = 'A unicode string: hbar = \u210f'
         >>> bytestring = s.encode('utf-8')
-        >>> VLArray.append(bytestring)
-
-    and decode when reading::
-
-        >>> bytestring = VLArray[0]
-        >>> s = bytestring.decode('utf-8')
+        >>> VLArray.append(bytestring) # doctest: +SKIP
 
     For full Unicode support, using VLUnicodeAtom (see :ref:`VLUnicodeAtom`) is
     recommended.

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1102,7 +1102,8 @@ class VLStringAtom(_BufferedAtom):
     base = UInt8Atom()
 
     def _tobuffer(self, object_):
-        if not isinstance(object_, basestring):
+        if not isinstance(object_, bytes) and \
+                not isinstance(object_, str):
             raise TypeError("object is not a string: %r" % (object_,))
         return numpy.string_(object_)
 
@@ -1142,7 +1143,7 @@ class VLUnicodeAtom(_BufferedAtom):
         # NumPy ticket #525).  Since ``_tobuffer()`` can't return an
         # array, we must override ``toarray()`` itself.
         def toarray(self, object_):
-            if not isinstance(object_, basestring):
+            if not isinstance(object_, bytes):
                 raise TypeError("object is not a string: %r" % (object_,))
             ustr = unicode(object_)
             uarr = numpy.array(ustr, dtype='U')

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1074,15 +1074,25 @@ class VLStringAtom(_BufferedAtom):
     it to one specific row*, i.e. the :meth:`VLArray.append` method only
     accepts one object when the base atom is of this type.
 
-    Like StringAtom, this class does not make assumptions on the encoding of
-    the string, and raw bytes are stored as is.  Unicode strings are supported
-    as long as no character is out of the ASCII set; otherwise, you will need
-    to *explicitly* convert them to strings before you can save them.  For full
-    Unicode support, using VLUnicodeAtom (see :ref:`VLUnicodeAtom`) is
+    This class stores bytestrings. It does not make assumptions on the
+    encoding of the string, and raw bytes are stored as is. To store a string
+    you will need to *explicitly* convert it to a bytestring before you can
+    save them::
+
+        >>> s = 'A unicode string: hbar = \u210f'
+        >>> bytestring = s.encode('utf-8')
+        >>> VLArray.append(bytestring)
+
+    and decode when reading::
+
+        >>> bytestring = VLArray[0]
+        >>> s = bytestring.decode('utf-8')
+
+    For full Unicode support, using VLUnicodeAtom (see :ref:`VLUnicodeAtom`) is
     recommended.
 
     Variable-length string atoms do not accept parameters and they cause the
-    reads of rows to always return Python strings.  You can regard vlstring
+    reads of rows to always return Python bytestrings.  You can regard vlstring
     atoms as an easy way to save generic variable length strings.
 
     """

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1143,20 +1143,33 @@ class VLUnicodeAtom(_BufferedAtom):
         # NumPy ticket #525).  Since ``_tobuffer()`` can't return an
         # array, we must override ``toarray()`` itself.
         def toarray(self, object_):
-            if not isinstance(object_, basestring):
+            if isinstance(object_, unicode):
+                ustr = unicode(object_)
+                uarr = numpy.array(ustr, dtype='U')
+                return numpy.ndarray(
+                    buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
+            elif isinstance(object_, bytes):
+                warnings.warn("Storing bytestrings in VLUnicodeAtom is "
+                              "deprecated.", DeprecationWarning)
+                ustr = unicode(object_)
+                uarr = numpy.array(ustr, dtype='U')
+                return numpy.ndarray(
+                    buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
+            else:
                 raise TypeError("object is not a string: %r" % (object_,))
-            ustr = unicode(object_)
-            uarr = numpy.array(ustr, dtype='U')
-            return numpy.ndarray(
-                buffer=uarr, dtype=self.base.dtype, shape=len(ustr))
 
     def _tobuffer(self, object_):
         # This works (and is used) only with UCS-4 builds of Python,
         # where the width of the internal representation of a
         # character matches that of the base atoms.
-        if not isinstance(object_, basestring):
+        if isinstance(object_, unicode):
+            return numpy.unicode_(object_)
+        elif isinstance(object_, bytes):
+            warnings.warn("Storing bytestrings in VLUnicodeAtom is "
+                          "deprecated.", DeprecationWarning)
+            return numpy.string_(object_)
+        else:
             raise TypeError("object is not a string: %r" % (object_,))
-        return numpy.unicode_(object_)
 
     def fromarray(self, array):
         length = len(array)

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -18,6 +18,7 @@ import re
 import sys
 import inspect
 import cPickle
+import warnings
 
 import numpy
 
@@ -1097,10 +1098,14 @@ class VLStringAtom(_BufferedAtom):
     base = UInt8Atom()
 
     def _tobuffer(self, object_):
-        if not isinstance(object_, bytes) and \
-                not isinstance(object_, unicode):
+        if isinstance(object_, bytes):
+            return numpy.string_(object_)
+        elif isinstance(object_, unicode):
+            warnings.warn("Storing non bytestrings in VLStringAtom is "
+                          "deprecated.", DeprecationWarning)
+            return numpy.string_(object_)
+        else:
             raise TypeError("object is not a string: %r" % (object_,))
-        return numpy.string_(object_)
 
     def fromarray(self, array):
         return array.tostring()


### PR DESCRIPTION
This is a version of #553 against `master`.

This fixes: #552 

The bug is caused by `lib2to3` changing `basestring` to `str` on python3.

This fix also explicitly allows strings to make sure we do not break the API. 
This allows `bytes`  (which includes `str` in python 2) and `unicode` for python 2. 
This is converted to `bytes` and `str` for python 3 by `lib2to3`.

ToDo:
- [x] check if this breaks tests