### PR TITLE
speedup in `_where`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ tables/*.so
 
 # specific files
 src/version.h
+
+
+tmp/*
+*.egg-info/*


### PR DESCRIPTION
I saw my code spending a lot of time in the coords = [p.nrow ...] comprehension, this change should speed up the creation of the coordinates array dramatically. The monotonic check removal is because it took a long time to create the array to do the check, it seems to be fine to just skip it because the savings are lost by allocating and doing the elementwise compare.

The idea of the change is to do the iteration directly in cython to produce a coordinate array.