### PR TITLE
feat(attributes): __dir__() autocompletes also valid py-indentifiers

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -12,9 +12,9 @@ Changes from 3.4.2 to 3.4.x
 
 Improvements
 ------------
- - Autocomplete group-children that are named as valid python identifiers
-   on interactive python sessions. 
-   :issue:`624` thanks to ankostis.
+ - On interactive python sessions, group/attribute  `__dir__()` method
+   autocompletes children that are named as valid python identifiers.
+   :issue:`624` & :issue:`625` thanks to ankostis.
 
 
 Changes from 3.4.1 to 3.4.2

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -26,6 +26,7 @@ from .exceptions import ClosedNodeError, PerformanceWarning
 from .path import check_attribute_name
 from .undoredo import attr_to_shadow
 from .filters import Filters
+from .utils import is_python_identifier as _is_python_identifier  # not to polute ns
 
 from six.moves import map
 import six
@@ -151,9 +152,9 @@ class AttributeSet(hdf5extension.AttributeSet, object):
 
     .. rubric:: Notes on AttributeSet methods
 
-    Note that this class overrides the __getattr__(), __setattr__() and
-    __delattr__() special methods.  This allows you to read, assign or
-    delete attributes on disk by just using the next constructs::
+    Note that this class overrides the __getattr__(), __setattr__(),
+    __delattr__() and __dir__() special methods.  This allows you to
+    read, assign or delete attributes on disk by just using the next constructs::
 
         leaf.attrs.myattr = 'str attr'    # set a string (native support)
         leaf.attrs.myattr2 = 3            # set an integer (native support)
@@ -169,6 +170,10 @@ class AttributeSet(hdf5extension.AttributeSet, object):
             print("name: %s, value: %s" % (name, node._v_attrs[name]))
 
     Use whatever idiom you prefer to access the attributes.
+
+    Finally, on interactive python sessions you may get autocompletions of
+    attributes named as *valid python identifiers* by pressing the  `[Tab]`
+    key, or to use the dir() global function.
 
     If an attribute is set on a target node that already has a large
     number of attributes, a PerformanceWarning will be issued.
@@ -282,6 +287,11 @@ class AttributeSet(hdf5extension.AttributeSet, object):
             return self._v_attrnamessys[:]
         elif attrset == "all":
             return self._v_attrnames[:]
+
+    def __dir__(self):
+        """Autocomplete only children named as valid python identifiers."""
+        subnods = [c for c in self._v_attrnames if _is_python_identifier(c)]
+        return super(AttributeSet, self).__dir__() + subnods
 
     def __getattr__(self, name):
         """Get the attribute named "name"."""

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -26,7 +26,6 @@ from .exceptions import ClosedNodeError, PerformanceWarning
 from .path import check_attribute_name
 from .undoredo import attr_to_shadow
 from .filters import Filters
-from .utils import is_python_identifier as _is_python_identifier  # not to polute ns
 
 from six.moves import map
 import six
@@ -289,8 +288,11 @@ class AttributeSet(hdf5extension.AttributeSet, object):
             return self._v_attrnames[:]
 
     def __dir__(self):
-        """Autocomplete only children named as valid python identifiers."""
-        subnods = [c for c in self._v_attrnames if _is_python_identifier(c)]
+        """Autocomplete only children named as valid python identifiers.
+
+        Only PY3 supports this special method.
+        """
+        subnods = [c for c in self._v_attrnames if c.isidentifier()]
         return super(AttributeSet, self).__dir__() + subnods
 
     def __getattr__(self, name):

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -292,8 +292,9 @@ class AttributeSet(hdf5extension.AttributeSet, object):
 
         Only PY3 supports this special method.
         """
-        subnods = [c for c in self._v_attrnames if c.isidentifier()]
-        return super(AttributeSet, self).__dir__() + subnods
+        return list(set(c for c in
+                    super(AttributeSet, self).__dir__() + self._v_attrnames
+                    if c.isidentifier()))
 
     def __getattr__(self, name):
         """Get the attribute named "name"."""

--- a/tables/group.py
+++ b/tables/group.py
@@ -111,11 +111,11 @@ class Group(hdf5extension.Group, Node):
     The following documentation includes methods that are automatically
     called when a Group instance is accessed in a special way.
 
-    For instance, this class defines the __setattr__, __getattr__, and
-    __delattr__ methods, and they set, get and delete *ordinary Python
-    attributes* as normally intended. In addition to that, __getattr__
-    allows getting *child nodes* by their name for the sake of easy
-    interaction on the command line, as long as there is no Python
+    For instance, this class defines the __setattr__, __getattr__,
+    __delattr__ and __dir__ methods, and they set, get and delete
+    *ordinary Python attributes* as normally intended. In addition to that,
+     __getattr__ allows getting *child nodes* by their name for the sake of
+     easy interaction on the command line, as long as there is no Python
     attribute with the same name. Groups also allow the interactive
     completion (when using readline) of the names of child nodes.
     For instance::
@@ -133,6 +133,9 @@ class Group(hdf5extension.Group, Node):
         del group.table              # delete a Python attribute
         table = group.table          # get the table child instance again
 
+    Additionally, on interactive python sessions you may get autocompletions
+    of children named as *valid python identifiers* by pressing the  `[Tab]`
+    key, or to use the dir() global function.
 
     .. rubric:: Group attributes
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -29,21 +29,13 @@ from .path import check_name_validity, join_path, isvisiblename
 from .node import Node, NotLoggedMixin
 from .leaf import Leaf
 from .unimplemented import UnImplemented, Unknown
+from .utils import is_python_identifier as _is_python_identifier  # not to polute ns
 
 from .link import Link, SoftLink, ExternalLink
 import six
 
 
 obversion = "1.0"
-
-
-def _is_python_identifier(s):
-    """
-    >>> [_is_python_identifier(s) 
-    ...  for s in ['5good-deeds', '5good_deeds', '_good_deeds']]
-    [False, False, True]
-    """
-    return re.sub('\W|^(?=\d)','_', s)
 
 
 class _ChildrenDict(ProxyDict):

--- a/tables/group.py
+++ b/tables/group.py
@@ -29,7 +29,6 @@ from .path import check_name_validity, join_path, isvisiblename
 from .node import Node, NotLoggedMixin
 from .leaf import Leaf
 from .unimplemented import UnImplemented, Unknown
-from .utils import is_python_identifier as _is_python_identifier  # not to polute ns
 
 from .link import Link, SoftLink, ExternalLink
 import six
@@ -812,8 +811,11 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             raise ae.__class__(str(ae) + hint)
 
     def __dir__(self):
-        """Autocomplete only children named as valid python identifiers."""
-        subnods = [c for c in self._v_children if _is_python_identifier(c)]
+        """Autocomplete only children named as valid python identifiers.
+
+        Only PY3 supports this special method.
+        """
+        subnods = [c for c in self._v_children if c.isidentifier()]
         return super(Group, self).__dir__() + subnods
 
     def __getattr__(self, name):

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -625,16 +625,19 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         #
         self.assertIn('__class__', completions)
         self.assertIn('_f_copy', completions)
+        self.assertEqual(completions.count('_f_copy'), 1)
 
         ## Check SYS attrs.
         #
         self.assertNotIn(bad_sys, completions)
         self.assertIn(sys_attr, completions)
+        self.assertEqual(completions.count(sys_attr), 1)
 
         ## Check USER attrs.
         #
         self.assertIn(user_attr, completions)
         self.assertNotIn(bad_user, completions)
+        self.assertEqual(completions.count(user_attr), 1)
 
 
 class NotCloseCreate(CreateTestCase):

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -69,23 +69,23 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(self.h5file.get_node_attr(self.root.atable, 'attr1'),
                          "a" * attrlength)
         self.assertEqual(self.h5file.get_node_attr(self.root.anarray, 'attr1'),
-                         "n" * attrlength) 
-        
+                         "n" * attrlength)
+
     def reopen(self):
         # Reopen
         if self.close:
             if common.verbose:
                 print("(closing file version)")
             self._reopen(mode='r+', node_cache_slots=self.node_cache_slots)
-            self.root = self.h5file.root  
-            
+            self.root = self.h5file.root
+
     def check_missing(self,name):
         self.reopen()
         self.assertFalse(name in self.root.agroup._v_attrs)
         self.assertFalse(name in self.root.atable.attrs)
-        self.assertFalse(name in self.root.anarray.attrs)       
-        
-                         
+        self.assertFalse(name in self.root.anarray.attrs)
+
+
     def check_name(self, name, val = ''):
         """Check validity of attribute name filtering"""
         self.check_missing(name)
@@ -103,7 +103,7 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         self.h5file.del_node_attr(self.root.atable, name)
         self.h5file.del_node_attr(self.root.anarray, name)
         self.check_missing(name)
-        
+
         # Using Node methods
         self.root.agroup._f_setattr(name, val)
         self.root.atable.set_attr(name, val)
@@ -112,16 +112,16 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         self.reopen()
         self.assertEqual(self.root.agroup._f_getattr(name), val)
         self.assertEqual(self.root.atable.get_attr(name), val)
-        self.assertEqual(self.root.anarray.get_attr(name), val)  
+        self.assertEqual(self.root.anarray.get_attr(name), val)
         self.root.agroup._f_delattr(name)
         self.root.atable.del_attr(name)
-        self.root.anarray.del_attr(name)      
+        self.root.anarray.del_attr(name)
         self.check_missing(name)
-        
+
         # Using AttributeSet methods
         setattr(self.root.agroup._v_attrs, name, val)
         setattr(self.root.atable.attrs, name, val)
-        setattr(self.root.anarray.attrs, name, val)        
+        setattr(self.root.anarray.attrs, name, val)
         # Check AttributeSet methods
         self.reopen()
         self.assertEqual(getattr(self.root.agroup._v_attrs, name), val)
@@ -131,21 +131,21 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         delattr(self.root.atable.attrs, name)
         delattr(self.root.anarray.attrs, name)
         self.check_missing(name)
-        
+
         # Using dict []
         self.root.agroup._v_attrs[name]=val
         self.root.atable.attrs[name]=val
         self.root.anarray.attrs[name]=val
         # Check dict []
-        self.reopen()  
+        self.reopen()
         self.assertEqual(self.root.agroup._v_attrs[name], val)
         self.assertEqual(self.root.atable.attrs[name], val)
-        self.assertEqual(self.root.anarray.attrs[name], val)  
+        self.assertEqual(self.root.anarray.attrs[name], val)
         del self.root.agroup._v_attrs[name]
         del self.root.atable.attrs[name]
         del self.root.anarray.attrs[name]
         self.check_missing(name)
-        
+
     def test01a_setAttributes(self):
         """Checking attribute names validity"""
         self.check_name('a')
@@ -601,6 +601,40 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         assert_array_equal(self.array.attrs['a'], data)
         assert_array_equal(self.array.attrs['b'], data.T)
         assert_array_equal(self.array.attrs['c'], data.T)  # AssertionError!
+
+    @unittest.skipIf(sys.version_info[0] < 3, "Special method `__dir__()` introduced in Python-3.")
+    def test12_dir(self):
+        """Checking AttributeSet.__dir__"""
+
+        if common.verbose:
+            print('\n', '-=' * 30)
+            print("Running %s.test12_dir..." % self.__class__.__name__)
+
+        attrset = self.group._v_attrs
+
+        user_attr = 'good_attr'
+        sys_attr = 'BETTER_ATTR'
+        bad_user = '5bad'
+        bad_sys = 'SYS%'
+        for a in [user_attr, sys_attr, bad_user, bad_sys]:
+            attrset[a] = 1
+
+        completions = dir(attrset)
+
+        ## Check some regular attributes.
+        #
+        self.assertIn('__class__', completions)
+        self.assertIn('_f_copy', completions)
+
+        ## Check SYS attrs.
+        #
+        self.assertNotIn(bad_sys, completions)
+        self.assertIn(sys_attr, completions)
+
+        ## Check USER attrs.
+        #
+        self.assertIn(user_attr, completions)
+        self.assertNotIn(bad_user, completions)
 
 
 class NotCloseCreate(CreateTestCase):
@@ -1620,7 +1654,7 @@ class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, TestCase):
         # a UnicodeDecodeError when unpickling on python 3.
         # Python 3.4 adds encoding='bytes' to fix this
         # http://bugs.python.org/issue6784
-        # Objects pickled in the testfile have non-ascii chars in the 
+        # Objects pickled in the testfile have non-ascii chars in the
         # picklestring and will throw UnicodeDecodeError when unpickled
         # on python 3.
 

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -18,6 +18,7 @@ import os
 import sys
 import warnings
 import subprocess
+import re
 from time import time
 
 import numpy
@@ -133,6 +134,17 @@ def convert_to_np_atom2(object, atom):
         nparr = nparr.byteswap()
 
     return nparr
+
+
+
+def is_python_identifier(s):
+    """Is string valid as python-identifier?
+
+    >>> [_is_python_identifier(s)
+    ...  for s in ['5good-deeds', '5good_deeds', '_good_deeds']]
+    [False, False, True]
+    """
+    return re.sub('\W|^(?=\d)','_', s)
 
 
 

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -137,17 +137,6 @@ def convert_to_np_atom2(object, atom):
 
 
 
-def is_python_identifier(s):
-    """Is string valid as python-identifier?
-
-    >>> [_is_python_identifier(s)
-    ...  for s in ['5good-deeds', '5good_deeds', '_good_deeds']]
-    [False, False, True]
-    """
-    return re.sub('\W|^(?=\d)','_', s)
-
-
-
 def check_file_access(filename, mode='r'):
     """Check for file access in the specified `mode`.
 


### PR DESCRIPTION
Similar to #624, implement also `AttributeSet.__dir__()`  to return in its autocompletion list those attributes that are named as valid python identifiers.

+ Docs updated.
+ Simple test-case.
+ Not suitable for PY-2 (no `__dir__()` in datamodel).