### PR TITLE
Test against python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 
 sudo: false
 
@@ -29,4 +30,3 @@ notifications:
     urls:
       - https://webhooks.gitter.im/e/58f8a9014ef02f6217ec
     on_success: change
-


### PR DESCRIPTION
CPython 3.6 was released 23-12-2016.

Add 3.6 to tests.
(`pytables-3.3.0` packages for python 3.6 already live on conda-forge)