### PR TITLE
No track times

### DIFF
--- a/src/H5ARRAY.c
+++ b/src/H5ARRAY.c
@@ -27,6 +27,7 @@
  * Date: March 19, 2001
  *
  * Comments: Modified by F. Alted. November 07, 2003
+ *           Modified by A. Cobb. August 21, 2017 (track_times)
  *
  *-------------------------------------------------------------------------
  */
@@ -44,6 +45,7 @@ hid_t H5ARRAYmake(  hid_t loc_id,
                     char  *complib,
                     int   shuffle,
                     int   fletcher32,
+		    hbool_t track_times,
                     const void *data)
 {
 
@@ -79,9 +81,15 @@ hid_t H5ARRAYmake(  hid_t loc_id,
  if ( (space_id = H5Screate_simple( rank, dims, maxdims )) < 0 )
    return -1;
 
+ /* Create dataset creation property list with default values */
+ plist_id = H5Pcreate (H5P_DATASET_CREATE);
+
+ /* Enable or disable recording dataset times */
+ if ( H5Pset_obj_track_times( plist_id, track_times ) < 0 )
+   return -1;
+
  if (chunked) {
    /* Modify dataset creation properties, i.e. enable chunking  */
-   plist_id = H5Pcreate (H5P_DATASET_CREATE);
    if ( H5Pset_chunk ( plist_id, rank, dims_chunk ) < 0 )
      return -1;
 
@@ -165,7 +173,7 @@ hid_t H5ARRAYmake(  hid_t loc_id,
  else {         /* Not chunked case */
    /* Create the dataset. */
    if ((dataset_id = H5Dcreate(loc_id, dset_name, type_id, space_id,
-                               H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT )) < 0 )
+                               H5P_DEFAULT, plist_id, H5P_DEFAULT )) < 0 )
      goto out;
  }
 

--- a/src/H5ARRAY.h
+++ b/src/H5ARRAY.h
@@ -26,6 +26,7 @@ hid_t H5ARRAYmake(  hid_t loc_id,
                     char  *complib,
                     int   shuffle,
                     int   fletcher32,
+                    hbool_t track_times,
                     const void *data);
 
 herr_t H5ARRAYappend_records( hid_t dataset_id,

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -67,6 +67,7 @@
  *    F. Alted
  *
  * Modifications:
+ *  * Modified by A. Cobb. August 21, 2017 (track_times)
  *
  *-------------------------------------------------------------------------
  */
@@ -85,6 +86,7 @@ hid_t H5TBOmake_table(  const char *table_title,
                         char *complib,
                         int shuffle,
                         int fletcher32,
+			hbool_t track_times,
                         const void *data )
 {
 
@@ -105,8 +107,14 @@ hid_t H5TBOmake_table(  const char *table_title,
  if ( (space_id = H5Screate_simple( 1, dims, maxdims )) < 0 )
   return -1;
 
- /* Modify dataset creation properties, i.e. enable chunking  */
+ /* Dataset creation properties */
  plist_id = H5Pcreate (H5P_DATASET_CREATE);
+
+ /* Enable or disable recording dataset times */
+ if ( H5Pset_obj_track_times( plist_id, track_times ) < 0 )
+   return -1;
+
+ /* Modify dataset creation properties, i.e. enable chunking  */
  if ( H5Pset_chunk ( plist_id, 1, dims_chunk ) < 0 )
   return -1;
 

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -17,6 +17,7 @@ hid_t H5TBOmake_table(  const char *table_title,
                         char *complib,
                         int shuffle,
                         int fletcher32,
+			hbool_t track_times,
                         const void *data );
 
 herr_t H5TBOread_records( hid_t dataset_id,

--- a/src/H5VLARRAY.c
+++ b/src/H5VLARRAY.c
@@ -26,6 +26,9 @@
  * Programmer: F. Alted
  *
  * Date: November 08, 2003
+ *
+ * Comments: Modified by A. Cobb. August 21, 2017 (track_times)
+ *
  *-------------------------------------------------------------------------
  */
 
@@ -41,6 +44,7 @@ hid_t H5VLARRAYmake(  hid_t loc_id,
                       char  *complib,
                       int   shuffle,
                       int   fletcher32,
+                      hbool_t track_times,
                       const void *data)
 {
 
@@ -81,8 +85,14 @@ hid_t H5VLARRAYmake(  hid_t loc_id,
  /* The dataspace */
  space_id = H5Screate_simple( 1, dataset_dims, maxdims );
 
- /* Modify dataset creation properties, i.e. enable chunking  */
+ /* Dataset creation properties */
  plist_id = H5Pcreate (H5P_DATASET_CREATE);
+
+ /* Enable or disable recording dataset times */
+ if ( H5Pset_obj_track_times( plist_id, track_times ) < 0 )
+   return -1;
+
+ /* Modify dataset creation properties, i.e. enable chunking  */
  if ( H5Pset_chunk ( plist_id, 1, dims_chunk ) < 0 )
    return -1;
 

--- a/src/H5VLARRAY.h
+++ b/src/H5VLARRAY.h
@@ -19,6 +19,7 @@ hid_t H5VLARRAYmake(  hid_t loc_id,
                       char  *complib,
                       int   shuffle,
                       int   fletcher32,
+		      hbool_t track_times,
                       const void *data);
 
 herr_t H5VLARRAYappend_records( hid_t dataset_id,

--- a/tables/array.py
+++ b/tables/array.py
@@ -84,6 +84,15 @@ class Array(hdf5extension.Array, Leaf, six.Iterator):
     byteorder
         The byteorder of the data *on disk*, specified as 'little' or 'big'.
         If this is not specified, the byteorder is that of the given `object`.
+    track_times
+        Whether time data associated with the leaf are recorded (object
+        access time, raw data modification time, metadata change time, object
+        birth time); default True.  Semantics of these times depend on their
+        implementation in the HDF5 library: refer to documentation of the
+        H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
+        change time) is implemented.
+
+        .. versionadded:: 3.4
 
     """
 
@@ -129,7 +138,8 @@ class Array(hdf5extension.Array, Leaf, six.Iterator):
     # ~~~~~~~~~~~~~
     def __init__(self, parentnode, name,
                  obj=None, title="",
-                 byteorder=None, _log=True, _atom=None):
+                 byteorder=None, _log=True, _atom=None,
+                 track_times=True):
 
         self._v_version = None
         """The object version of this array."""
@@ -184,7 +194,7 @@ class Array(hdf5extension.Array, Leaf, six.Iterator):
 
         # Ordinary arrays have no filters: leaf is created with default ones.
         super(Array, self).__init__(parentnode, name, new, Filters(),
-                                    byteorder, _log)
+                                    byteorder, _log, track_times)
 
     def _g_create(self):
         """Save a new array in file."""

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -79,6 +79,16 @@ class CArray(Array):
         or 'big'.  If this is not specified, the byteorder is that
         of the platform.
 
+    track_times
+        Whether time data associated with the leaf are recorded (object
+        access time, raw data modification time, metadata change time, object
+        birth time); default True.  Semantics of these times depend on their
+        implementation in the HDF5 library: refer to documentation of the
+        H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
+        change time) is implemented.
+
+        .. versionadded:: 3.4
+
     Examples
     --------
 
@@ -134,7 +144,7 @@ class CArray(Array):
                  atom=None, shape=None,
                  title="", filters=None,
                  chunkshape=None, byteorder=None,
-                 _log=True):
+                 _log=True, track_times=True):
 
         self.atom = atom
         """An `Atom` instance representing the shape, type of the atomic
@@ -209,7 +219,7 @@ class CArray(Array):
 
         # The `Array` class is not abstract enough! :(
         super(Array, self).__init__(parentnode, name, new, filters,
-                                    byteorder, _log)
+                                    byteorder, _log, track_times)
 
     def _g_create(self):
         """Create a new array in file (specific part)."""

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -459,6 +459,7 @@ cdef extern from "hdf5.h" nogil:
   herr_t H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
   herr_t H5Pget_userblock(hid_t plist, hsize_t *size)
   herr_t H5Pset_userblock(hid_t plist, hsize_t size)
+  herr_t H5Pget_obj_track_times(hid_t ocpl_id, hbool_t *track_times)
 
   # Error Handling Interface
   #herr_t H5Eget_auto(hid_t estack_id, H5E_auto_t *func, void** data)

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -94,6 +94,16 @@ class EArray(CArray):
         'big'. If this is not specified, the byteorder is that of the
         platform.
 
+    track_times
+        Whether time data associated with the leaf are recorded (object
+        access time, raw data modification time, metadata change time, object
+        birth time); default True.  Semantics of these times depend on their
+        implementation in the HDF5 library: refer to documentation of the
+        H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
+        change time) is implemented.
+
+        .. versionadded:: 3.4
+
     Examples
     --------
 
@@ -138,7 +148,7 @@ class EArray(CArray):
                  atom=None, shape=None, title="",
                  filters=None, expectedrows=None,
                  chunkshape=None, byteorder=None,
-                 _log=True):
+                 _log=True, track_times=True):
 
         # Specific of EArray
         if expectedrows is None:
@@ -148,7 +158,8 @@ class EArray(CArray):
 
         # Call the parent (CArray) init code
         super(EArray, self).__init__(parentnode, name, atom, shape, title,
-                                     filters, chunkshape, byteorder, _log)
+                                     filters, chunkshape, byteorder, _log,
+                                     track_times)
 
     # Public and private methods
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tables/file.py
+++ b/tables/file.py
@@ -952,7 +952,7 @@ class File(hdf5extension.File, object):
     def create_table(self, where, name, description=None, title="",
                      filters=None, expectedrows=10000,
                      chunkshape=None, byteorder=None,
-                     createparents=False, obj=None):
+                     createparents=False, obj=None, track_times=True):
         """Create a new table with the given name in where location.
 
         Parameters
@@ -1026,6 +1026,16 @@ class File(hdf5extension.File, object):
 
             .. versionadded:: 3.0
 
+        track_times
+            Whether time data associated with the leaf are recorded (object
+            access time, raw data modification time, metadata change time,
+            object birth time); default True.  Semantics of these times
+            depend on their implementation in the HDF5 library: refer to
+            documentation of the H5O_info_t data structure.  As of HDF5
+            1.8.15, only ctime (metadata change time) is implemented.
+
+            .. versionadded:: 3.4
+
         See Also
         --------
         Table : for more information on tables
@@ -1052,7 +1062,8 @@ class File(hdf5extension.File, object):
         ptobj = Table(parentnode, name,
                       description=description, title=title,
                       filters=filters, expectedrows=expectedrows,
-                      chunkshape=chunkshape, byteorder=byteorder)
+                      chunkshape=chunkshape, byteorder=byteorder,
+                      track_times=track_times)
 
         if obj is not None:
             ptobj.append(obj)
@@ -1062,7 +1073,7 @@ class File(hdf5extension.File, object):
 
     def create_array(self, where, name, obj=None, title="",
                      byteorder=None, createparents=False,
-                     atom=None, shape=None):
+                     atom=None, shape=None, track_times=True):
         """Create a new array.
 
         Parameters
@@ -1109,6 +1120,16 @@ class File(hdf5extension.File, object):
 
             .. versionadded:: 3.0
 
+        track_times
+            Whether time data associated with the leaf are recorded (object
+            access time, raw data modification time, metadata change time,
+            object birth time); default True.  Semantics of these times
+            depend on their implementation in the HDF5 library: refer to
+            documentation of the H5O_info_t data structure.  As of HDF5
+            1.8.15, only ctime (metadata change time) is implemented.
+
+            .. versionadded:: 3.4
+
         See Also
         --------
         Array : for more information on arrays
@@ -1143,12 +1164,14 @@ class File(hdf5extension.File, object):
 
         parentnode = self._get_or_create_path(where, createparents)
         return Array(parentnode, name,
-                     obj=obj, title=title, byteorder=byteorder)
+                     obj=obj, title=title, byteorder=byteorder,
+                     track_times=track_times)
 
 
     def create_carray(self, where, name, atom=None, shape=None, title="",
                       filters=None, chunkshape=None,
-                      byteorder=None, createparents=False, obj=None):
+                      byteorder=None, createparents=False, obj=None,
+                      track_times=True):
         """Create a new chunked array.
 
         Parameters
@@ -1213,6 +1236,16 @@ class File(hdf5extension.File, object):
 
             .. versionadded:: 3.0
 
+        track_times
+            Whether time data associated with the leaf are recorded (object
+            access time, raw data modification time, metadata change time,
+            object birth time); default True.  Semantics of these times
+            depend on their implementation in the HDF5 library: refer to
+            documentation of the H5O_info_t data structure.  As of HDF5
+            1.8.15, only ctime (metadata change time) is implemented.
+
+            .. versionadded:: 3.4
+
         See Also
         --------
         CArray : for more information on chunked arrays
@@ -1238,7 +1271,8 @@ class File(hdf5extension.File, object):
         _checkfilters(filters)
         ptobj = CArray(parentnode, name,
                        atom=atom, shape=shape, title=title, filters=filters,
-                       chunkshape=chunkshape, byteorder=byteorder)
+                       chunkshape=chunkshape, byteorder=byteorder,
+                       track_times=track_times)
 
         if obj is not None:
             ptobj[...] = obj
@@ -1249,7 +1283,7 @@ class File(hdf5extension.File, object):
     def create_earray(self, where, name, atom=None, shape=None, title="",
                       filters=None, expectedrows=1000,
                       chunkshape=None, byteorder=None,
-                      createparents=False, obj=None):
+                      createparents=False, obj=None, track_times=True):
         """Create a new enlargeable array.
 
         Parameters
@@ -1316,6 +1350,16 @@ class File(hdf5extension.File, object):
 
             .. versionadded:: 3.0
 
+        track_times
+            Whether time data associated with the leaf are recorded (object
+            access time, raw data modification time, metadata change time,
+            object birth time); default True.  Semantics of these times
+            depend on their implementation in the HDF5 library: refer to
+            documentation of the H5O_info_t data structure.  As of HDF5
+            1.8.15, only ctime (metadata change time) is implemented.
+
+            .. versionadded:: 3.4
+
         See Also
         --------
         EArray : for more information on enlargeable arrays
@@ -1345,7 +1389,8 @@ class File(hdf5extension.File, object):
         ptobj = EArray(parentnode, name,
                        atom=atom, shape=shape, title=title,
                        filters=filters, expectedrows=expectedrows,
-                       chunkshape=chunkshape, byteorder=byteorder)
+                       chunkshape=chunkshape, byteorder=byteorder,
+                       track_times=track_times)
 
         if obj is not None:
             ptobj.append(obj)
@@ -1356,7 +1401,8 @@ class File(hdf5extension.File, object):
     def create_vlarray(self, where, name, atom=None, title="",
                        filters=None, expectedrows=None,
                        chunkshape=None, byteorder=None,
-                       createparents=False, obj=None):
+                       createparents=False, obj=None,
+                       track_times=True):
         """Create a new variable-length array.
 
         Parameters
@@ -1419,6 +1465,16 @@ class File(hdf5extension.File, object):
 
             .. versionadded:: 3.0
 
+        track_times
+            Whether time data associated with the leaf are recorded (object
+            access time, raw data modification time, metadata change time,
+            object birth time); default True.  Semantics of these times
+            depend on their implementation in the HDF5 library: refer to
+            documentation of the H5O_info_t data structure.  As of HDF5
+            1.8.15, only ctime (metadata change time) is implemented.
+
+            .. versionadded:: 3.4
+
         See Also
         --------
         VLArray : for more informationon variable-length arrays
@@ -1446,7 +1502,8 @@ class File(hdf5extension.File, object):
         ptobj = VLArray(parentnode, name,
                         atom=atom, title=title, filters=filters,
                         expectedrows=expectedrows,
-                        chunkshape=chunkshape, byteorder=byteorder)
+                        chunkshape=chunkshape, byteorder=byteorder,
+                        track_times=track_times)
 
         if obj is not None:
             ptobj.append(obj)

--- a/tables/hdf5extension.pxd
+++ b/tables/hdf5extension.pxd
@@ -11,7 +11,7 @@
 ########################################################################
 
 from numpy cimport ndarray
-from definitions cimport hid_t, hsize_t
+from definitions cimport hid_t, hsize_t, hbool_t
 
 
 # Declaration of instance variables for shared classes

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -34,6 +34,8 @@ import warnings
 from collections import namedtuple
 
 ObjInfo = namedtuple('ObjInfo', ['addr', 'rc'])
+ObjTimestamps = namedtuple('ObjTimestamps', ['atime', 'mtime',
+                                             'ctime', 'btime'])
 
 
 from cpython cimport PY_MAJOR_VERSION
@@ -928,6 +930,18 @@ cdef class Node:
                          self. _v_pathname)
 
     return ObjInfo(oinfo.addr, oinfo.rc)
+
+  def _get_obj_timestamps(self):
+    cdef herr_t ret = 0
+    cdef H5O_info_t oinfo
+
+    ret = H5Oget_info(self._v_objectid, &oinfo)
+    if ret < 0:
+      raise HDF5ExtError("Unable to get object info for '%s'" %
+                         self. _v_pathname)
+
+    return ObjTimestamps(oinfo.atime, oinfo.mtime, oinfo.ctime,
+                         oinfo.btime)
 
 
 cdef class Group(Node):

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -119,7 +119,7 @@ cdef extern from "H5ARRAY.h" nogil:
                      int rank, hsize_t *dims, int extdim,
                      hid_t type_id, hsize_t *dims_chunk, void *fill_data,
                      int complevel, char  *complib, int shuffle,
-                     int fletcher32, void *data)
+                     int fletcher32, hbool_t track_times, void *data)
 
   herr_t H5ARRAYappend_records(hid_t dataset_id, hid_t type_id,
                                int rank, hsize_t *dims_orig,
@@ -154,7 +154,7 @@ cdef extern from "H5VLARRAY.h" nogil:
                         int rank, hsize_t *dims, hid_t type_id,
                         hsize_t chunk_size, void *fill_data, int complevel,
                         char *complib, int shuffle, int flecther32,
-                        void *data)
+                        hbool_t track_times, void *data)
 
   herr_t H5VLARRAYappend_records( hid_t dataset_id, hid_t type_id,
                                   int nobjects, hsize_t nrecords,
@@ -1291,6 +1291,7 @@ cdef class Array(Leaf):
                                   self.filters.complevel, complib,
                                   self.filters.shuffle_bitshuffle,
                                   self.filters.fletcher32,
+                                  self._want_track_times,
                                   rbuf)
     if self.dataset_id < 0:
       raise HDF5ExtError("Problems creating the %s." % self.__class__.__name__)
@@ -1359,7 +1360,8 @@ cdef class Array(Leaf):
       self.parent_id, encoded_name, version, self.rank,
       self.dims, self.extdim, self.disk_type_id, self.dims_chunk,
       fill_data, self.filters.complevel, complib,
-      self.filters.shuffle_bitshuffle, self.filters.fletcher32, rbuf)
+        self.filters.shuffle_bitshuffle, self.filters.fletcher32,
+        self._want_track_times, rbuf)
     if self.dataset_id < 0:
       raise HDF5ExtError("Problems creating the %s." % self.__class__.__name__)
 
@@ -1959,7 +1961,7 @@ cdef class VLArray(Leaf):
                                     self.filters.complevel, complib,
                                     self.filters.shuffle_bitshuffle,
                                     self.filters.fletcher32,
-                                    rbuf)
+                                    self._want_track_times, rbuf)
     if dims:
       free(<void *>dims)
     if self.dataset_id < 0:

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -187,6 +187,20 @@ class Leaf(Node):
 
         return Filters._from_leaf(self)
 
+    @property
+    def track_times(self):
+        """Whether timestamps for the leaf are recorded
+
+        If the leaf is not a dataset, this will fail with HDF5ExtError.
+
+        The track times dataset creation property does not seem to
+        survive closing and reopening as of HDF5 1.8.17.  Currently,
+        it may be more accurate to test whether the ctime for the
+        dataset is 0:
+        track_times = (leaf._get_obj_timestamps().ctime == 0)
+        """
+        return self._get_obj_track_times()
+
     # Other properties
     # ````````````````
 

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -254,7 +254,8 @@ class Leaf(Node):
     # ~~~~~~~~~~~~~~~
     def __init__(self, parentnode, name,
                  new=False, filters=None,
-                 byteorder=None, _log=True):
+                 byteorder=None, _log=True,
+                 track_times=True):
         self._v_new = new
         """Is this the first time the node has been created?"""
         self.nrowsinbuf = None
@@ -280,8 +281,11 @@ class Leaf(Node):
             self.byteorder = byteorder
             """The byte ordering of the leaf data *on disk*."""
 
+        self._want_track_times = track_times
+
         # Existing filters need not be read since `filters`
         # is a lazy property that automatically handles their loading.
+
 
         super(Leaf, self).__init__(parentnode, name, _log)
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -433,6 +433,15 @@ class Table(tableextension.Table, Leaf):
         this is not specified, the byteorder is that of the platform, unless
         you passed a recarray as the `description`, in which case the recarray
         byteorder will be chosen.
+    track_times
+        Whether time data associated with the leaf are recorded (object
+        access time, raw data modification time, metadata change time, object
+        birth time); default True.  Semantics of these times depend on their
+        implementation in the HDF5 library: refer to documentation of the
+        H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
+        change time) is implemented.
+
+        .. versionadded:: 3.4
 
     Notes
     -----
@@ -665,7 +674,7 @@ class Table(tableextension.Table, Leaf):
     def __init__(self, parentnode, name,
                  description=None, title="", filters=None,
                  expectedrows=None, chunkshape=None,
-                 byteorder=None, _log=True):
+                 byteorder=None, _log=True, track_times=True):
 
         self._v_new = new = description is not None
         """Is this the first time the node has been created?"""
@@ -830,7 +839,7 @@ class Table(tableextension.Table, Leaf):
             self._v_chunkshape = tuple(SizeType(s) for s in chunkshape)
 
         super(Table, self).__init__(parentnode, name, new, filters,
-                                    byteorder, _log)
+                                    byteorder, _log, track_times)
 
     def _g_post_init_hook(self):
         # We are putting here the index-related issues

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -46,7 +46,7 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, strdup, strcmp, strlen
 from numpy cimport (import_array, ndarray, PyArray_GETITEM, PyArray_SETITEM, \
   npy_intp)
-from definitions cimport (hid_t, herr_t, hsize_t, htri_t,
+from definitions cimport (hid_t, herr_t, hsize_t, htri_t, hbool_t,
   H5F_ACC_RDONLY, H5P_DEFAULT, H5D_CHUNKED, H5T_DIR_DEFAULT,
   H5F_SCOPE_LOCAL, H5F_SCOPE_GLOBAL, H5T_COMPOUND, H5Tget_order,
   H5Fflush, H5Dget_create_plist, H5T_ORDER_LE,
@@ -76,7 +76,7 @@ cdef extern from "H5TB-opt.h" nogil:
                           hid_t mem_type_id, hsize_t nrecords,
                           hsize_t chunk_size, void *fill_data, int compress,
                           char *complib, int shuffle, int fletcher32,
-                          void *data )
+                          hbool_t track_times, void *data )
 
   herr_t H5TBOread_records( hid_t dataset_id, hid_t mem_type_id,
                             hsize_t start, hsize_t nrecords, void *data )
@@ -206,7 +206,7 @@ cdef class Table(Leaf):
                                       self.filters.complevel, encoded_complib,
                                       self.filters.shuffle_bitshuffle,
                                       self.filters.fletcher32,
-                                      data)
+                                      self._want_track_times, data)
     if self.dataset_id < 0:
       raise HDF5ExtError("Problems creating the table")
 

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+
+"""This test unit checks control of dataset timestamps with track_times.
+
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+import hashlib
+import sys
+import time
+
+import tables
+from tables import (
+    StringAtom, Int16Atom, StringCol, IntCol, Int16Col,
+)
+from tables.tests import common
+from tables.tests.common import unittest
+from tables.tests.common import PyTablesTestCase as TestCase
+from six.moves import range
+
+HEXDIGEST = '2aafb84ab739bb4ae61d2939dc010bfd'
+
+
+class Record(tables.IsDescription):
+    var1 = StringCol(itemsize=4)  # 4-character String
+    var2 = IntCol()               # integer
+    var3 = Int16Col()             # short integer
+
+
+class TrackTimesMixin(object):
+    def _add_datasets(self, group, j, track_times):
+        # Create a table
+        table = self.h5file.create_table(group, 'table{}'.format(j),
+                                         Record,
+                                         title=self.title,
+                                         filters=None,
+                                         track_times=track_times)
+        # Get the record object associated with the new table
+        d = table.row
+        # Fill the table
+        for i in range(self.nrows):
+            d['var1'] = '%04d' % (self.nrows - i)
+            d['var2'] = i
+            d['var3'] = i * 2
+            d.append()      # This injects the Record values
+        # Flush the buffer for this table
+        table.flush()
+
+        # Create a couple of arrays in each group
+        var1List = [x['var1'] for x in table.iterrows()]
+        var3List = [x['var3'] for x in table.iterrows()]
+
+        self.h5file.create_array(group, 'array{}'.format(j),
+                                 var1List, "col {}".format(j),
+                                 track_times=track_times)
+
+        # Create CArrays as well
+        self.h5file.create_carray(group, name='carray{}'.format(j),
+                                  obj=var3List,
+                                  title="col {}".format(j + 2),
+                                  track_times=track_times)
+
+        # Create EArrays as well
+        ea = self.h5file.create_earray(group, 'earray{}'.format(j),
+                                       StringAtom(itemsize=4), (0,),
+                                       "col {}".format(j + 4),
+                                       track_times=track_times)
+        # And fill them with some values
+        ea.append(var1List)
+
+        # Finally VLArrays too
+        vla = self.h5file.create_vlarray(group, 'vlarray{}'.format(j),
+                                         Int16Atom(),
+                                         "col {}".format(j + 6),
+                                         track_times=track_times)
+        # And fill them with some values
+        vla.append(var3List)
+
+
+class TimestampTestCase(TrackTimesMixin, common.TempFileMixin, TestCase):
+    title = "A title"
+    nrows = 10
+
+    def setUp(self):
+        super(TimestampTestCase, self).setUp()
+        self.populateFile()
+
+    def populateFile(self):
+        group = self.h5file.root
+        for j in range(4):
+            track_times = bool(j % 2)
+            self._add_datasets(group, j, track_times)
+
+    def test00_checkTimestamps(self):
+        """Checking retrieval of timestamps"""
+
+        for pattern in ('/table{}',
+                        '/array{}',
+                        '/carray{}',
+                        '/earray{}',
+                        '/vlarray{}'):
+            # Verify that:
+            # - if track_times was False, ctime is 0
+            # - if track_times was True, ctime is not 0,
+            #   and has either stayed the same or incremented
+            tracked_ctimes = []
+            for j in range(4):
+                track_times = bool(j % 2)
+                node = pattern.format(j)
+                obj = self.h5file.get_node(node)
+                # Test property retrieval
+                self.assertEqual(obj.track_times, track_times)
+                timestamps = obj._get_obj_timestamps()
+                self.assertEqual(timestamps.atime, 0)
+                self.assertEqual(timestamps.mtime, 0)
+                self.assertEqual(timestamps.btime, 0)
+                if not track_times:
+                    self.assertEqual(timestamps.ctime, 0)
+                else:
+                    self.assertNotEqual(timestamps.ctime, 0)
+                    tracked_ctimes.append(timestamps.ctime)
+            self.assertTrue(tracked_ctimes[1] >= tracked_ctimes[0])
+
+
+class BitForBitTestCase(TrackTimesMixin, common.TempFileMixin, TestCase):
+    title = "A title"
+    nrows = 10
+
+    def repopulateFile(self, track_times):
+        self.h5file.close()
+        self.h5file = tables.open_file(self.h5fname, mode="w")
+        group = self.h5file.root
+        self._add_datasets(group, 1, track_times)
+        self.h5file.close()
+
+    def test00_checkReproducibility(self):
+        """Checking bit-for-bit reproducibility with no track_times"""
+
+        self.repopulateFile(track_times=False)
+        hexdigest_wo_track_1 = self._get_digest(self.h5fname)
+        self.repopulateFile(track_times=True)
+        hexdigest_w_track_1 = self._get_digest(self.h5fname)
+        time.sleep(1)
+        self.repopulateFile(track_times=True)
+        hexdigest_w_track_2 = self._get_digest(self.h5fname)
+        self.repopulateFile(track_times=False)
+        hexdigest_wo_track_2 = self._get_digest(self.h5fname)
+        self.assertEqual(HEXDIGEST, hexdigest_wo_track_1)
+        self.assertEqual(hexdigest_wo_track_1, hexdigest_wo_track_2)
+        self.assertNotEqual(hexdigest_wo_track_1, hexdigest_w_track_1)
+        self.assertNotEqual(hexdigest_w_track_1, hexdigest_w_track_2)
+
+    def _get_digest(self, filename):
+        md5 = hashlib.md5()
+        fd = open(filename, 'rb')
+
+        for data in fd:
+            md5.update(data)
+
+        fd.close()
+
+        hexdigest = md5.hexdigest()
+
+        return hexdigest
+
+
+def suite():
+    theSuite = unittest.TestSuite()
+    niter = 1
+    # common.heavy = 1 # Uncomment this only for testing purposes!
+
+    for i in range(niter):
+        theSuite.addTest(unittest.makeSuite(TimestampTestCase))
+        theSuite.addTest(unittest.makeSuite(BitForBitTestCase))
+
+    return theSuite
+
+
+if __name__ == '__main__':
+    common.parse_argv(sys.argv)
+    common.print_versions()
+    unittest.main(defaultTest='suite')

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -108,6 +108,16 @@ class VLArray(hdf5extension.VLArray, Leaf, six.Iterator):
         The byteorder of the data *on disk*, specified as 'little' or 'big'.
         If this is not specified, the byteorder is that of the platform.
 
+    track_times
+        Whether time data associated with the leaf are recorded (object
+        access time, raw data modification time, metadata change time, object
+        birth time); default True.  Semantics of these times depend on their
+        implementation in the HDF5 library: refer to documentation of the
+        H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
+        change time) is implemented.
+
+        .. versionadded:: 3.4
+
     .. versionchanged:: 3.0
        The *expectedsizeinMB* parameter has been replaced by *expectedrows*.
 
@@ -254,7 +264,7 @@ class VLArray(hdf5extension.VLArray, Leaf, six.Iterator):
     def __init__(self, parentnode, name, atom=None, title="",
                  filters=None, expectedrows=None,
                  chunkshape=None, byteorder=None,
-                 _log=True):
+                 _log=True, track_times=True):
 
         self._v_version = None
         """The object version of this array."""
@@ -341,7 +351,7 @@ class VLArray(hdf5extension.VLArray, Leaf, six.Iterator):
             self._v_chunkshape = tuple(SizeType(s) for s in chunkshape)
 
         super(VLArray, self).__init__(parentnode, name, new, filters,
-                                      byteorder, _log)
+                                      byteorder, _log, track_times)
 
     def _g_post_init_hook(self):
         super(VLArray, self)._g_post_init_hook()


### PR DESCRIPTION
As mentioned on the mailing list, these are changes to optionally disable recording of ctime (metadata creation time) when creating datasets.  This makes it possible to get bitwise identical output from repeated runs of the same application, which is useful for regression testing, and also for working with build tools that use hashes for change detection.

Commit 6eace4d does the real work, accepting a track_times flag on dataset constructors and then using H5Pset_obj_track_times() to optionally disable time tracking when creating datasets.

One of the commits here (19df430) adds a .track_times property to the Leaf class so that users can retrieve the value, but I am not sure this is actually a good idea.  The property uses H5Pget_obj_track_times() to get the value of this flag after retrieving the dataset creation property list, but H5Pget_obj_track_times() does not seem to give a correct value for the flag after the HDF5 file has been closed and reopened.  H5Py uses this function too, and has the same issue.  It might be better to just drop this property.   Users could simply check for a non-zero ctime for the dataset (using Node._get_obj_timestamps() from 69f6d41).  Dropping the .track_times property would mean reverting the changes in 19df430 and some minor changes to the tests created in 69f6d41.




