### PR TITLE
Define `Group.__getitem__()` method

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -15,6 +15,9 @@ Improvements
  - On interactive python sessions, group/attribute  `__dir__()` method
    autocompletes children that are named as valid python identifiers.
    :issue:`624` & :issue:`625` thanks to ankostis.
+ - Implement `Group.__getitem__()` to have groups act as python-containers,
+   so code like this works: ``hfile.root['some child']``.
+   :issue:`628` thanks to ankostis.
 
 
 Changes from 3.4.1 to 3.4.2

--- a/tables/group.py
+++ b/tables/group.py
@@ -434,6 +434,16 @@ class Group(hdf5extension.Group, Node):
             return False
         return True
 
+    def __getitem__(self, childname):
+        """Return the (visible or hidden) child with that `name` ( a string).
+
+        Raise IndexError if child not exist.
+        """
+        try:
+            return self._f_get_child(childname)
+        except NoSuchNodeError:
+            raise IndexError(childname)
+
     def _f_walknodes(self, classname=None):
         """Iterate over descendant nodes.
 
@@ -827,6 +837,9 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         if name in self._c_lazy_children_attrs:
             self._g_add_children_names()
             return self.__dict__[name]
+        return self._f_get_child(name)
+
+    def __item__(self, name):
         return self._f_get_child(name)
 
     def __setattr__(self, name, value):

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -639,6 +639,10 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         self.assertNotIn(bad_user, completions)
         self.assertEqual(completions.count(user_attr), 1)
 
+        # Now check all for no duplicates.
+        self.assertSequenceEqual(sorted(set(completions)),
+                                 sorted(completions))
+
 
 class NotCloseCreate(CreateTestCase):
     close = False

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -516,7 +516,7 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         '/group0/group1/table2', '/group0/group1/var1', '/group0/group1/var4'
         """
         root_dir = dir(self.h5file.root)
-        
+
         ## Check some regular attributes.
         #
         self.assertIn('_v_children', root_dir)
@@ -532,12 +532,16 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         self.assertIn('var1', root_dir)
         self.assertNotIn('table1', root_dir)
         self.assertNotIn('table2', root_dir)
+        self.assertSequenceEqual(sorted(set(root_dir)),
+                                 sorted(root_dir))  # Check for no duplicates.
 
         root_group0_dir = dir(self.h5file.root.group0)
         self.assertIn('group1', root_group0_dir)
         self.assertIn('table1', root_group0_dir)
         self.assertNotIn('table0', root_group0_dir)
         self.assertNotIn('table2', root_group0_dir)
+        self.assertSequenceEqual(sorted(set(root_group0_dir)),
+                                 sorted(root_group0_dir))
 
         root_group0_group1_dir = dir(self.h5file.root.group0.group1)
         self.assertIn('group2', root_group0_group1_dir)
@@ -546,6 +550,8 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         self.assertNotIn('table1', root_group0_group1_dir)
         self.assertNotIn('group0', root_group0_group1_dir)
         self.assertNotIn('group1', root_group0_group1_dir)
+        self.assertSequenceEqual(sorted(set(root_group0_group1_dir)),
+                                 sorted(root_group0_group1_dir))
 
         if common.verbose:
             print("Group.__dir__ test passed")


### PR DESCRIPTION
Since `tables.group.Group` class defines `__contains__()` and `iter__()` methods, it should also define `__getitem__()`, and work as a proper *container*.  

That would make the code below to work intuitively:

```python
>>> 'group 1' in hfile.root
>>> g1 = hfile.root['group 1']
>>> g1['some &^%&^* named group']._v_pathname 
/group 1/some &^%&^* named group
```
For the record, that must have been the purpose of #270.

### Bonus commit: 
Improv unique checks on `__dir__()` TCs.