### PR TITLE
Include citation in repo

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,6 @@
+@Misc{,
+  author = {Francesc Alted and Ivan Vilata and others},
+  title = {{PyTables}: Hierarchical Datasets in {Python}},
+  year = {2002--},
+  url = "https://www.pytables.org/"
+}


### PR DESCRIPTION
Hello :-)

How about including the snippet from https://www.pytables.org/FAQ.html#how-can-i-cite-pytables into the code? Additionally possible: using [`@software`](https://github.com/force11/force11-sciwg/issues/48#issuecomment-372022915) and [sync'ing this repo with Zenodo to get a DOI](https://guides.github.com/activities/citable-code/). What do you think?