### PR TITLE
MAINT: Fixed test failures with Python 2.7 and NumPy 1.14.3

### DIFF
--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -201,7 +201,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
                 else:
                     tmplist.append(1 + float(i)*1j)
 
-            buflist.append(tmplist)
+            buflist.append(tuple(tmplist))
 
         self.record = records.array(buflist, dtype=record.dtype,
                                     shape=self.expectedrows)


### PR DESCRIPTION
While fixing fall-outs of changes to `numpy.rec.array`
(see https://github.com/numpy/numpy/issues/10344) I evidently missed
a spot which is now causing trouble. See

https://github.com/PyTables/PyTables/pull/664

I think I noted this in the aforementioned PR in a comment.

This PR is to make sure that `initRecArray` method produces list of
tuples, rather than list of lists, as an argument to `numpy.rec.array` constructor.