### PR TITLE
MNT: fix bad import

### DIFF
--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -495,7 +495,7 @@ cdef extern from "hdf5.h" nogil:
   H5I_type_t H5Iget_type(hid_t id)
   herr_t H5Rcreate(void *reference, hid_t loc_id, const char *name, H5R_type_t type, hid_t space_id)
   hid_t H5Rdereference(hid_t dset, H5R_type_t rtype, void *reference)
-  int H5Rget_object_type(hid_t obj_id, void *reference)
+  int H5Rget_obj_type(hid_t obj_id, void *reference)
   herr_t H5Oclose( hid_t object_id )
 
 


### PR DESCRIPTION
No function H5Rget_object_type exists in hdf5 (as of 1.10).  There is a
H5Rget_obj_type.

This function is not used in pytables.
