### PR TITLE
Do not try to convert values of an empty array

### DIFF
--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -956,7 +956,8 @@ cdef class Row:
         # Evaluate the condition on this table fragment.
         iobuf = iobuf[:recout]
 
-        self.table._convert_types(iobuf, len(iobuf), 1)
+        if len(iobuf) > 0:
+          self.table._convert_types(iobuf, len(iobuf), 1)
         self.indexvalid = call_on_recarr(
           self.condfunc, self.condargs, iobuf, **self.condkwargs)
         self.index_valid_data = <char *>self.indexvalid.data


### PR DESCRIPTION
`tables.tableextension.Table._convert_time64_()` divides by zero
when its called with an empty `nparr` array. This happens because
the `__next_indexed()` method tries to convert attributes an array
even if it is empty.

Fixes #653