### PR TITLE
Fix versionadded tags for v3.4.3

### DIFF
--- a/tables/array.py
+++ b/tables/array.py
@@ -92,7 +92,7 @@ class Array(hdf5extension.Array, Leaf, six.Iterator):
         H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
         change time) is implemented.
 
-        .. versionadded:: 3.4
+        .. versionadded:: 3.4.3
 
     """
 

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -87,7 +87,7 @@ class CArray(Array):
         H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
         change time) is implemented.
 
-        .. versionadded:: 3.4
+        .. versionadded:: 3.4.3
 
     Examples
     --------

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -102,7 +102,7 @@ class EArray(CArray):
         H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
         change time) is implemented.
 
-        .. versionadded:: 3.4
+        .. versionadded:: 3.4.3
 
     Examples
     --------

--- a/tables/file.py
+++ b/tables/file.py
@@ -1034,7 +1034,7 @@ class File(hdf5extension.File, object):
             documentation of the H5O_info_t data structure.  As of HDF5
             1.8.15, only ctime (metadata change time) is implemented.
 
-            .. versionadded:: 3.4
+            .. versionadded:: 3.4.3
 
         See Also
         --------
@@ -1128,7 +1128,7 @@ class File(hdf5extension.File, object):
             documentation of the H5O_info_t data structure.  As of HDF5
             1.8.15, only ctime (metadata change time) is implemented.
 
-            .. versionadded:: 3.4
+            .. versionadded:: 3.4.3
 
         See Also
         --------
@@ -1244,7 +1244,7 @@ class File(hdf5extension.File, object):
             documentation of the H5O_info_t data structure.  As of HDF5
             1.8.15, only ctime (metadata change time) is implemented.
 
-            .. versionadded:: 3.4
+            .. versionadded:: 3.4.3
 
         See Also
         --------
@@ -1358,7 +1358,7 @@ class File(hdf5extension.File, object):
             documentation of the H5O_info_t data structure.  As of HDF5
             1.8.15, only ctime (metadata change time) is implemented.
 
-            .. versionadded:: 3.4
+            .. versionadded:: 3.4.3
 
         See Also
         --------
@@ -1473,7 +1473,7 @@ class File(hdf5extension.File, object):
             documentation of the H5O_info_t data structure.  As of HDF5
             1.8.15, only ctime (metadata change time) is implemented.
 
-            .. versionadded:: 3.4
+            .. versionadded:: 3.4.3
 
         See Also
         --------

--- a/tables/table.py
+++ b/tables/table.py
@@ -441,7 +441,7 @@ class Table(tableextension.Table, Leaf):
         H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
         change time) is implemented.
 
-        .. versionadded:: 3.4
+        .. versionadded:: 3.4.3
 
     Notes
     -----

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -116,7 +116,7 @@ class VLArray(hdf5extension.VLArray, Leaf, six.Iterator):
         H5O_info_t data structure.  As of HDF5 1.8.15, only ctime (metadata
         change time) is implemented.
 
-        .. versionadded:: 3.4
+        .. versionadded:: 3.4.3
 
     .. versionchanged:: 3.0
        The *expectedsizeinMB* parameter has been replaced by *expectedrows*.


### PR DESCRIPTION
Flags for time tracking control have been added in v3.4.3, not in 3.4.