### PR TITLE
Fix slicing outside of data samples

### DIFF
--- a/tables/expression.py
+++ b/tables/expression.py
@@ -578,7 +578,10 @@ value of dimensions that are orthogonal (and preferably close) to the
 
         if i_nrows == 0:
             # No elements to compute
-            return self._single_row_out
+            if start == stop and self.start is not None:
+                return out
+            else:
+                return self._single_row_out
 
         # Create a key that selects every element in inputs and output
         # (including the main dimension)

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -578,7 +578,7 @@ value of dimensions that are orthogonal (and preferably close) to the
 
         if i_nrows == 0:
             # No elements to compute
-            if start == stop and self.start is not None:
+            if start >= stop and self.start is not None:
                 return out
             else:
                 return self._single_row_out

--- a/tables/tests/test_expression.py
+++ b/tables/tests/test_expression.py
@@ -149,6 +149,25 @@ class ExprTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(common.areArraysEqual(r1, r2),
                         "Evaluate is returning a wrong value.")
 
+    def test02_out(self):
+        """Checking that expression is correctly evaluated when slice is
+        outside of data samples (`out` param)"""
+        expr = tables.Expr(self.expr, self.vars)
+        # maybe it's better to use the leading dimemsion instead?
+        maxshape = max(self.shape)
+        start, stop, step = (maxshape + 1, maxshape + 2, None)
+        expr.set_inputs_range(start, stop, step)
+        r1 = expr.eval()
+        # create an empty array with the same dtype and shape
+        zeros = np.zeros(shape=self.shape, dtype=r1.dtype)
+        r2 = zeros[start:stop:step]
+        self.assertListEqual(r1.tolist(), r2.tolist())
+        if common.verbose:
+            print("Computed expression:", repr(r1))
+            print("Should look like:", repr(r2))
+        self.assertTrue(common.areArraysEqual(r1, r2),
+                        "Evaluate is returning a wrong value.")
+
 
 class ExprNumPy(ExprTestCase):
     kind = "NumPy"


### PR DESCRIPTION
Hopefully this fixes issue #651 

Actually I think this is more a workaround than a real fix...

I created the test `test02_out` in `test_expression.py`.