### PR TITLE
Internal c-blosc bumped to 1.9.2

### DIFF
--- a/c-blosc/ANNOUNCE.rst
+++ b/c-blosc/ANNOUNCE.rst
@@ -1,14 +1,16 @@
 ===============================================================
- Announcing c-blosc 1.8.1
+ Announcing c-blosc 1.9.2
  A blocking, shuffling and lossless compression library for C
 ===============================================================
 
 What is new?
 ============
 
-This is a patch release for disabling the use of
-__builtin_cpu_supports() call for comaptibilty with GCC 5.3.1 (the one
-in forthcoming Ubuntu/Xenial).  Details in:
+This is a maintenance release.  On it, a check on whether Blosc is
+actually initialized before blosc_init(), blosc_destroy() and
+blosc_free_resources() is done, so that the library is more resistant
+to different initialization cycles
+(e.g. https://github.com/stevengj/Blosc.jl/issues/19).
 
 For more info, please see the release notes in:
 

--- a/c-blosc/CMakeLists.txt
+++ b/c-blosc/CMakeLists.txt
@@ -9,6 +9,8 @@
 #       build test programs and generates the "test" target
 #   BUILD_BENCHMARKS: default ON
 #       build the benchmark program
+#   DEACTIVATE_AVX2: default OFF
+#       do not attempt to build with AVX2 instructions
 #   DEACTIVATE_LZ4: default OFF
 #       do not include support for the LZ4 library
 #   DEACTIVATE_SNAPPY: default OFF
@@ -81,6 +83,8 @@ option(BUILD_TESTS
     "Build test programs form the blosc compression library" ON)
 option(BUILD_BENCHMARKS
     "Build benchmark programs form the blosc compression library" ON)
+option(DEACTIVATE_AVX2
+    "Do not attempt to build with AVX2 instructions" OFF)
 option(DEACTIVATE_LZ4
     "Do not include support for the LZ4 library." OFF)
 option(DEACTIVATE_SNAPPY
@@ -205,6 +209,11 @@ else()
     # If the target system processor isn't recognized, emit a warning message to alert the user
     # that hardware-acceleration support won't be available but allow configuration to proceed.
     message(WARNING "Unrecognized system processor ${CMAKE_SYSTEM_PROCESSOR}. Cannot determine which hardware features (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}) supports, so hardware-accelerated implementations will not be available.")
+endif()
+
+# disable AVX2 if specified
+if(DEACTIVATE_AVX2)
+    set(COMPILER_SUPPORT_AVX2 FALSE)
 endif()
 
 # flags

--- a/c-blosc/README.rst
+++ b/c-blosc/README.rst
@@ -5,13 +5,18 @@
 :Author: Francesc Alted
 :Contact: francesc@blosc.org
 :URL: http://www.blosc.org
+:Gitter: |gitter|
 :Travis CI: |travis|
 :Appveyor: |appveyor|
+
+.. |gitter| image:: https://badges.gitter.im/Blosc/c-blosc.svg
+        :alt: Join the chat at https://gitter.im/Blosc/c-blosc
+        :target: https://gitter.im/Blosc/c-blosc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 .. |travis| image:: https://travis-ci.org/Blosc/c-blosc.svg?branch=master
         :target: https://travis-ci.org/Blosc/c-blosc
 
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/gccmb03j8ghbj0ig/branch/master?svg=true
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/3mlyjc1ak0lbkmte?svg=true
         :target: https://ci.appveyor.com/project/FrancescAlted/c-blosc/branch/master
 
 

--- a/c-blosc/RELEASE_NOTES.rst
+++ b/c-blosc/RELEASE_NOTES.rst
@@ -1,10 +1,78 @@
-=================================
- Release notes for C-Blosc 1.8.1
-=================================
+===========================
+ Release notes for C-Blosc
+===========================
 
 :Author: Francesc Alted
 :Contact: francesc@blosc.org
 :URL: http://www.blosc.org
+
+
+Changes from 1.9.1 to 1.9.2
+===========================
+
+- Check whether Blosc is actually initialized before blosc_init(),
+  blosc_destroy() and blosc_free_resources().  This makes the library
+  more resistant to different initialization cycles
+  (e.g. https://github.com/stevengj/Blosc.jl/issues/19).
+
+
+Changes from 1.9.0 to 1.9.1
+===========================
+
+- The internal copies when clevel=0 are made now via memcpy().  At the
+  beginning of C-Blosc development, benchmarks where saying that the
+  internal, multi-threaded copies inside C-Blosc were faster than
+  memcpy(), but 6 years later, memcpy() made greats strides in terms
+  of efficiency.  With this, you should expect an slight speed
+  advantage (10% ~ 20%) when C-Blosc is used as a replacement of
+  memcpy() (which should not be the most common scenario out there).
+
+- Added a new DEACTIVATE_AVX2 cmake option to explicitly disable AVX2
+  at build-time.  Thanks to James Bird.
+
+- The ``make -jN`` for parallel compilation should work now.  Thanks
+  to James Bird.
+
+
+Changes from 1.8.1 to 1.9.0
+===========================
+
+* New blosc_get_nthreads() function to get the number of threads that
+  will be used internally during compression/decompression (set by
+  already existing blosc_set_nthreads()).
+
+* New blosc_get_compressor() function to get the compressor that will
+  be used internally during compression (set by already existing
+  blosc_set_compressor()).
+
+* New blosc_get_blocksize() function to get the internal blocksize to
+  be used during compression (set by already existing
+  blosc_set_blocksize()).
+
+* Now, when the BLOSC_NOLOCK environment variable is set (to any
+  value), the calls to blosc_compress() and blosc_decompress() will
+  call blosc_compress_ctx() and blosc_decompress_ctx() under the hood
+  so as to avoid the internal locks.  See blosc.h for details.  This
+  allows multi-threaded apps calling the non _ctx() functions to avoid
+  the internal locks in C-Blosc.  For the not multi-threaded app
+  though, it is in general slower to call the _ctx() functions so the
+  use of BLOSC_NOLOCK is discouraged.
+
+* In the same vein, from now on, when the BLOSC_NTHREADS environment
+  variable is set to an integer, every call to blosc_compress() and
+  blosc_decompress() will call blosc_set_nthreads(BLOSC_NTHREADS)
+  before the actuall compression/decompression process.  See blosc.h
+  for details.
+
+* Finally, if BLOSC_CLEVEL, BLOSC_SHUFFLE, BLOSC_TYPESIZE and/or
+  BLOSC_COMPRESSOR variables are set in the environment, these will be
+  also honored before calling blosc_compress().
+
+* Calling blosc_init() before any other Blosc call, although
+  recommended, is not necessary anymore.  The idea is that you can use
+  just the basic blosc_compress() and blosc_decompress() and control
+  other parameters (nthreads, compressor, blocksize) by using
+  environment variables (see above).
 
 
 Changes from 1.8.0 to 1.8.1

--- a/c-blosc/RELEASING.rst
+++ b/c-blosc/RELEASING.rst
@@ -64,6 +64,11 @@ Post-release actions
 
   #XXX version-specific blurb XXX#
 
+- Commit the changes::
+
+    $ git commit -a -m"Post X.Y.Z release actions done"
+    $ git push
+
 
 That's all folks!
 

--- a/c-blosc/appveyor.yml
+++ b/c-blosc/appveyor.yml
@@ -9,12 +9,21 @@ init:
 version: '{build}'
 
 environment:
-  matrix:
-    - GENERATOR: "Visual Studio 9 2008"
-      CONFIG: Release
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
-    - GENERATOR: "Visual Studio 9 2008 Win64"
-      CONFIG: Release
+  matrix:
+    # Unfortunately, I was not able to correctly make VS2008 to work
+    # - GENERATOR: "Visual Studio 9 2008"
+    #   CONFIG: Release
+
+    # Using Win64 for 2008 is unnecessarily complicated.  See:
+    # http://help.appveyor.com/discussions/kb/38-visual-studio-2008-64-bit-builds
+    # - GENERATOR: "Visual Studio 9 2008 Win64"
+    #   CONFIG: Release
 
     - GENERATOR: "Visual Studio 10 2010"
       CONFIG: Release

--- a/c-blosc/examples/multithread.c
+++ b/c-blosc/examples/multithread.c
@@ -11,12 +11,12 @@
 
     or, if you don't have the blosc library installed:
 
-    gcc -O3 -msse2 multithread.c ../blosc/*.c  -I../blosc -o multithread -lpthread
+    gcc -O3 -msse2 multithread.c ../blosc/!(*avx2*)*.c  -I../blosc -o multithread -lpthread
 
     Using MSVC on Windows:
 
     cl /Ox /Femultithread.exe /Iblosc multithread.c blosc\*.c
-    
+
     To run:
 
     $ ./multithread

--- a/c-blosc/examples/noinit.c
+++ b/c-blosc/examples/noinit.c
@@ -1,27 +1,29 @@
 /*
-    Copyright (C) 2014  Francesc Alted
+    Copyright (C) 2016  Francesc Alted
     http://blosc.org
     License: MIT (see LICENSE.txt)
 
-    Example program demonstrating use of the Blosc filter from C code.
+    Example program demonstrating that from 1.9.0 on, Blosc does not
+    need to be initialized (although it is recommended).
 
     To compile this program:
 
-    $ gcc simple.c -o simple -lblosc
+    $ gcc noinit.c -o noinit -lblosc
 
-    or, if you don't have the blosc library installed:
+    or, if you don't have the blosc library installed yet:
 
-    $ gcc -O3 -msse2 simple.c -I../blosc -o simple -L../build/blosc
+    $ gcc -O3 -msse2 noinit.c -I../blosc -o noinit -L../build/blosc
+    $ export LD_LIBRARY_PATH=../build/blosc
 
     Using MSVC on Windows:
 
-    $ cl /arch:SSE2 /Ox /Fesimple.exe /Iblosc examples\simple.c blosc\blosc.c blosc\blosclz.c blosc\shuffle.c blosc\shuffle-sse2.c blosc\shuffle-generic.c blosc\bitshuffle-generic.c blosc\bitshuffle-sse2.c
+    $ cl /arch:SSE2 /Ox /Fenoinit.exe /Iblosc examples\noinit.c blosc\blosc.c blosc\blosclz.c blosc\shuffle.c blosc\shuffle-sse2.c blosc\shuffle-generic.c blosc\bitshuffle-generic.c blosc\bitshuffle-sse2.c
 
     To run:
 
-    $ ./simple
-    Blosc version info: 1.4.2.dev ($Date:: 2014-07-08 #$)
-    Compression: 4000000 -> 158494 (25.2x)
+    $ ./noinit
+    Blosc version info: 1.8.2.dev ($Date:: 2016-04-08 #$)
+    Compression: 4000000 -> 158788 (25.2x)
     Decompression succesful!
     Succesful roundtrip!
 
@@ -48,8 +50,8 @@ int main(){
   printf("Blosc version info: %s (%s)\n",
 	 BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
 
-  /* Initialize the Blosc compressor */
-  blosc_init();
+  /* From 1.9 on, we don't need to initialize the Blosc compressor anymore */
+  /* blosc_init(); */
 
   /* Compress with clevel=5 and shuffle active  */
   csize = blosc_compress(5, 1, sizeof(float), isize, data, data_out, osize);
@@ -72,9 +74,6 @@ int main(){
   }
 
   printf("Decompression succesful!\n");
-
-  /* After using it, destroy the Blosc environment */
-  blosc_destroy();
 
   for(i=0;i<SIZE;i++){
     if(data[i] != data_dest[i]) {

--- a/c-blosc/tests/CMakeLists.txt
+++ b/c-blosc/tests/CMakeLists.txt
@@ -7,6 +7,24 @@ link_directories(${PROJECT_BINARY_DIR}/blosc)
 
 # targets and tests
 foreach(source ${SOURCES})
+    get_filename_component(target ${source} NAME_WE)
+
+    # test_nolock and test_noinit will be enabled only for Unix
+    if(WIN32)
+        if (target STREQUAL test_nolock OR
+            target STREQUAL test_noinit OR
+            target STREQUAL test_compressor)
+            message("Skipping ${target} on Windows systems")
+            continue()
+        endif()
+    endif()
+
+    # test_compressor will be enabled only when LZ4 support is in
+    if(target STREQUAL test_compressor AND DEACTIVATE_LZ4)
+        message("Skipping ${target} on non-LZ4 builds")
+        continue()
+    endif()
+
     # Enable support for testing accelerated shuffles
     if(COMPILER_SUPPORT_SSE2)
         # Define a symbol so tests for SSE2 shuffle/unshuffle will be compiled in.
@@ -21,7 +39,6 @@ foreach(source ${SOURCES})
 #            APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_AVX2_ENABLED)
 #    endif(COMPILER_SUPPORT_AVX2)
 
-    get_filename_component(target ${source} NAME_WE)
     add_executable(${target} ${source})
 
     # Define the BLOSC_TESTING symbol so normally-hidden functions
@@ -32,6 +49,11 @@ foreach(source ${SOURCES})
 
     # have to copy dlls for Visual Studio
     if(MSVC)
+        if(MSVC_VERSION EQUAL 1500)
+            # This is an attempt to make VS2008 work, but no luck...
+            # https://cmake.org/pipermail/cmake/2014-October/058777.html
+            SET(Configuration "Release")
+        endif()
         add_custom_command(
             TARGET      ${target}
             POST_BUILD
@@ -50,6 +72,7 @@ foreach(source ${SOURCES})
     endif()
 
     target_link_libraries(${target} blosc_testing)
+    add_dependencies(${target} blosc_shared_testing)
 
     # If there's a CSV file present for this test, read it to get the list
     # of test parameters then add a test for each parameter set.

--- a/c-blosc/tests/test_api.c
+++ b/c-blosc/tests/test_api.c
@@ -65,11 +65,36 @@ static char *test_cbuffer_complib() {
 }
 
 
+static char *test_nthreads() {
+  int nthreads;
+
+  nthreads = blosc_set_nthreads(4);
+  mu_assert("ERROR: set_nthreads incorrect", nthreads == 1);
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads incorrect", nthreads == 4);
+  return 0;
+}
+
+static char *test_blocksize() {
+  int blocksize;
+
+  blocksize = blosc_get_blocksize();
+  mu_assert("ERROR: get_blocksize incorrect", blocksize == 0);
+
+  blosc_set_blocksize(4096);
+  blocksize = blosc_get_blocksize();
+  mu_assert("ERROR: get_blocksize incorrect", blocksize == 4096);
+  return 0;
+}
+
+
 static char *all_tests() {
   mu_run_test(test_cbuffer_sizes);
   mu_run_test(test_cbuffer_metainfo);
   mu_run_test(test_cbuffer_versions);
   mu_run_test(test_cbuffer_complib);
+  mu_run_test(test_nthreads);
+  mu_run_test(test_blocksize);
   return 0;
 }
 

--- a/c-blosc/tests/test_common.h
+++ b/c-blosc/tests/test_common.h
@@ -29,6 +29,11 @@
 #include <math.h>
 #include "../blosc/blosc.h"
 
+#if defined(_WIN32) && !defined(__MINGW32__)
+  /* MSVC does not have setenv */
+  #define setenv(name, value, overwrite) do {_putenv_s(name, value);} while(0)
+#endif
+
 
 /* This is MinUnit in action (http://www.jera.com/techinfo/jtns/jtn002.html) */
 #define mu_assert(message, test) do { if (!(test)) return message; } while (0)

--- a/c-blosc/tests/test_compressor.c
+++ b/c-blosc/tests/test_compressor.c
@@ -1,0 +1,246 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Unit tests for BLOSC_COMPRESSOR environment variable in Blosc.
+
+  Creation date: 2016-04-25
+  Author: Francesc Alted <francesc@blosc.org>
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include "test_common.h"
+
+int tests_run = 0;
+
+/* Global vars */
+void *src, *srccpy, *dest, *dest2;
+int nbytes, cbytes;
+int clevel = 1;
+int doshuffle = 1;
+size_t typesize = 8;
+size_t size = 8 * 1000 * 1000;  /* must be divisible by typesize */
+
+
+/* Check compressor */
+static char *test_compressor() {
+  char* compressor;
+
+  /* Before any blosc_compress() the compressor must be blosclz */
+  compressor = blosc_get_compressor();
+  mu_assert("ERROR: get_compressor (compress, before) incorrect",
+	    strcmp(compressor, "blosclz") == 0);
+
+  /* Activate the BLOSC_COMPRESSOR variable */
+  setenv("BLOSC_COMPRESSOR", "lz4", 0);
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  compressor = blosc_get_compressor();
+  mu_assert("ERROR: get_compressor (compress, after) incorrect",
+	    strcmp(compressor, "lz4") == 0);
+
+  /* Reset envvar */
+  unsetenv("BLOSC_COMPRESSOR");
+  return 0;
+}
+
+
+/* Check compressing + decompressing */
+static char *test_compress_decompress() {
+  char* compressor;
+
+  /* Activate the BLOSC_COMPRESSOR variable */
+  setenv("BLOSC_COMPRESSOR", "lz4", 0);
+
+  compressor = blosc_get_compressor();
+  mu_assert("ERROR: get_compressor incorrect",
+	    strcmp(compressor, "lz4") == 0);
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  compressor = blosc_get_compressor();
+  mu_assert("ERROR: get_compressor incorrect",
+	    strcmp(compressor, "lz4") == 0);
+
+  /* Decompress the buffer */
+  nbytes = blosc_decompress(dest, dest2, size);
+  mu_assert("ERROR: nbytes incorrect(1)", nbytes == size);
+
+  compressor = blosc_get_compressor();
+  mu_assert("ERROR: get_compressor incorrect",
+	    strcmp(compressor, "lz4") == 0);
+
+  /* Reset envvar */
+  unsetenv("BLOSC_COMPRESSOR");
+  return 0;
+}
+
+
+/* Check compression level */
+static char *test_clevel() {
+  int cbytes2;
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  /* Activate the BLOSC_CLEVEL variable */
+  setenv("BLOSC_CLEVEL", "9", 0);
+  cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
+                           dest, size + 16);
+  mu_assert("ERROR: BLOSC_CLEVEL does not work correctly", cbytes2 < cbytes);
+
+  /* Reset envvar */
+  unsetenv("BLOSC_CLEVEL");
+  return 0;
+}
+
+/* Check noshuffle */
+static char *test_noshuffle() {
+  int cbytes2;
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  /* Activate the BLOSC_SHUFFLE variable */
+  setenv("BLOSC_SHUFFLE", "NOSHUFFLE", 0);
+  cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
+                           dest, size + 16);
+  mu_assert("ERROR: BLOSC_SHUFFLE=NOSHUFFLE does not work correctly",
+            cbytes2 > cbytes);
+
+  /* Reset env var */
+  unsetenv("BLOSC_SHUFFLE");
+  return 0;
+}
+
+
+/* Check regular shuffle */
+static char *test_shuffle() {
+  int cbytes2;
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not 0", cbytes < size);
+
+  /* Activate the BLOSC_SHUFFLE variable */
+  setenv("BLOSC_SHUFFLE", "SHUFFLE", 0);
+  cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
+                           dest, size + 16);
+  mu_assert("ERROR: BLOSC_SHUFFLE=SHUFFLE does not work correctly",
+            cbytes2 == cbytes);
+
+  /* Reset env var */
+  unsetenv("BLOSC_SHUFFLE");
+  return 0;
+}
+
+/* Check bitshuffle */
+static char *test_bitshuffle() {
+  int cbytes2;
+
+  /* Get a compressed buffer */
+  blosc_set_compressor("blosclz");  /* avoid lz4 here for now (see #168) */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not 0", cbytes < size);
+
+  /* Activate the BLOSC_BITSHUFFLE variable */
+  setenv("BLOSC_SHUFFLE", "BITSHUFFLE", 0);
+  cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
+                           dest, size + 16);
+  mu_assert("ERROR: BLOSC_SHUFFLE=BITSHUFFLE does not work correctly",
+            cbytes2 < cbytes);
+
+  /* Reset env var */
+  unsetenv("BLOSC_SHUFFLE");
+  return 0;
+}
+
+
+/* Check typesize */
+static char *test_typesize() {
+  int cbytes2;
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  /* Activate the BLOSC_TYPESIZE variable */
+  setenv("BLOSC_TYPESIZE", "9", 0);
+  cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
+                           dest, size + 16);
+  mu_assert("ERROR: BLOSC_TYPESIZE does not work correctly", cbytes2 > cbytes);
+
+  /* Reset envvar */
+  unsetenv("BLOSC_TYPESIZE");
+  return 0;
+}
+
+
+static char *all_tests() {
+  mu_run_test(test_compressor);
+  mu_run_test(test_compress_decompress);
+  mu_run_test(test_clevel);
+  mu_run_test(test_noshuffle);
+  mu_run_test(test_shuffle);
+  mu_run_test(test_bitshuffle);
+  mu_run_test(test_typesize);
+
+  return 0;
+}
+
+#define BUFFER_ALIGN_SIZE   32
+
+int main(int argc, char **argv) {
+  int64_t *_src;
+  char *result;
+  size_t i;
+
+  printf("STARTING TESTS for %s", argv[0]);
+
+  blosc_init();
+  blosc_set_compressor("blosclz");
+
+  /* Initialize buffers */
+  src = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  srccpy = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  dest = blosc_test_malloc(BUFFER_ALIGN_SIZE, size + 16);
+  dest2 = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  _src = (int64_t *)src;
+  for (i=0; i < (size / sizeof(int64_t)); i++) {
+    _src[i] = (int64_t)i;
+  }
+  memcpy(srccpy, src, size);
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != 0) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc_test_free(src);
+  blosc_test_free(srccpy);
+  blosc_test_free(dest);
+  blosc_test_free(dest2);
+
+  blosc_destroy();
+
+  return result != 0;
+}

--- a/c-blosc/tests/test_noinit.c
+++ b/c-blosc/tests/test_noinit.c
@@ -1,0 +1,108 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Unit tests for BLOSC_NOLOCK environment variable in Blosc.
+
+  Creation date: 2016-04-25
+  Author: Francesc Alted <francesc@blosc.org>
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+/* Test for using blosc without blosc_init() and blosc_destroy() */
+
+#include <unistd.h>
+#include "test_common.h"
+
+int tests_run = 0;
+
+/* Global vars */
+void *src, *srccpy, *dest, *dest2;
+size_t nbytes, cbytes;
+int clevel = 1;
+int doshuffle = 1;
+size_t typesize = 4;
+size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
+
+
+/* Check just compressing */
+static char *test_compress() {
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  return 0;
+}
+
+
+/* Check compressing + decompressing */
+static char *test_compress_decompress() {
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  /* Decompress the buffer */
+  nbytes = blosc_decompress(dest, dest2, size);
+  mu_assert("ERROR: nbytes incorrect(1)", nbytes == size);
+
+  return 0;
+}
+
+
+static char *all_tests() {
+  mu_run_test(test_compress);
+  mu_run_test(test_compress_decompress);
+
+  return 0;
+}
+
+#define BUFFER_ALIGN_SIZE   32
+
+int main(int argc, char **argv) {
+  int32_t *_src;
+  char *result;
+  size_t i;
+  int pid, nchildren = 4;
+
+  printf("STARTING TESTS for %s\n", argv[0]);
+
+  /* Launch several subprocesses */
+  for (i = 1; i <= nchildren; i++) {
+    pid = fork();
+  }
+
+  blosc_set_nthreads(4);
+
+  /* Initialize buffers */
+  src = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  srccpy = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  dest = blosc_test_malloc(BUFFER_ALIGN_SIZE, size + 16);
+  dest2 = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  _src = (int32_t *)src;
+  for (i=0; i < (size/4); i++) {
+    _src[i] = (int32_t)i;
+  }
+  memcpy(srccpy, src, size);
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != 0) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED\n");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc_test_free(src);
+  blosc_test_free(srccpy);
+  blosc_test_free(dest);
+  blosc_test_free(dest2);
+
+
+  return result != 0;
+}

--- a/c-blosc/tests/test_nolock.c
+++ b/c-blosc/tests/test_nolock.c
@@ -1,0 +1,111 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Unit tests for BLOSC_NOLOCK environment variable in Blosc.
+
+  Creation date: 2016-04-25
+  Author: Francesc Alted <francesc@blosc.org>
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include <unistd.h>
+#include "test_common.h"
+
+int tests_run = 0;
+
+/* Global vars */
+void *src, *srccpy, *dest, *dest2;
+size_t nbytes, cbytes;
+int clevel = 1;
+int doshuffle = 1;
+size_t typesize = 4;
+size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
+
+
+/* Check just compressing */
+static char *test_compress() {
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  return 0;
+}
+
+
+/* Check compressing + decompressing */
+static char *test_compress_decompress() {
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  /* Decompress the buffer */
+  nbytes = blosc_decompress(dest, dest2, size);
+  mu_assert("ERROR: nbytes incorrect(1)", nbytes == size);
+
+  return 0;
+}
+
+
+static char *all_tests() {
+  mu_run_test(test_compress);
+  mu_run_test(test_compress_decompress);
+
+  return 0;
+}
+
+#define BUFFER_ALIGN_SIZE   32
+
+int main(int argc, char **argv) {
+  int32_t *_src;
+  char *result;
+  size_t i;
+  int pid, nchildren = 4;
+
+  printf("STARTING TESTS for %s\n", argv[0]);
+
+  /* Activate the BLOSC_NOLOCK variable */
+  setenv("BLOSC_NOLOCK", "TRUE", 0);
+
+  /* Launch several subprocesses */
+  for (i = 1; i <= nchildren; i++) {
+    pid = fork();
+  }
+
+  blosc_init();
+  blosc_set_nthreads(4);
+
+  /* Initialize buffers */
+  src = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  srccpy = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  dest = blosc_test_malloc(BUFFER_ALIGN_SIZE, size + 16);
+  dest2 = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  _src = (int32_t *)src;
+  for (i=0; i < (size/4); i++) {
+    _src[i] = (int32_t)i;
+  }
+  memcpy(srccpy, src, size);
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != 0) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED\n");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc_test_free(src);
+  blosc_test_free(srccpy);
+  blosc_test_free(dest);
+  blosc_test_free(dest2);
+
+  blosc_destroy();
+
+  return result != 0;
+}

--- a/c-blosc/tests/test_nthreads.c
+++ b/c-blosc/tests/test_nthreads.c
@@ -1,0 +1,124 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Unit tests for BLOSC_NTHREADS environment variable in Blosc.
+
+  Creation date: 2016-04-25
+  Author: Francesc Alted <francesc@blosc.org>
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include "test_common.h"
+
+int tests_run = 0;
+
+/* Global vars */
+void *src, *srccpy, *dest, *dest2;
+int nbytes, cbytes;
+int clevel = 1;
+int doshuffle = 1;
+size_t typesize = 4;
+size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
+
+
+/* Check just compressing */
+static char *test_compress() {
+  int nthreads;
+
+  /* Before any blosc_compress() or blosc_decompress() the number of
+     threads must be 1 */
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads (compress, before) incorrect", nthreads == 1);
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size + 16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads (compress, after) incorrect", nthreads == 3);
+
+  return 0;
+}
+
+
+/* Check compressing + decompressing */
+static char *test_compress_decompress() {
+  int nthreads;
+
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads incorrect", nthreads == 3);
+
+  /* Get a compressed buffer */
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
+                          dest, size+16);
+  mu_assert("ERROR: cbytes is not correct", cbytes < size);
+
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads incorrect", nthreads == 3);
+
+  /* Decompress the buffer */
+  nbytes = blosc_decompress(dest, dest2, size);
+  mu_assert("ERROR: nbytes incorrect(1)", nbytes == size);
+
+  nthreads = blosc_get_nthreads();
+  mu_assert("ERROR: get_nthreads incorrect", nthreads == 3);
+
+  return 0;
+}
+
+
+static char *all_tests() {
+  mu_run_test(test_compress);
+  mu_run_test(test_compress_decompress);
+
+  return 0;
+}
+
+#define BUFFER_ALIGN_SIZE   32
+
+int main(int argc, char **argv) {
+  int32_t *_src;
+  char *result;
+  size_t i;
+  int pid, nchildren = 4;
+
+  printf("STARTING TESTS for %s", argv[0]);
+
+  /* Activate the BLOSC_NTHREADS variable */
+  setenv("BLOSC_NTHREADS", "3", 1);
+
+  blosc_init();
+  blosc_set_nthreads(1);
+
+  /* Initialize buffers */
+  src = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  srccpy = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  dest = blosc_test_malloc(BUFFER_ALIGN_SIZE, size + 16);
+  dest2 = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  _src = (int32_t *)src;
+  for (i=0; i < (size/4); i++) {
+    _src[i] = (int32_t)i;
+  }
+  memcpy(srccpy, src, size);
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != 0) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc_test_free(src);
+  blosc_test_free(srccpy);
+  blosc_test_free(dest);
+  blosc_test_free(dest2);
+
+  blosc_destroy();
+
+  return result != 0;
+}


### PR DESCRIPTION
This is an update of C-Blosc sources to latest 1.9.2, where some fixes and performance improvements are done.  Also, C-Blosc 1.9.2 does honor environment variables to change the behavior of the compressor.  For details see:  https://github.com/Blosc/c-blosc/pull/164/files#diff-ef50c2e1ff36cb90b51cbba3ebb3ad04L156

If there are no complains, I will merge this by tomorrow.