### PR TITLE
DOC small documentation fixes

### DIFF
--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -542,7 +542,7 @@ uninstall `Numeric`.
 .. _`Python language`: http://www.python.org
 .. _NumPy: http://www.numpy.org
 .. _`users mailing list`: https://groups.google.com/group/pytables-users
-.. _`archives of the user's list`: http://sourceforge.net/mailarchive/forum.php?forum_id=13760
+.. _`archives of the user's list`: https://sourceforge.net/p/pytables/mailman/pytables-users/
 .. _`Gmane archives`: http://www.mail-archive.com/pytables-users@lists.sourceforge.net/
 .. _`R&D 100 Award`: http://www.hdfgroup.org/HDF5/RD100-2002/
 .. _ViTables: http://vitables.org

--- a/doc/source/project_pointers.rst
+++ b/doc/source/project_pointers.rst
@@ -22,5 +22,3 @@ Project pointers
   (going to be closed)
 * Development version of the
   `HTML documentation <http://pytables.github.io/latest/index.html>`_
-* `Old trac site <http://www.pytables.org/trac-bck>`_
-

--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -113,7 +113,7 @@ Creating a PyTables file from scratch
 
 Use the top-level :func:`open_file` function to create a PyTables file::
 
-    >>> h5file = open_file("tutorial1.h5", mode = "w", title = "Test file")
+    >>> h5file = open_file("tutorial1.h5", mode="w", title="Test file")
 
 :func:`open_file` is one of the objects imported by the
 ```from tables import *``` statement. Here, we are saying that we want to


### PR DESCRIPTION
A few small fixes in the documentation,
 * PEP8 in an example
 * fixed broken URL to the sourceforge mailing list archive
 * removed the "Old trac site" link as it is not working (but maybe there is a way to fix it)?