### PR TITLE
Allow Windows absolute file paths in ptrepack args

### DIFF
--- a/doc/source/usersguide/utilities.rst
+++ b/doc/source/usersguide/utilities.rst
@@ -235,11 +235,9 @@ to see the message usage:
     positional arguments:
       sourcefile:sourcegroup
                             source file/group
-                            file names/paths in sourcegroup are separated by ","
-                            on Windows systems and ":" on Linus/macOS systems.
+                            file names/paths in sourcegroup are separated by ":"
       destfile:destgroup    destination file/group
-                            file names/paths in destgroup are separated by ","
-                            on Windows systems and ":" on Linus/macOS systems.
+                            file names/paths in destgroup are separated by ":"
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/doc/source/usersguide/utilities.rst
+++ b/doc/source/usersguide/utilities.rst
@@ -235,7 +235,11 @@ to see the message usage:
     positional arguments:
       sourcefile:sourcegroup
                             source file/group
+                            file names/paths in sourcegroup are separated by ","
+                            on Windows systems and ":" on Linus/macOS systems.
       destfile:destgroup    destination file/group
+                            file names/paths in destgroup are separated by ","
+                            on Windows systems and ":" on Linus/macOS systems.
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -422,8 +422,15 @@ def main():
         )
 
     # Catch the files passed as the last arguments
-    src = args.src.split(':')
-    dst = args.dst.split(':')
+    if 'win' in sys.platform():
+        # the file separator for windows is deemed ','
+        src = args.src.split(',')
+        dst = args.dst.split(',')
+    else:
+        # the file separator for osx, linux for  is deemed ':'
+        src = args.src.split(':')
+        dst = args.dst.split(':')
+
     if len(src) == 1:
         srcfile, srcnode = src[0], "/"
     else:

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -422,14 +422,8 @@ def main():
         )
 
     # Catch the files passed as the last arguments
-    if 'win' in sys.platform():
-        # the file separator for windows is deemed ','
-        src = args.src.split(',')
-        dst = args.dst.split(',')
-    else:
-        # the file separator for osx, linux for  is deemed ':'
-        src = args.src.split(':')
-        dst = args.dst.split(':')
+    src = args.src.rsplit(':', 1)
+    dst = args.dst.rsplit(':', 1)
 
     if len(src) == 1:
         srcfile, srcnode = src[0], "/"

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -50,6 +50,7 @@ def suite():
         'tables.tests.test_indexvalues',
         'tables.tests.test_index_backcompat',
         'tables.tests.test_aux',
+        'tables.tests.test_utils',
         # Sub-packages
         'tables.nodes.tests.test_filenode',
     ]

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -78,7 +78,16 @@ class pttreeTestCase(TestCase):
         self.assertEqual(args, (src_fn, 'r'))
 
 
+def suite():
+    theSuite = unittest.TestSuite()
+
+    theSuite.addTest(unittest.makeSuite(ptrepackTestCase))
+    theSuite.addTest(unittest.makeSuite(ptdumpTestCase))
+    theSuite.addTest(unittest.makeSuite(pttreeTestCase))
+
+    return theSuite
+
 if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
-    unittest.main()
+    unittest.main(defaultTest='suite')

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -1,0 +1,84 @@
+import sys
+from mock import patch
+
+from tables.tests import common
+from tables.tests.common import unittest
+from tables.tests.common import PyTablesTestCase as TestCase
+
+import tables.scripts.ptrepack as ptrepack
+import tables.scripts.ptdump as ptdump
+import tables.scripts.ptdump as pttree
+
+
+class ptrepackTestCase(TestCase):
+    """Test ptrepack"""
+
+    @patch.object(ptrepack, 'copy_leaf')
+    @patch.object(ptrepack, 'open_file')
+    def test_paths_windows(self, mock_open_file, mock_copy_leaf):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616
+        src_fn = 'D:\\window~1\\path\\000\\infile'
+        src_path = '/'
+        dst_fn = 'another\\path\\'
+        dst_path = '/path/in/outfile'
+
+        argv = ['ptrepack', src_fn + ':' + src_path, dst_fn + ':' + dst_path]
+        with patch.object(sys, 'argv', argv):
+            ptrepack.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+        args, kwargs = mock_copy_leaf.call_args_list[0]
+        self.assertEqual(args, (src_fn, dst_fn, src_path, dst_path))
+
+
+class ptdumpTestCase(TestCase):
+    """Test ptdump"""
+
+    @patch.object(ptdump, 'open_file')
+    @patch.object(ptdump, 'print')  # suppress output
+    def test_paths_windows(self, _, mock_open_file):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616 (in ptdump)
+        src_fn = 'D:\\window~1\\path\\000\\ptdump'
+        src_path = '/'
+
+        argv = ['ptdump', src_fn + ':' + src_path]
+        with patch.object(sys, 'argv', argv):
+            ptdump.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+
+class pttreeTestCase(TestCase):
+    """Test ptdump"""
+
+    @patch.object(pttree, 'open_file')
+    @patch.object(pttree, 'print')  # suppress output
+    def test_paths_windows(self, _, mock_open_file):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616 (in pttree)
+        src_fn = 'D:\\window~1\\path\\000\\pttree'
+        src_path = '/app'
+
+        argv = ['pttree', src_fn + ':' + src_path]
+        with patch.object(sys, 'argv', argv):
+            pttree.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+
+if __name__ == '__main__':
+    common.parse_argv(sys.argv)
+    common.print_versions()
+    unittest.main()


### PR DESCRIPTION
Allow different file separators based on OS: ":" for
Linux/macOS and "," for Windows. Clarify documentation
(available via "ptreapck --help") accordingly.
Not test included. Need help on that. Any example ?

Resolves: #616
See also: commit 476a2f956322569efefa5d779b457d639b90a552