### PR TITLE
fixing Deprecation Warning from numpy.issubdtype

### DIFF
--- a/tables/array.py
+++ b/tables/array.py
@@ -722,7 +722,7 @@ class Array(hdf5extension.Array, Leaf, six.Iterator):
         # truncate data if least_significant_digit filter is set
         # TODO: add the least_significant_digit attribute to the array on disk
         if (self.filters.least_significant_digit is not None and
-                not numpy.issubdtype(nparr.dtype, int)):
+                not numpy.issubdtype(nparr.dtype, numpy.signedinteger)):
             nparr = quantize(nparr, self.filters.least_significant_digit)
 
         try:

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -824,8 +824,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking setting Int attributes (scalar, NumPy case)"""
 
         # 'UInt64' not supported on Win
-        checktypes = ['Int8', 'Int16', 'Int32', 'Int64',
-                      'UInt8', 'UInt16', 'UInt32']
+        checktypes = ['int8', 'int16', 'int32', 'int64',
+                      'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype, numpy.array(1, dtype=dtype))
@@ -851,8 +851,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking setting Int attributes (unidimensional NumPy case)"""
 
         # 'UInt64' not supported on Win
-        checktypes = ['Int8', 'Int16', 'Int32', 'Int64',
-                      'UInt8', 'UInt16', 'UInt32']
+        checktypes = ['int8', 'int16', 'int32', 'int64',
+                      'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype, numpy.array([1, 2], dtype=dtype))
@@ -876,8 +876,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking setting Int attributes (unidimensional, non-contiguous)"""
 
         # 'UInt64' not supported on Win
-        checktypes = ['Int8', 'Int16', 'Int32', 'Int64',
-                      'UInt8', 'UInt16', 'UInt32']
+        checktypes = ['int8', 'int16', 'int32', 'int64',
+                      'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
             arr = numpy.array([1, 2, 3, 4], dtype=dtype)[::2]
@@ -902,8 +902,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking setting Int attributes (bidimensional NumPy case)"""
 
         # 'UInt64' not supported on Win
-        checktypes = ['Int8', 'Int16', 'Int32', 'Int64',
-                      'UInt8', 'UInt16', 'UInt32']
+        checktypes = ['int8', 'int16', 'int32', 'int64',
+                      'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
@@ -955,7 +955,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test02b_setFloatAttributes(self):
         """Checking setting Float attributes (scalar, NumPy case)"""
 
-        checktypes = ['Float32', 'Float64']
+        checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
@@ -982,7 +982,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test02c_setFloatAttributes(self):
         """Checking setting Float attributes (unidimensional NumPy case)"""
 
-        checktypes = ['Float32', 'Float64']
+        checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
@@ -1009,7 +1009,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking setting Float attributes (unidimensional,
         non-contiguous)"""
 
-        checktypes = ['Float32', 'Float64']
+        checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
             arr = numpy.array([1.1, 2.1, 3.1, 4.1], dtype=dtype)[1::2]
@@ -1035,7 +1035,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test02e_setFloatAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
 
-        checktypes = ['Float32', 'Float64']
+        checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
@@ -1268,7 +1268,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test05c_setComplexAttributes(self):
         """Checking setting Complex attributes (unidimensional NumPy case)"""
 
-        checktypes = ['Complex32', 'Complex64']
+        checktypes = ['complex64', 'complex128']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
@@ -1294,7 +1294,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test05d_setComplexAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
 
-        checktypes = ['Complex32', 'Complex64']
+        checktypes = ['complex64', 'complex128']
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -1430,7 +1430,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            title="array of ints")
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Int32')
+            1, 1, 1), (3, 3, 3)], dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1462,7 +1462,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            title="array of floats")
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Float64')
+            1, 1, 1), (3, 3, 3)], dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1496,7 +1496,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            byteorder=byteorder)
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Int32')
+            1, 1, 1), (3, 3, 3)], dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1532,7 +1532,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         earray = self.h5file.get_node("/EAtom")
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Int32')
+            1, 1, 1), (3, 3, 3)], dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1566,7 +1566,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            byteorder=byteorder)
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Float64')
+            1, 1, 1), (3, 3, 3)], dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1602,7 +1602,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         earray = self.h5file.get_node("/EAtom")
         # Add a native ordered array
         a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='Float64')
+            1, 1, 1), (3, 3, 3)], dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1636,7 +1636,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
 
         if self.close:
             if common.verbose:
@@ -1687,7 +1687,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
 
         if self.close:
             if common.verbose:
@@ -1881,7 +1881,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -1919,7 +1919,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -1960,7 +1960,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -2177,7 +2177,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
         # Add a couple of rows
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='Int16'))
+        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
 
     def test00_truncate(self):
         """Checking EArray.truncate() method (truncating to 0 rows)"""
@@ -2196,7 +2196,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
             print("array1-->", array1.read())
 
         self.assertTrue(allequal(
-            array1[:], numpy.array([], dtype='Int16').reshape(0, 2)))
+            array1[:], numpy.array([], dtype='int16').reshape(0, 2)))
 
     def test01_truncate(self):
         """Checking EArray.truncate() method (truncating to 1 rows)"""
@@ -2215,7 +2215,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
             print("array1-->", array1.read())
 
         self.assertTrue(allequal(
-            array1.read(), numpy.array([[456, 2]], dtype='Int16')))
+            array1.read(), numpy.array([[456, 2]], dtype='int16')))
 
     def test02_truncate(self):
         """Checking EArray.truncate() method (truncating to == self.nrows)"""
@@ -2235,7 +2235,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         self.assertTrue(
             allequal(array1.read(),
-                     numpy.array([[456, 2], [3, 457]], dtype='Int16')))
+                     numpy.array([[456, 2], [3, 457]], dtype='int16')))
 
     def test03_truncate(self):
         """Checking EArray.truncate() method (truncating to > self.nrows)"""
@@ -2256,10 +2256,10 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(array1.nrows, 4)
         # Check the original values
         self.assertTrue(allequal(array1[:2], numpy.array([[456, 2], [3, 457]],
-                                                         dtype='Int16')))
+                                                         dtype='int16')))
         # Check that the added rows have the default values
         self.assertTrue(allequal(array1[2:], numpy.array([[3, 3], [3, 3]],
-                                                         dtype='Int16')))
+                                                         dtype='int16')))
 
 
 class TruncateOpenTestCase(TruncateTestCase):
@@ -2290,7 +2290,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
             expectedrows=self.narows * self.nanumber)
 
         # Fill the array
-        na = numpy.arange(self.narows, dtype='Int8')
+        na = numpy.arange(self.narows, dtype='int8')
         for i in range(self.nanumber):
             array.append(na)
 
@@ -2325,7 +2325,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
                 stop -= 256
             start = stop - 10
             print("Should look like-->", numpy.arange(start, stop,
-                                                      dtype='Int8'))
+                                                      dtype='int8'))
 
         nrows = self.narows * self.nanumber
         # check nrows
@@ -2333,14 +2333,14 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
         # Check shape
         self.assertEqual(array.shape, (nrows,))
         # check the 10 first elements
-        self.assertTrue(allequal(array[:10], numpy.arange(10, dtype='Int8')))
+        self.assertTrue(allequal(array[:10], numpy.arange(10, dtype='int8')))
         # check the 10 last elements
         stop = self.narows % 256
         if stop > 127:
             stop -= 256
         start = stop - 10
         self.assertTrue(allequal(array[-10:],
-                                 numpy.arange(start, stop, dtype='Int8')))
+                                 numpy.arange(start, stop, dtype='int8')))
 
 
 class Rows64bitsTestCase1(Rows64bitsTestCase):

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -75,23 +75,23 @@ class TestTDescr(t.IsDescription):
 
 # The corresponding nested array description:
 testADescr = [
-    ('x', '(2,)Int32'),
+    ('x', '(2,)int32'),
     ('Info', [
-        ('value', 'Complex64'),
-        ('y2', 'Float64'),
+        ('value', 'complex128'),
+        ('y2', 'float64'),
         ('Info2', [
             ('name', 'a2'),
-            ('value', '(2,)Complex64'),
-            ('y3', '(2,)Float64'),
-            ('z3', '(2,)Int32')]),
+            ('value', '(2,)complex128'),
+            ('y3', '(2,)float64'),
+            ('z3', '(2,)int32')]),
         ('name', 'a2'),
-        ('z2', 'UInt8')]),
+        ('z2', 'uint8')]),
     ('color', 'a2'),
     ('info', [
         ('Name', 'a2'),
-        ('Value', 'Complex64')]),
-    ('y', '(2,2)Float64'),
-    ('z', 'UInt8')]
+        ('Value', 'complex128')]),
+    ('y', '(2,2)float64'),
+    ('z', 'uint8')]
 
 # The corresponding nested array description (brief version):
 testADescr2 = [

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -277,7 +277,7 @@ class AtomTestCase(TestCase):
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_04(self):
-        atom1 = Atom.from_dtype(numpy.dtype('Float64'))
+        atom1 = Atom.from_dtype(numpy.dtype('float64'))
         atom2 = Float64Atom(shape=(), dflt=0.0)
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -655,13 +655,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with integer atoms."""
 
         ttypes = [
-            "Int8",
-            "UInt8",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
             #"UInt64",  # Unavailable in some platforms
         ]
         if common.verbose:
@@ -699,13 +699,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with integer atoms (byteorder swapped)"""
 
         ttypes = {
-            "Int8": numpy.int8,
-            "UInt8": numpy.uint8,
-            "Int16": numpy.int16,
-            "UInt16": numpy.uint16,
-            "Int32": numpy.int32,
-            "UInt32": numpy.uint32,
-            "Int64": numpy.int64,
+            "int8": numpy.int8,
+            "uint8": numpy.uint8,
+            "int16": numpy.int16,
+            "uint16": numpy.uint16,
+            "int32": numpy.int32,
+            "uint32": numpy.uint32,
+            "int64": numpy.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -749,13 +749,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with integer atoms."""
 
         ttypes = [
-            "Int8",
-            "UInt8",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
             #"UInt64",  # Unavailable in some platforms
         ]
         if common.verbose:
@@ -797,13 +797,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with integer atoms (byteorder swapped)"""
 
         ttypes = {
-            "Int8": numpy.int8,
-            "UInt8": numpy.uint8,
-            "Int16": numpy.int16,
-            "UInt16": numpy.uint16,
-            "Int32": numpy.int32,
-            "UInt32": numpy.uint32,
-            "Int64": numpy.int64,
+            "int8": numpy.int8,
+            "uint8": numpy.uint8,
+            "int16": numpy.int16,
+            "uint16": numpy.uint16,
+            "int32": numpy.int32,
+            "uint32": numpy.uint32,
+            "int64": numpy.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -853,13 +853,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with integer atoms (another byteorder)"""
 
         ttypes = {
-            "Int8": numpy.int8,
-            "UInt8": numpy.uint8,
-            "Int16": numpy.int16,
-            "UInt16": numpy.uint16,
-            "Int32": numpy.int32,
-            "UInt32": numpy.uint32,
-            "Int64": numpy.int64,
+            "int8": numpy.int8,
+            "uint8": numpy.uint8,
+            "int16": numpy.int16,
+            "uint16": numpy.uint16,
+            "int32": numpy.int32,
+            "uint32": numpy.uint32,
+            "int64": numpy.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -916,8 +916,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with floating point atoms."""
 
         ttypes = [
-            "Float32",
-            "Float64",
+            "float32",
+            "float64",
         ]
         for name in ("float16", "float96", "float128"):
             atomname = name.capitalize() + 'Atom'
@@ -959,8 +959,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with float atoms (byteorder swapped)"""
 
         ttypes = {
-            "Float32": numpy.float32,
-            "Float64": numpy.float64,
+            "float32": numpy.float32,
+            "float64": numpy.float64,
         }
         if hasattr(tables, "Float16Atom"):
             ttypes["float16"] = numpy.float16
@@ -1010,8 +1010,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with floating point atoms."""
 
         ttypes = [
-            "Float32",
-            "Float64",
+            "float32",
+            "float64",
         ]
         for name in ("float16", "float96", "float128"):
             atomname = name.capitalize() + 'Atom'
@@ -1057,8 +1057,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with float atoms (byteorder swapped)"""
 
         ttypes = {
-            "Float32": numpy.float32,
-            "Float64": numpy.float64,
+            "float32": numpy.float32,
+            "float64": numpy.float64,
         }
         if hasattr(tables, "Float16Atom"):
             ttypes["float16"] = numpy.float16
@@ -1114,8 +1114,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with float atoms (another byteorder)"""
 
         ttypes = {
-            "Float32": numpy.float32,
-            "Float64": numpy.float64,
+            "float32": numpy.float32,
+            "float64": numpy.float64,
         }
         if hasattr(tables, "Float16Atom"):
             ttypes["float16"] = numpy.float16
@@ -1175,14 +1175,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with numerical complex atoms."""
 
         ttypes = [
-            "Complex32",
-            "Complex64",
+            "complex64",
+            "complex128",
         ]
 
         if hasattr(tables, "Complex192Atom"):
-            ttypes.append("Complex96")
+            ttypes.append("complex192")
         if hasattr(tables, "Complex256Atom"):
-            ttypes.append("Complex128")
+            ttypes.append("complex256")
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -1222,14 +1222,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking modifying vlarray with numerical complex atoms."""
 
         ttypes = [
-            "Complex32",
-            "Complex64",
+            "complex64",
+            "complex128",
         ]
 
         if hasattr(tables, "Complex192Atom"):
-            ttypes.append("Complex96")
+            ttypes.append("complex192")
         if hasattr(tables, "Complex256Atom"):
-            ttypes.append("Complex128")
+            ttypes.append("complex256")
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -1835,13 +1835,13 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with MD integer atoms."""
 
         ttypes = [
-            "Int8",
-            "UInt8",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
             #"UInt64",  # Unavailable in some platforms
         ]
         root = self.rootgroup
@@ -1878,20 +1878,20 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with MD floating point atoms."""
 
         ttypes = [
-            "Float32",
-            "Float64",
-            "Complex32",
-            "Complex64",
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
         ]
 
         for name in ("float16", "float96", "float128"):
             atomname = name.capitalize() + "Atom"
             if hasattr(tables, atomname):
-                ttypes.append(name.capitalize())
+                ttypes.append(name)
         for itemsize in (192, 256):
             atomname = "Complex%dAtom" % itemsize
             if hasattr(tables, atomname):
-                ttypes.append("Complex%d" % (itemsize // 2))
+                ttypes.append("complex%d" % (itemsize))
 
         root = self.rootgroup
         if common.verbose:
@@ -2220,13 +2220,13 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with different flavors (integer versions)"""
 
         ttypes = [
-            "Int8",
-            "UInt8",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
             # Not checked because some platforms does not support it
             #"UInt64",
         ]
@@ -2280,13 +2280,13 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray flavors (integer versions and closed file)"""
 
         ttypes = [
-            "Int8",
-            "UInt8",
-            "Int16",
-            "UInt16",
-            "Int32",
-            "UInt32",
-            "Int64",
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
             # Not checked because some platforms does not support it
             #"UInt64",
         ]
@@ -2343,21 +2343,21 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with different flavors (floating point versions)"""
 
         ttypes = [
-            "Float32",
-            "Float64",
-            "Complex32",
-            "Complex64",
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
         ]
 
         for name in ("float16", "float96", "float128"):
             atomname = name.capitalize() + "Atom"
             if hasattr(tables, atomname):
-                ttypes.append(name.capitalize())
+                ttypes.append(name)
 
         for itemsize in (192, 256):
             atomname = "Complex%dAtom" % itemsize
             if hasattr(tables, atomname):
-                ttypes.append("Complex%d" % (itemsize // 2))
+                ttypes.append("complex%d" % (itemsize))
 
         root = self.rootgroup
         if common.verbose:
@@ -3937,8 +3937,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
             self.h5file.root, 'array1', arr, "title array1")
 
         # Add a couple of rows
-        array1.append(numpy.array([456, 2], dtype='Int16'))
-        array1.append(numpy.array([3], dtype='Int16'))
+        array1.append(numpy.array([456, 2], dtype='int16'))
+        array1.append(numpy.array([3], dtype='int16'))
 
     def test00_truncate(self):
         """Checking VLArray.truncate() method (truncating to 0 rows)"""
@@ -3977,7 +3977,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         self.assertEqual(array1.nrows, 1)
         self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='Int16')))
+            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
 
     def test02_truncate(self):
         """Checking VLArray.truncate() method (truncating to == self.nrows)"""
@@ -3997,8 +3997,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         self.assertEqual(array1.nrows, 2)
         self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='Int16')))
-        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='Int16')))
+            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
+        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='int16')))
 
     def test03_truncate(self):
         """Checking VLArray.truncate() method (truncating to > self.nrows)"""
@@ -4020,12 +4020,12 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         # Check the original values
         self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='Int16')))
-        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='Int16')))
+            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
+        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='int16')))
 
         # Check that the added rows are empty
-        self.assertTrue(allequal(array1[2], numpy.array([], dtype='Int16')))
-        self.assertTrue(allequal(array1[3], numpy.array([], dtype='Int16')))
+        self.assertTrue(allequal(array1[2], numpy.array([], dtype='int16')))
+        self.assertTrue(allequal(array1[3], numpy.array([], dtype='int16')))
 
 
 class TruncateOpenTestCase(TruncateTestCase):


### PR DESCRIPTION
Changed `numpy.issubdtype(dt, int)` to `numpy.issubdtype(dt, np.signedinteger)` as suggested by the deprecation warning:

```text
In [2]: np.issubdtype(np.int32, int)
/localdisk/work/miniconda3/envs/np114/bin/ipython:1: FutureWarning: Conversion of the second argument of issubdtype from `int` to `np.signedinteger` is deprecated. In future, it will be treated as `np.int64 == np.dtype(int).type`.
  #!/localdisk/work/opavlyk/miniconda3/envs/np114/bin/python
Out[2]: True
```