### PR TITLE
HDF5 1.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,8 +105,7 @@ optional.
 Installation
 ------------
 
-1. Make sure you have HDF5 version 1.8.4 or above. HDF5 1.10.x is not
-supported.
+1. Make sure you have HDF5 version 1.8.4 or above.
 
    On OSX you can install HDF5 using `Homebrew <http://brew.sh>`_::
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 environment:
-
-  # Make setup.py include conda specific dll's in wheels
+  PACKAGE_NAME: tables
+  BUILD_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six cython bzip2"
+  TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six"
+  # Make setup.py include conda specific dll's in wheel
   BUILDWHEEL: True
 
   global:
@@ -18,6 +20,12 @@ environment:
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
+      HDF5_VERSION: "1.8"
+
+    - PYTHON: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      HDF5_VERSION: "1.10"
 
 #    - PYTHON: "C:\\Miniconda35"
 #      PYTHON_VERSION: "3.5"
@@ -26,32 +34,44 @@ environment:
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
+      HDF5_VERSION: "1.8"
+
+    - PYTHON: "C:\\Miniconda35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      HDF5_VERSION: "1.10"
 
 install:
   # this installs the appropriate Miniconda (Py2/Py3, 32/64 bit),
   # as well as pip, conda-build, and the binstar CLI
-  - powershell .\\ci\\appveyor\\install.ps1   
+  - powershell .\\ci\\appveyor\\install.ps1
   - powershell .\\ci\\appveyor\\missing-headers.ps1
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
-  - cmd: conda install --yes numexpr cython bzip2
-  # Install hdf5=1.8.17 from conda-forge. Anaconda default is 1.8.16.
-  - cmd: conda install --yes -c conda-forge hdf5=1.8.17 
-  - cmd: set HDF5_DIR="%PYTHON%\\Library\\"
-  - cmd: set BZIP2_DIR="%PYTHON%\\Library\\" 
-  - cmd: SET LIBRARY_PATH="%HDF5_DIR%\\lib"
-  # Make sure the wheel works:
-  # Build wheel and install using pip. 
-  - "%CMD_IN_ENV% python setup.py bdist_wheel"
-  - cmd: dir /B dist\*whl >WHEEL
-  - cmd: set /p WHEEL=<WHEEL
-  - cmd: pip install dist\%WHEEL%
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
 
-build: false
+build_script:
+  - conda install --yes %BUILD_DEPENDS%
+
+  # Install HDF5 Library
+  # Add tomkooij channel for HDF5 v1.10 conda packages
+  - conda config --add channels http://conda.anaconda.org/tomkooij
+  - conda install --yes hdf5=%HDF5_VERSION%
+  - "set HDF5_DIR=%PYTHON%\\Library"
+  - "set BZIP2_DIR=%PYTHON%\\Library\\"
+  - "set LIBRARY_PATH=%HDF5_DIR%\\lib"
+
+  # Build wheel
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
 
 test_script:
-  - cmd: cd ..
-  - cmd: python -m tables.tests.test_all
+  # create test env
+  - conda create --yes -n test_env python=%PYTHON_VERSION% %TEST_DEPENDS%
+  - activate test_env
+
+  # install from wheel
+  - pip install --no-index --find-links dist/ %PACKAGE_NAME%
+
+  - cd ..
+  - python -m tables.tests.test_all
 
 artifacts:
-  # download wheels
-  - path: dist\*
+    - path: "dist\\*"

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -49,7 +49,7 @@ Prerequisites
 First, make sure that you have
 
 * Python_ >= 2.7 including Python 3.x
-* HDF5_ >= 1.8.4 (>=1.8.15 is strongly recommended, HDF5 v1.10 not supported)
+* HDF5_ >= 1.8.4 (>=1.8.15 is strongly recommended)
 * NumPy_ >= 1.8.1
 * Numexpr_ >= 2.5.2
 * Cython_ >= 0.21

--- a/setup.py
+++ b/setup.py
@@ -523,29 +523,7 @@ CFLAGS.append("-Isrc")
 # Force the 1.8.x HDF5 API even if the library as been compiled to use the
 # 1.6.x API by default
 CFLAGS.extend([
-    "-DH5Acreate_vers=2",
-    "-DH5Aiterate_vers=2",
-    "-DH5Dcreate_vers=2",
-    "-DH5Dopen_vers=2",
-    "-DH5Eclear_vers=2",
-    "-DH5Eprint_vers=2",
-    "-DH5Epush_vers=2",
-    "-DH5Eset_auto_vers=2",
-    "-DH5Eget_auto_vers=2",
-    "-DH5Ewalk_vers=2",
-    "-DH5E_auto_t_vers=2",
-    "-DH5Gcreate_vers=2",
-    "-DH5Gopen_vers=2",
-    "-DH5Pget_filter_vers=2",
-    "-DH5Pget_filter_by_id_vers=2",
-    # "-DH5Pinsert_vers=2",
-    # "-DH5Pregister_vers=2",
-    # "-DH5Rget_obj_type_vers=2",
-    "-DH5Tarray_create_vers=2",
-    # "-DH5Tcommit_vers=2",
-    "-DH5Tget_array_dims_vers=2",
-    # "-DH5Topen_vers=2",
-    "-DH5Z_class_t_vers=2",
+    "-DH5_USE_18_API",
 ])
 # H5Oget_info_by_name seems to have performance issues (see gh-402), so we
 # need to use teh deprecated H5Gget_objinfo function
@@ -579,11 +557,6 @@ for (package, location) in [(hdf5_package, HDF5_DIR),
             exit_with_error(
                 "Unsupported HDF5 version! HDF5 v%s+ required. "
                 "Found version v%s" % (min_hdf5_version, hdf5_version))
-
-        if hdf5_version >= "1.10":
-            exit_with_error(
-                "HDF5 1.10 release not supported. HDF5 v1.8 release required. "
-                "Found version v%s" % (hdf5_version))
 
         if os.name == 'nt' and hdf5_version < "1.8.10":
             # Change in DLL naming happened in 1.8.10

--- a/setup.py
+++ b/setup.py
@@ -524,6 +524,29 @@ CFLAGS.append("-Isrc")
 # 1.6.x API by default
 CFLAGS.extend([
     "-DH5_USE_18_API",
+    "-DH5Acreate_vers=2",
+    "-DH5Aiterate_vers=2",
+    "-DH5Dcreate_vers=2",
+    "-DH5Dopen_vers=2",
+    "-DH5Eclear_vers=2",
+    "-DH5Eprint_vers=2",
+    "-DH5Epush_vers=2",
+    "-DH5Eset_auto_vers=2",
+    "-DH5Eget_auto_vers=2",
+    "-DH5Ewalk_vers=2",
+    "-DH5E_auto_t_vers=2",
+    "-DH5Gcreate_vers=2",
+    "-DH5Gopen_vers=2",
+    "-DH5Pget_filter_vers=2",
+    "-DH5Pget_filter_by_id_vers=2",
+    # "-DH5Pinsert_vers=2",
+    # "-DH5Pregister_vers=2",
+    # "-DH5Rget_obj_type_vers=2",
+    "-DH5Tarray_create_vers=2",
+    # "-DH5Tcommit_vers=2",
+    "-DH5Tget_array_dims_vers=2",
+    # "-DH5Topen_vers=2",
+    "-DH5Z_class_t_vers=2",
 ])
 # H5Oget_info_by_name seems to have performance issues (see gh-402), so we
 # need to use teh deprecated H5Gget_objinfo function

--- a/src/H5ARRAY.c
+++ b/src/H5ARRAY.c
@@ -31,7 +31,7 @@
  *-------------------------------------------------------------------------
  */
 
-herr_t H5ARRAYmake( hid_t loc_id,
+hid_t H5ARRAYmake(  hid_t loc_id,
                     const char *dset_name,
                     const char *obversion,
                     const int rank,
@@ -138,7 +138,7 @@ herr_t H5ARRAYmake( hid_t loc_id,
        blosc_compcode = blosc_compname_to_compcode(blosc_compname);
        cd_values[6] = blosc_compcode;
        if ( H5Pset_filter( plist_id, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values) < 0 )
-	 return -1;
+         return -1;
      }
      /* The LZO compressor does accept parameters */
      else if (strcmp(complib, "lzo") == 0) {

--- a/src/H5ARRAY.h
+++ b/src/H5ARRAY.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-herr_t H5ARRAYmake( hid_t loc_id,
+hid_t H5ARRAYmake(  hid_t loc_id,
                     const char *dset_name,
                     const char *obversion,
                     const int rank,

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -72,7 +72,7 @@
  */
 
 
-herr_t H5TBOmake_table( const char *table_title,
+hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,
                         const char *dset_name,
                         char *version,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-herr_t H5TBOmake_table( const char *table_title,
+hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,
                         const char *dset_name,
                         char *version,

--- a/src/H5VLARRAY.c
+++ b/src/H5VLARRAY.c
@@ -29,7 +29,7 @@
  *-------------------------------------------------------------------------
  */
 
-herr_t H5VLARRAYmake( hid_t loc_id,
+hid_t H5VLARRAYmake(  hid_t loc_id,
                       const char *dset_name,
                       const char *obversion,
                       const int rank,

--- a/src/H5VLARRAY.h
+++ b/src/H5VLARRAY.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-herr_t H5VLARRAYmake( hid_t loc_id,
+hid_t H5VLARRAYmake(  hid_t loc_id,
                       const char *dset_name,
                       const char *obversion,
                       const int rank,

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -38,16 +38,16 @@ cdef extern from "numpy/arrayobject.h":
 # Structs and types from HDF5
 cdef extern from "hdf5.h" nogil:
 
-  ctypedef int hid_t  # In H5Ipublic.h
+  ctypedef long long hid_t  # In H5Ipublic.h
   ctypedef int hbool_t
   ctypedef int herr_t
   ctypedef int htri_t
   # hsize_t should be unsigned, but Windows platform does not support
   # such an unsigned long long type.
-  ctypedef long long hsize_t
+  ctypedef unsigned long long hsize_t
   ctypedef signed long long hssize_t
   ctypedef long long int64_t
-  ctypedef long long haddr_t
+  ctypedef unsigned long long haddr_t
   ctypedef haddr_t hobj_ref_t
 
   ctypedef struct hvl_t:
@@ -170,61 +170,58 @@ cdef extern from "hdf5.h" nogil:
     H5T_NCLASSES                # this must be last
 
   # Native types
-  cdef enum:
-    H5T_C_S1
-    H5T_NATIVE_B8
-    H5T_NATIVE_CHAR
-    H5T_NATIVE_SCHAR
-    H5T_NATIVE_UCHAR
-    H5T_NATIVE_SHORT
-    H5T_NATIVE_USHORT
-    H5T_NATIVE_INT
-    H5T_NATIVE_UINT
-    H5T_NATIVE_LONG
-    H5T_NATIVE_ULONG
-    H5T_NATIVE_LLONG
-    H5T_NATIVE_ULLONG
-    H5T_NATIVE_FLOAT
-    H5T_NATIVE_DOUBLE
-    H5T_NATIVE_LDOUBLE
+  hid_t H5T_C_S1
+  hid_t H5T_NATIVE_B8
+  hid_t H5T_NATIVE_CHAR
+  hid_t H5T_NATIVE_SCHAR
+  hid_t H5T_NATIVE_UCHAR
+  hid_t H5T_NATIVE_SHORT
+  hid_t H5T_NATIVE_USHORT
+  hid_t H5T_NATIVE_INT
+  hid_t H5T_NATIVE_UINT
+  hid_t H5T_NATIVE_LONG
+  hid_t H5T_NATIVE_ULONG
+  hid_t H5T_NATIVE_LLONG
+  hid_t H5T_NATIVE_ULLONG
+  hid_t H5T_NATIVE_FLOAT
+  hid_t H5T_NATIVE_DOUBLE
+  hid_t H5T_NATIVE_LDOUBLE
 
   # "Standard" types
-  cdef enum:
-    H5T_STD_I8LE
-    H5T_STD_I16LE
-    H5T_STD_I32LE
-    H5T_STD_I64LE
-    H5T_STD_U8LE
-    H5T_STD_U16LE
-    H5T_STD_U32LE
-    H5T_STD_U64LE
-    H5T_STD_B8LE
-    H5T_STD_B16LE
-    H5T_STD_B32LE
-    H5T_STD_B64LE
-    H5T_IEEE_F32LE
-    H5T_IEEE_F64LE
-    H5T_STD_I8BE
-    H5T_STD_I16BE
-    H5T_STD_I32BE
-    H5T_STD_I64BE
-    H5T_STD_U8BE
-    H5T_STD_U16BE
-    H5T_STD_U32BE
-    H5T_STD_U64BE
-    H5T_STD_B8BE
-    H5T_STD_B16BE
-    H5T_STD_B32BE
-    H5T_STD_B64BE
-    H5T_IEEE_F32BE
-    H5T_IEEE_F64BE
+  hid_t H5T_STD_I8LE
+  hid_t H5T_STD_I16LE
+  hid_t H5T_STD_I32LE
+  hid_t H5T_STD_I64LE
+  hid_t H5T_STD_U8LE
+  hid_t H5T_STD_U16LE
+  hid_t H5T_STD_U32LE
+  hid_t H5T_STD_U64LE
+  hid_t H5T_STD_B8LE
+  hid_t H5T_STD_B16LE
+  hid_t H5T_STD_B32LE
+  hid_t H5T_STD_B64LE
+  hid_t H5T_IEEE_F32LE
+  hid_t H5T_IEEE_F64LE
+  hid_t H5T_STD_I8BE
+  hid_t H5T_STD_I16BE
+  hid_t H5T_STD_I32BE
+  hid_t H5T_STD_I64BE
+  hid_t H5T_STD_U8BE
+  hid_t H5T_STD_U16BE
+  hid_t H5T_STD_U32BE
+  hid_t H5T_STD_U64BE
+  hid_t H5T_STD_B8BE
+  hid_t H5T_STD_B16BE
+  hid_t H5T_STD_B32BE
+  hid_t H5T_STD_B64BE
+  hid_t H5T_IEEE_F32BE
+  hid_t H5T_IEEE_F64BE
 
   # Types which are particular to UNIX (for Time types)
-  cdef enum:
-    H5T_UNIX_D32LE
-    H5T_UNIX_D64LE
-    H5T_UNIX_D32BE
-    H5T_UNIX_D64BE
+  hid_t H5T_UNIX_D32LE
+  hid_t H5T_UNIX_D64LE
+  hid_t H5T_UNIX_D32BE
+  hid_t H5T_UNIX_D64BE
 
   # The order to retrieve atomic native datatype
   cdef enum H5T_direction_t:

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1217,6 +1217,10 @@ cdef class Array(Leaf):
       atom_ = atom
       shape = shape[:-len(atom_.shape)]
     self.disk_type_id = atom_to_hdf5_type(atom_, self.byteorder)
+    if self.disk_type_id < 0:
+      raise HDF5ExtError(
+        "Problems creating the %s: invalid disk type ID for atom %s" % (
+            self.__class__.__name__, atom_))
 
     # Allocate space for the dimension axis info and fill it
     dims = numpy.array(shape, dtype=numpy.intp)
@@ -1885,6 +1889,10 @@ cdef class VLArray(Leaf):
     # Get the HDF5 type of the *scalar* atom
     scatom = atom.copy(shape=())
     self.base_type_id = atom_to_hdf5_type(scatom, self.byteorder)
+    if self.base_type_id < 0:
+      raise HDF5ExtError(
+        "Problems creating the %s: invalid base type ID for atom %s" % (
+            self.__class__.__name__, scatom))
 
     # Allocate space for the dimension axis info
     rank = len(atom.shape)

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -1155,6 +1155,7 @@ def enum_to_hdf5(object enum_atom, str byteorder):
 
 def atom_to_hdf5_type(atom, str byteorder):
   cdef hid_t   tid = -1
+  cdef hid_t   tid2 = -1
   cdef hsize_t *dims = NULL
   cdef bytes   encoded_byteorder
   cdef char    *cbyteorder = NULL


### PR DESCRIPTION
This PR fixes compatibility with HDF5 v1.10 using the old 1.8 API.

This PR fixes issue #545.

The fix is backward compatible and should be almost complete.

A minor issue remains: it seems that the naming convention for hdf5 libraries is changed.
Now (v1.10 ?) when one builds HDF5 from code libraries are installed with the `-shared` and `-static` suffixes. The current setup.py does not play well with this naming but the easy workaround is to create symlinks with old names.
