### PR TITLE
Allow Windows absolute paths in ptutils args

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -12,7 +12,10 @@ Changes from 3.4.1 to 3.4.x
 ===========================
 
 
-
+Bugs fixed
+----------
+ - Fixed windows absolute paths in ptrepack, ptdump, ptree.
+   :issue:`616`. Thanks to oscar6echo.
 
 
 Changes from 3.4.0 to 3.4.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   PACKAGE_NAME: tables
   BUILD_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six cython bzip2"
-  TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six"
+  TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 six mock"
   # Make setup.py include conda specific dll's in wheel
   BUILDWHEEL: True
 

--- a/tables/scripts/ptdump.py
+++ b/tables/scripts/ptdump.py
@@ -167,7 +167,7 @@ def main():
             args.dump = 1
 
     # Catch the files passed as the last arguments
-    src = args.src.split(':')
+    src = args.src.rsplit(':', 1)
     if len(src) == 1:
         filename, nodename = src[0], "/"
     else:

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -422,8 +422,8 @@ def main():
         )
 
     # Catch the files passed as the last arguments
-    src = args.src.split(':')
-    dst = args.dst.split(':')
+    src = args.src.rsplit(':', 1)
+    dst = args.dst.rsplit(':', 1)
     if len(src) == 1:
         srcfile, srcnode = src[0], "/"
     else:

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -544,7 +544,10 @@ def main():
     cpu2 = time.clock()
     tcopy = round(t2 - t1, 3)
     cpucopy = round(cpu2 - cpu1, 3)
-    tpercent = int(round(cpucopy / tcopy, 2) * 100)
+    try:
+        tpercent = int(round(cpucopy / tcopy, 2) * 100)
+    except ZeroDivisionError:
+        tpercent = 'NaN'
 
     if verbose:
         ngroups = stats['groups']

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -103,7 +103,7 @@ def main():
     args = parser.parse_args()
 
     # Catch the files passed as the last arguments
-    src = args.__dict__.pop('src').split(':')
+    src = args.__dict__.pop('src').rsplit(':', 1)
     if len(src) == 1:
         filename, nodename = src[0], "/"
     else:

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -50,6 +50,7 @@ def suite():
         'tables.tests.test_indexvalues',
         'tables.tests.test_index_backcompat',
         'tables.tests.test_aux',
+        'tables.tests.test_utils',
         # Sub-packages
         'tables.nodes.tests.test_filenode',
     ]

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -1,0 +1,94 @@
+import sys
+from mock import patch
+
+from tables.tests import common
+from tables.tests.common import unittest
+from tables.tests.common import PyTablesTestCase as TestCase
+
+import tables.scripts.ptrepack as ptrepack
+import tables.scripts.ptdump as ptdump
+import tables.scripts.pttree as pttree
+
+
+class ptrepackTestCase(TestCase):
+    """Test ptrepack"""
+
+    @patch.object(ptrepack, 'copy_leaf')
+    @patch.object(ptrepack, 'open_file')
+    def test_paths_windows(self, mock_open_file, mock_copy_leaf):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616
+        src_fn = 'D:\\window~1\\path\\000\\infile'
+        src_path = '/'
+        dst_fn = 'another\\path\\'
+        dst_path = '/path/in/outfile'
+
+        argv = ['ptrepack', src_fn + ':' + src_path, dst_fn + ':' + dst_path]
+        with patch.object(sys, 'argv', argv):
+            ptrepack.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+        args, kwargs = mock_copy_leaf.call_args_list[0]
+        self.assertEqual(args, (src_fn, dst_fn, src_path, dst_path))
+
+
+class ptdumpTestCase(TestCase):
+    """Test ptdump"""
+
+    @patch.object(ptdump, 'open_file')
+    @patch.object(ptdump, 'print')  # suppress output
+    def test_paths_windows(self, _, mock_open_file):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616 (in ptdump)
+        src_fn = 'D:\\window~1\\path\\000\\ptdump'
+        src_path = '/'
+
+        argv = ['ptdump', src_fn + ':' + src_path]
+        with patch.object(sys, 'argv', argv):
+            ptdump.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+
+class pttreeTestCase(TestCase):
+    """Test ptdump"""
+
+    @patch.object(pttree.tables, 'open_file')
+    @patch.object(pttree, 'get_tree_str')
+    @patch.object(pttree, 'print')  # suppress output
+    def test_paths_windows(self, _, mock_get_tree_str, mock_open_file):
+        """Checking handling of windows filenames: test gh-616"""
+
+        # this filename has a semi-colon to check for
+        # regression of gh-616 (in pttree)
+        src_fn = 'D:\\window~1\\path\\000\\pttree'
+        src_path = '/'
+
+        argv = ['pttree', src_fn + ':' + src_path]
+        with patch.object(sys, 'argv', argv):
+            pttree.main()
+
+        args, kwargs = mock_open_file.call_args_list[0]
+        self.assertEqual(args, (src_fn, 'r'))
+
+
+def suite():
+    theSuite = unittest.TestSuite()
+
+    theSuite.addTest(unittest.makeSuite(ptrepackTestCase))
+    theSuite.addTest(unittest.makeSuite(ptdumpTestCase))
+    theSuite.addTest(unittest.makeSuite(pttreeTestCase))
+
+    return theSuite
+
+if __name__ == '__main__':
+    common.parse_argv(sys.argv)
+    common.print_versions()
+    unittest.main(defaultTest='suite')

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -1,6 +1,7 @@
 import sys
 from mock import patch
 
+import six
 from tables.tests import common
 from tables.tests.common import unittest
 from tables.tests.common import PyTablesTestCase as TestCase
@@ -40,7 +41,7 @@ class ptdumpTestCase(TestCase):
     """Test ptdump"""
 
     @patch.object(ptdump, 'open_file')
-    @patch.object(ptdump, 'print')  # suppress output
+    @patch('sys.stdout', new_callable=six.StringIO)
     def test_paths_windows(self, _, mock_open_file):
         """Checking handling of windows filenames: test gh-616"""
 
@@ -62,7 +63,7 @@ class pttreeTestCase(TestCase):
 
     @patch.object(pttree.tables, 'open_file')
     @patch.object(pttree, 'get_tree_str')
-    @patch.object(pttree, 'print')  # suppress output
+    @patch('sys.stdout', new_callable=six.StringIO)
     def test_paths_windows(self, _, mock_get_tree_str, mock_open_file):
         """Checking handling of windows filenames: test gh-616"""
 


### PR DESCRIPTION
ptdump, pttree and ptrepack use 'path:/group/node' as input.
On windows this could be: 'drive:\folder\filename:/group/node' (extra colon)
No testcase included.

Resolves: #616
See also: commit 476a2f956322569efefa5d779b457d639b90a552