### PR TITLE
Use deepcopy for recursion to work

### DIFF
--- a/tables/conditions.py
+++ b/tables/conditions.py
@@ -31,6 +31,7 @@ Functions:
 """
 
 import re
+from copy import deepcopy
 from numexpr.necompiler import typecode_to_kind
 from numexpr.necompiler import expressionToAST, typeCompileAst
 from numexpr.necompiler import stringToExpression, NumExpr, getExprNames
@@ -199,6 +200,10 @@ def _get_idx_expr_recurse(exprnode, indexedcols, idxexprs, strexpr):
             exprnode = idxcmp[0]
             idxcmp = _get_indexable_cmp(exprnode, indexedcols)
         return idxcmp, exprnode, invert
+
+    # deepcopy arguments for recursion to work
+    idxexprs = deepcopy(idxexprs)
+    strexpr = deepcopy(strexpr)
 
     # Indexable variable-constant comparison.
     idxcmp = _get_indexable_cmp(exprnode, indexedcols)

--- a/tables/conditions.py
+++ b/tables/conditions.py
@@ -253,8 +253,13 @@ def _get_idx_expr_recurse(exprnode, indexedcols, idxexprs, strexpr):
             return [expr]
 
     # Recursively get the expressions at the left and the right
-    lexpr = _get_idx_expr_recurse(left, indexedcols, idxexprs, strexpr)
+    lexpr = deepcopy(_get_idx_expr_recurse(left, indexedcols, idxexprs,
+                                           strexpr))
+    if len(lexpr) == 2 and lexpr != not_indexable:
+        idxexprs, strexpr = lexpr
     rexpr = _get_idx_expr_recurse(right, indexedcols, idxexprs, strexpr)
+    if len(rexpr) == 2 and rexpr != not_indexable:
+        idxexprs, strexpr = rexpr
 
     def add_expr(expr, idxexprs, strexpr):
         """Add a single expression to the list."""


### PR DESCRIPTION
This is a fix for #564

This function returns a tuple with references to `strexpr` and
`idxexprs` which a then passed recursively to this function while
traversing an expression AST. We need to make deepcopies of these
objects to prevent overwriting them. This fixes queries such as:
((a = 1 & b = 2) | (a = 2 & b = 1)).
Fixes gh-564. Thanks to ajenkens-cargometrics for reporting.