### PR TITLE
Remove unused import and fix ImportError with numexpr 2.6.5.dev0

### DIFF
--- a/tables/table.py
+++ b/tables/table.py
@@ -29,8 +29,7 @@ from . import tableextension
 from .lrucacheextension import ObjectCache, NumCache
 from .atom import Atom
 from .conditions import compile_condition
-from numexpr.necompiler import (
-    getType as numexpr_getType, double, is_cpu_amd_intel)
+from numexpr.necompiler import getType as numexpr_getType, double
 from numexpr.expressions import functions as numexpr_functions
 from .flavor import flavor_of, array_as_internal, internal_to_flavor
 from .utils import is_idx, lazyattr, SizeType, NailedDict as CacheDict


### PR DESCRIPTION
`is_cpu_amd_intel` was recently removed from [`numexpr.necompiler`](https://github.com/pydata/numexpr/blob/master/numexpr/necompiler.py#L16)