### PR TITLE
Make non-ascii returning __str__ work on Python2

### DIFF
--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -72,6 +72,7 @@ def issysattrname(name):
         return False
 
 
+@six.python_2_unicode_compatible
 class AttributeSet(hdf5extension.AttributeSet, object):
     """Container for the HDF5 attributes of a Node.
 

--- a/tables/description.py
+++ b/tables/description.py
@@ -313,6 +313,7 @@ Time64Col = Col._subclass_from_prefix('Time64')
 
 # Table description classes
 # =========================
+@six.python_2_unicode_compatible
 class Description(object):
     """This class represents descriptions of the structure of tables.
 

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -23,6 +23,7 @@ import warnings
 import traceback
 
 
+@six.python_2_unicode_compatible
 class HDF5ExtError(RuntimeError):
     """A low level HDF5 operation failed.
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -576,6 +576,7 @@ class NodeManager(object):
                 node._f_close()
 
 
+@six.python_2_unicode_compatible
 class File(hdf5extension.File, object):
     """The in-memory representation of a PyTables file.
 

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -57,6 +57,7 @@ _bitshuffle_flag = 0x8
 
 # Classes
 # =======
+@six.python_2_unicode_compatible
 class Filters(object):
     """Container for filter properties.
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -41,7 +41,7 @@ class _ChildrenDict(ProxyDict):
         return container._f_get_child(key)
 
 
-
+@six.python_2_unicode_compatible
 class Group(hdf5extension.Group, Node):
     """Basic PyTables grouping structure.
 

--- a/tables/index.py
+++ b/tables/index.py
@@ -45,6 +45,7 @@ from .utilsextension import (nan_aware_gt, nan_aware_ge,
                                    nan_aware_lt, nan_aware_le,
                                    bisect_left, bisect_right)
 from .lrucacheextension import ObjectCache
+import six
 from six.moves import range
 
 
@@ -105,7 +106,7 @@ def _table_column_pathname_of_index(indexpathname):
     return (tablepathname, colpathname)
 
 
-
+@six.python_2_unicode_compatible
 class Index(NotLoggedMixin, Group, indexesextension.Index):
     """Represents the index of a column in a table.
 

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -20,6 +20,7 @@ from .node import NotLoggedMixin
 from .carray import CArray
 from .earray import EArray
 from . import indexesextension
+import six
 
 
 # Declarations for inheriting
@@ -32,7 +33,6 @@ class CacheArray(indexesextension.CacheArray, NotLoggedMixin, EArray):
     _c_classid = 'CACHEARRAY'
 
 
-
 class LastRowArray(indexesextension.LastRowArray, NotLoggedMixin, CArray):
     """Container for keeping sorted and indices values of last row of an
     index."""
@@ -41,7 +41,7 @@ class LastRowArray(indexesextension.LastRowArray, NotLoggedMixin, CArray):
     _c_classid = 'LASTROWARRAY'
 
 
-
+@six.python_2_unicode_compatible
 class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
     """Represent the index (sorted or reverse index) dataset in HDF5 file.
 
@@ -72,7 +72,6 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
 
     # Class identifier.
     _c_classid = 'INDEXARRAY'
-
 
     # Properties
     # ~~~~~~~~~~
@@ -173,7 +172,6 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
             result2 = indexesextension._bisect_right(chunk, item2, chunksize)
             result2 += chunksize * nchunk2
         return (result1, result2)
-
 
     def __str__(self):
         "A compact representation of this class"

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -25,6 +25,7 @@ from .filters import Filters
 from .utils import byteorders, lazyattr, SizeType
 from .exceptions import PerformanceWarning
 from . import utilsextension
+import six
 from six.moves import range
 
 
@@ -73,6 +74,7 @@ def calc_chunksize(expected_mb):
     return chunksize * 8
 
 
+@six.python_2_unicode_compatible
 class Leaf(Node):
     """Abstract base class for all PyTables leaves.
 

--- a/tables/link.py
+++ b/tables/link.py
@@ -200,7 +200,7 @@ class SoftLink(linkextension.SoftLink, Link):
     # SoftLink rather than the target node
     _link_attrnames = ('target', 'dereference', 'is_dangling', 'copy', 'move',
                        'remove', 'rename', '__init__', '__str__', '__repr__',
-                       '__class__', '__dict__')
+                       '__unicode__', '__class__', '__dict__')
     _link_attrprefixes = ('_f_', '_c_', '_g_', '_v_')
 
 

--- a/tables/link.py
+++ b/tables/link.py
@@ -34,6 +34,7 @@ from . import linkextension
 from .node import Node
 from .utils import lazyattr
 from .attributeset import AttributeSet
+import six
 import tables.file
 
 
@@ -138,6 +139,7 @@ class Link(Node):
         return str(self)
 
 
+@six.python_2_unicode_compatible
 class SoftLink(linkextension.SoftLink, Link):
     """Represents a soft link (aka symbolic link).
 
@@ -323,6 +325,7 @@ class SoftLink(linkextension.SoftLink, Link):
                                       self.target, dangling)
 
 
+@six.python_2_unicode_compatible
 class ExternalLink(linkextension.ExternalLink, Link):
     """Represents an external link.
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -2991,6 +2991,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 (str(self), self.description, self.byteorder, self.chunkshape)
 
 
+@six.python_2_unicode_compatible
 class Cols(object):
     """Container for columns in a table or nested column.
 
@@ -3265,6 +3266,7 @@ class Cols(object):
         return out
 
 
+@six.python_2_unicode_compatible
 class Column(object):
     """Accessor for a non-nested column in a table.
 

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -13,6 +13,7 @@
 """Here is defined the UnImplemented class."""
 from __future__ import absolute_import
 
+import six
 import warnings
 
 from . import hdf5extension
@@ -114,6 +115,7 @@ class UnImplemented(hdf5extension.UnImplemented, Leaf):
 
 
 # Classes reported as H5G_UNKNOWN by HDF5
+@six.python_2_unicode_compatible
 class Unknown(Node):
     """This class represents nodes reported as *unknown* by the underlying
     HDF5 library.


### PR DESCRIPTION
Uses class decorator `@python_2_unicode_compatible` from `six`.

```
A class decorator that takes a class defining a __str__ method. On
Python 3, the decorator does nothing. On Python 2, it aliases the
__str__ method to __unicode__ and creates a new __str__ method that
returns the result of __unicode__() encoded with UTF-8.
```

Closes #514
