### PR TITLE
ENH(BF?): allow for  long type in nextafter

### DIFF
--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -13,6 +13,7 @@
 """Utilities to be used mainly by the Index class."""
 from __future__ import absolute_import
 
+import six
 import sys
 import math
 import numpy
@@ -471,7 +472,7 @@ def nextafter(x, direction, dtype, itemsize):
     direction."""
 
     assert direction in [-1, 0, +1]
-    assert dtype.kind == "S" or type(x) in (bool, int, float)
+    assert dtype.kind == "S" or type(x) in (bool, float) + six.integer_types
 
     if direction == 0:
         return x


### PR DESCRIPTION
Blind attempt to address failing tests of pandas on i386, e.g.
https://buildd.debian.org/status/fetch.php?pkg=pandas&arch=i386&ver=0.19.1-1&stamp=1479504883

Somewhat a blind shot but I thought that if int and even float are kosher enough, long should be as good ;)   With this change corresponding tests in pandas have passed just fine 