### PR TITLE
Fix VLArray._read_coordinates

### DIFF
--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -833,7 +833,7 @@ class VLArray(hdf5extension.VLArray, Leaf, six.Iterator):
         """Read rows specified in `coords`."""
         rows = []
         for coord in coords:
-            rows.append(self.read(int(coord))[0])
+            rows.append(self.read(int(coord), int(coord) + 1, 1)[0])
         return rows
 
     def _g_copy_with_stats(self, group, name, start, stop, step,


### PR DESCRIPTION
 This PR prevents from reading all rows for each coord when indexing using a list (see [here](https://github.com/PyTables/PyTables/blob/develop/tables/vlarray.py#L836)). 

**Example on how to reproduce the error:**

Generating the hdf5 file
```python
import tables
import numpy as np

f = tables.open_file('test.h5', 'w')
input_node = f.create_vlarray(f.root, 'input',  tables.Float32Atom(shape=(30, )), 
                              "Input", expectedrows=1000)
for _ in range(1000):
    input_node.append(np.random.randn(np.random.randint(5,100), 30))
f.close()
````

Reading non-continuous indexes
```python
import tables

f = tables.open_file('test.h5', 'r')
input_node = f.get_node('/input')

%timeit input_node[[0,1,2,33,634, 125]]
```

and you will get:
```
72.4 ms ± 14.8 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

With this fix:
```
266 µs ± 3.64 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
