### PR TITLE
feat(group): autocomplete valid python-identifiers

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -7,10 +7,14 @@
 
 .. py:currentmodule:: tables
 
-Changes from 3.4.1 to 3.4.x
+Changes from 3.4.2 to 3.4.x
 ===========================
 
-
+Improvements
+------------
+ - Autocomplete group-children that are named as valid python identifiers
+   on interactive python sessions. 
+   :issue:`624` thanks to ankostis.
 
 
 Changes from 3.4.1 to 3.4.2

--- a/tables/group.py
+++ b/tables/group.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import os
+import re
 import weakref
 import warnings
 
@@ -34,6 +35,15 @@ import six
 
 
 obversion = "1.0"
+
+
+def _is_python_identifier(s):
+    """
+    >>> [_is_python_identifier(s) 
+    ...  for s in ['5good-deeds', '5good_deeds', '_good_deeds']]
+    [False, False, True]
+    """
+    return re.sub('\W|^(?=\d)','_', s)
 
 
 class _ChildrenDict(ProxyDict):
@@ -805,6 +815,11 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         except AttributeError as ae:
             hint = " (use ``node._f_remove()`` if you want to remove a node)"
             raise ae.__class__(str(ae) + hint)
+
+    def __dir__(self):
+        """Autocomplete only children named as valid python identifiers."""
+        subnods = [c for c in self._v_children if _is_python_identifier(c)]
+        return super(Group, self).__dir__() + subnods
 
     def __getattr__(self, name):
         """Get a Python attribute or child node called name.

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -499,6 +499,45 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("walk_nodes(pathname, classname) test passed")
 
+    def test05_dir(self):
+        """Checking Group.__dir__"""
+
+        if common.verbose:
+            print('\n', '-=' * 30)
+            print("Running %s.test05_dir..." % self.__class__.__name__)
+
+        self.h5file = tables.open_file(self.h5fname, "r")
+
+        """
+        h5file nodes:
+        '/table0', '/var1', '/var4'
+        '/group0/table1', '/group0/var1', '/group0/var4',
+        '/group0/group1/table2', '/group0/group1/var1', '/group0/group1/var4'
+        """
+        root_dir = dir(self.h5file.root)
+        self.assertIn('group0', root_dir)
+        self.assertIn('table0', root_dir)
+        self.assertIn('var1', root_dir)
+        self.assertNotIn('table1', root_dir)
+        self.assertNotIn('table2', root_dir)
+
+        root_group0_dir = dir(self.h5file.root.group0)
+        self.assertIn('group1', root_group0_dir)
+        self.assertIn('table1', root_group0_dir)
+        self.assertNotIn('table0', root_group0_dir)
+        self.assertNotIn('table2', root_group0_dir)
+
+        root_group0_group1_dir = dir(self.h5file.root.group0.group1)
+        self.assertIn('group2', root_group0_group1_dir)
+        self.assertIn('table2', root_group0_group1_dir)
+        self.assertNotIn('table0', root_group0_group1_dir)
+        self.assertNotIn('table1', root_group0_group1_dir)
+        self.assertNotIn('group0', root_group0_group1_dir)
+        self.assertNotIn('group1', root_group0_group1_dir)
+
+        if common.verbose:
+            print("Group.__dir__ test passed")
+
 
 class DeepTreeTestCase(common.TempFileMixin, TestCase):
     """Checks for deep hierarchy levels in PyTables trees."""

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -499,6 +499,7 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("walk_nodes(pathname, classname) test passed")
 
+    @unittest.skipIf(sys.version_info[0] < 3, "Special method `__dir__()` introduced in Python-3.")
     def test05_dir(self):
         """Checking Group.__dir__"""
 
@@ -515,6 +516,17 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         '/group0/group1/table2', '/group0/group1/var1', '/group0/group1/var4'
         """
         root_dir = dir(self.h5file.root)
+        
+        ## Check some regular attributes.
+        #
+        self.assertIn('_v_children', root_dir)
+        self.assertIn('_v_attrs', root_dir)
+        self.assertIn('_g_get_child_group_class', root_dir)
+        self.assertIn('_g_get_child_group_class', root_dir)
+        self.assertIn('_f_close', root_dir)
+
+        ## Check children nodes.
+        #
         self.assertIn('group0', root_dir)
         self.assertIn('table0', root_dir)
         self.assertIn('var1', root_dir)


### PR DESCRIPTION
Implement `__dir__()` on group nodes to include in the list of autocompletions also those children that are named as valid python identifiers.