### PR TITLE
enable building PyTables with Intel compiler (icc/icpc)

### DIFF
--- a/c-blosc/blosc/shuffle-avx2.c
+++ b/c-blosc/blosc/shuffle-avx2.c
@@ -41,7 +41,7 @@ static void printymm(__m256i ymm0)
 
 /* GCC doesn't include the split load/store intrinsics
    needed for the tiled shuffle, so define them here. */
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC)
 static inline __m256i
 __attribute__((__always_inline__))
 _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)


### PR DESCRIPTION
While trying to build PyTables using icc/icpc, the build would fail with the following error:

```
error: identifier "_mm256_castsi128_si256" is undefined
  _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
  ^

test.c(5): error: expected a type specifier
  _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
  ^

test.c(5): error: expected a type specifier
  _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
  ^

test.c(5): error #141: unnamed prototyped parameters not allowed when body is present
  _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
  ^

test.c(8): error: identifier "loaddr" is undefined
      _mm256_castsi128_si256(_mm_loadu_si128(loaddr)), _mm_loadu_si128(hiaddr), 1);
                                             ^

test.c(8): error: identifier "hiaddr" is undefined
      _mm256_castsi128_si256(_mm_loadu_si128(loaddr)), _mm_loadu_si128(hiaddr), 1);
```

It was diagnosed that `immintrin.h` from include directory of icc already defines split load/store intrinsics.
Ensuring that section of `shuffle-avx2.c` is not defined while building with icc/icpc, allows builds to go through.

@FrancescAlted 