### PR TITLE
Add AVX2 support for  Windows

### DIFF
--- a/cpuinfo.py
+++ b/cpuinfo.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-# Copyright (c) 2014-2017, Matthew Brennan Jones <matthew.brennan.jones@gmail.com>
-# Py-cpuinfo is a Python module to show the cpuinfo of a processor
-# It uses a MIT style license
+# Copyright (c) 2014-2018, Matthew Brennan Jones <matthew.brennan.jones@gmail.com>
+# Py-cpuinfo gets CPU info with pure Python 2 & 3
+# It uses the MIT License
 # It is hosted at: https://github.com/workhorsy/py-cpuinfo
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -25,9 +25,10 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-CPUINFO_VERSION = (3, 0, 0)
+CPUINFO_VERSION = (4, 0, 0)
 
 import os, sys
+import glob
 import re
 import time
 import platform
@@ -47,6 +48,38 @@ except ImportError as err:
 
 PY2 = sys.version_info[0] == 2
 
+# Load hacks for Windows
+if platform.system().lower() == 'windows':
+	# Monkey patch multiprocessing's Popen to fork properly on Windows Pyinstaller
+	# https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing
+	try:
+		import multiprocessing.popen_spawn_win32 as forking
+	except ImportError as err:
+		try:
+			import multiprocessing.popen_fork as forking
+		except ImportError as err:
+			import multiprocessing.forking as forking
+
+	class _Popen(forking.Popen):
+		def __init__(self, *args, **kw):
+			if hasattr(sys, 'frozen'):
+				# We have to set original _MEIPASS2 value from sys._MEIPASS
+				# to get --onefile mode working.
+				os.putenv('_MEIPASS2', sys._MEIPASS)
+			try:
+				super(_Popen, self).__init__(*args, **kw)
+			finally:
+				if hasattr(sys, 'frozen'):
+					# On some platforms (e.g. AIX) 'os.unsetenv()' is not
+					# available. In those cases we cannot delete the variable
+					# but only set it to the empty string. The bootloader
+					# can handle this case.
+					if hasattr(os, 'unsetenv'):
+						os.unsetenv('_MEIPASS2')
+					else:
+						os.putenv('_MEIPASS2', '')
+
+	forking.Popen = _Popen
 
 class DataSource(object):
 	bits = platform.architecture()[0]
@@ -65,7 +98,8 @@ class DataSource(object):
 
 	@staticmethod
 	def has_var_run_dmesg_boot():
-		return os.path.exists('/var/run/dmesg.boot')
+		uname = platform.system().strip().strip('"').strip("'").strip().lower()
+		return 'linux' in uname and os.path.exists('/var/run/dmesg.boot')
 
 	@staticmethod
 	def has_cpufreq_info():
@@ -94,6 +128,15 @@ class DataSource(object):
 	@staticmethod
 	def has_lscpu():
 		return len(program_paths('lscpu')) > 0
+
+	@staticmethod
+	def has_ibm_pa_features():
+		return len(program_paths('lsprop')) > 0
+
+	@staticmethod
+	def has_wmic():
+		returncode, output = run_and_get_stdout(['wmic', 'os', 'get', 'Version'])
+		return returncode == 0 and len(output) > 0
 
 	@staticmethod
 	def cat_proc_cpuinfo():
@@ -140,6 +183,16 @@ class DataSource(object):
 		return run_and_get_stdout(['lscpu'])
 
 	@staticmethod
+	def ibm_pa_features():
+		ibm_features = glob.glob('/proc/device-tree/cpus/*/ibm,pa-features')
+		if ibm_features:
+			return run_and_get_stdout(['lsprop', ibm_features[0]])
+
+	@staticmethod
+	def wmic_cpu():
+		return run_and_get_stdout(['wmic', 'cpu', 'get', 'Name,CurrentClockSpeed,L2CacheSize,L3CacheSize,Description,Caption,Manufacturer', '/format:list'])
+
+	@staticmethod
 	def winreg_processor_brand():
 		key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Hardware\Description\System\CentralProcessor\0")
 		processor_brand = winreg.QueryValueEx(key, "ProcessorNameString")[0]
@@ -183,19 +236,22 @@ def obj_to_b64(thing):
 	return d
 
 def b64_to_obj(thing):
-	a = base64.b64decode(thing)
-	b = pickle.loads(a)
-	return b
+	try:
+		a = base64.b64decode(thing)
+		b = pickle.loads(a)
+		return b
+	except:
+		return {}
 
 def run_and_get_stdout(command, pipe_command=None):
 	if not pipe_command:
-		p1 = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		p1 = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
 		output = p1.communicate()[0]
 		if not PY2:
 			output = output.decode(encoding='UTF-8')
 		return p1.returncode, output
 	else:
-		p1 = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		p1 = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
 		p2 = subprocess.Popen(pipe_command, stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		p1.stdout.close()
 		output = p2.communicate()[0]
@@ -334,6 +390,24 @@ def to_hz_string(ticks):
 
 	return ticks
 
+def to_friendly_bytes(input):
+	if not input:
+		return input
+	input = "{0}".format(input)
+
+	formats = {
+		r"^[0-9]+B$" : 'B',
+		r"^[0-9]+K$" : 'KB',
+		r"^[0-9]+M$" : 'MB',
+		r"^[0-9]+G$" : 'GB'
+	}
+
+	for pattern, friendly_size in formats.items():
+		if re.match(pattern, input):
+			return "{0} {1}".format(input[ : -1].strip(), friendly_size)
+
+	return input
+
 def _parse_cpu_string(cpu_string):
 	# Get location of fields at end of string
 	fields_index = cpu_string.find('(', cpu_string.find('@'))
@@ -416,7 +490,6 @@ def _parse_dmesg_output(output):
 			fields = [n.strip().split('=') for n in fields]
 			fields = [{n[0].strip().lower() : n[1].strip()} for n in fields]
 			#print('fields: ', fields)
-
 			for field in fields:
 				name = list(field.keys())[0]
 				value = list(field.values())[0]
@@ -429,7 +502,6 @@ def _parse_dmesg_output(output):
 					model = int(value.lstrip('0x'), 16)
 				elif name in ['fam', 'family']:
 					family = int(value.lstrip('0x'), 16)
-
 		#print('FIELDS: ', (vendor_id, stepping, model, family))
 
 		# Features
@@ -519,6 +591,8 @@ def is_bit_set(reg, bit):
 
 class CPUID(object):
 	def __init__(self):
+		self.prochandle = None
+
 		# Figure out if SE Linux is on and in enforcing mode
 		self.is_selinux_enforcing = False
 
@@ -538,9 +612,13 @@ class CPUID(object):
 		if DataSource.is_windows:
 			# Allocate a memory segment the size of the byte code, and make it executable
 			size = len(byte_code)
+			# Alloc at least 1 page to ensure we own all pages that we want to change protection on
+			if size < 0x1000: size = 0x1000
 			MEM_COMMIT = ctypes.c_ulong(0x1000)
-			PAGE_EXECUTE_READWRITE = ctypes.c_ulong(0x40)
-			address = ctypes.windll.kernel32.VirtualAlloc(ctypes.c_int(0), ctypes.c_size_t(size), MEM_COMMIT, PAGE_EXECUTE_READWRITE)
+			PAGE_READWRITE = ctypes.c_ulong(0x4)
+			pfnVirtualAlloc = ctypes.windll.kernel32.VirtualAlloc
+			pfnVirtualAlloc.restype = ctypes.c_void_p
+			address = pfnVirtualAlloc(None, ctypes.c_size_t(size), MEM_COMMIT, PAGE_READWRITE)
 			if not address:
 				raise Exception("Failed to VirtualAlloc")
 
@@ -548,27 +626,48 @@ class CPUID(object):
 			memmove = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t)(ctypes._memmove_addr)
 			if memmove(address, byte_code, size) < 0:
 				raise Exception("Failed to memmove")
+
+			# Enable execute permissions
+			PAGE_EXECUTE = ctypes.c_ulong(0x10)
+			old_protect = ctypes.c_ulong(0)
+			pfnVirtualProtect = ctypes.windll.kernel32.VirtualProtect
+			res = pfnVirtualProtect(ctypes.c_void_p(address), ctypes.c_size_t(size), PAGE_EXECUTE, ctypes.byref(old_protect))
+			if not res:
+				raise Exception("Failed VirtualProtect")
+
+			# Flush Instruction Cache
+			# First, get process Handle
+			if not self.prochandle:
+				pfnGetCurrentProcess = ctypes.windll.kernel32.GetCurrentProcess
+				pfnGetCurrentProcess.restype = ctypes.c_void_p
+				self.prochandle = ctypes.c_void_p(pfnGetCurrentProcess())
+			# Actually flush cache
+			res = ctypes.windll.kernel32.FlushInstructionCache(self.prochandle, ctypes.c_void_p(address), ctypes.c_size_t(size))
+			if not res:
+				raise Exception("Failed FlushInstructionCache")
 		else:
 			# Allocate a memory segment the size of the byte code
 			size = len(byte_code)
-			address = ctypes.pythonapi.valloc(size)
+			pfnvalloc = ctypes.pythonapi.valloc
+			pfnvalloc.restype = ctypes.c_void_p
+			address = pfnvalloc(ctypes.c_size_t(size))
 			if not address:
 				raise Exception("Failed to valloc")
 
 			# Mark the memory segment as writeable only
 			if not self.is_selinux_enforcing:
 				WRITE = 0x2
-				if ctypes.pythonapi.mprotect(address, size, WRITE) < 0:
+				if ctypes.pythonapi.mprotect(ctypes.c_void_p(address), size, WRITE) < 0:
 					raise Exception("Failed to mprotect")
 
 			# Copy the byte code into the memory segment
-			if ctypes.pythonapi.memmove(address, byte_code, size) < 0:
+			if ctypes.pythonapi.memmove(ctypes.c_void_p(address), byte_code, ctypes.c_size_t(size)) < 0:
 				raise Exception("Failed to memmove")
 
 			# Mark the memory segment as writeable and executable only
 			if not self.is_selinux_enforcing:
 				WRITE_EXECUTE = 0x2 | 0x4
-				if ctypes.pythonapi.mprotect(address, size, WRITE_EXECUTE) < 0:
+				if ctypes.pythonapi.mprotect(ctypes.c_void_p(address), size, WRITE_EXECUTE) < 0:
 					raise Exception("Failed to mprotect")
 
 		# Cast the memory segment into a function
@@ -578,55 +677,45 @@ class CPUID(object):
 
 	def _run_asm(self, *byte_code):
 		# Convert the byte code into a function that returns an int
-		restype = None
-		if DataSource.bits == '64bit':
-			restype = ctypes.c_uint64
-		else:
-			restype = ctypes.c_uint32
+		restype = ctypes.c_uint32
 		argtypes = ()
 		func, address = self._asm_func(restype, argtypes, byte_code)
 
 		# Call the byte code like a function
 		retval = func()
 
+		byte_code = bytes.join(b'', byte_code)
 		size = ctypes.c_size_t(len(byte_code))
 
 		# Free the function memory segment
 		if DataSource.is_windows:
 			MEM_RELEASE = ctypes.c_ulong(0x8000)
-			ctypes.windll.kernel32.VirtualFree(address, size, MEM_RELEASE)
+			ctypes.windll.kernel32.VirtualFree(ctypes.c_void_p(address), ctypes.c_size_t(0), MEM_RELEASE)
 		else:
 			# Remove the executable tag on the memory
 			READ_WRITE = 0x1 | 0x2
-			if ctypes.pythonapi.mprotect(address, size, READ_WRITE) < 0:
+			if ctypes.pythonapi.mprotect(ctypes.c_void_p(address), size, READ_WRITE) < 0:
 				raise Exception("Failed to mprotect")
 
-			ctypes.pythonapi.free(address)
+			ctypes.pythonapi.free(ctypes.c_void_p(address))
 
 		return retval
 
 	# FIXME: We should not have to use different instructions to
 	# set eax to 0 or 1, on 32bit and 64bit machines.
 	def _zero_eax(self):
-		if DataSource.bits == '64bit':
-			return (
-				b"\x66\xB8\x00\x00" # mov eax,0x0"
-			)
-		else:
-			return (
-				b"\x31\xC0"         # xor ax,ax
-			)
+		return (
+			b"\x31\xC0"         # xor eax,eax
+		)
 
+	def _zero_ecx(self):
+		return (
+			b"\x31\xC9"         # xor ecx,ecx
+		)
 	def _one_eax(self):
-		if DataSource.bits == '64bit':
-			return (
-				b"\x66\xB8\x01\x00" # mov eax,0x1"
-			)
-		else:
-			return (
-				b"\x31\xC0"         # xor ax,ax
-				b"\x40"             # inc ax
-			)
+		return (
+			b"\xB8\x01\x00\x00\x00" # mov eax,0x1"
+		)
 
 	# http://en.wikipedia.org/wiki/CPUID#EAX.3D0:_Get_vendor_ID
 	def get_vendor_id(self):
@@ -790,18 +879,102 @@ class CPUID(object):
 		# Get a list of only the flags that are true
 		flags = [k for k, v in flags.items() if v]
 
-		# Get the Extended CPU flags
-		extended_flags = {}
-
 		# http://en.wikipedia.org/wiki/CPUID#EAX.3D7.2C_ECX.3D0:_Extended_Features
-		if max_extension_support == 7:
-			pass
-			# FIXME: Are we missing all these flags too?
-			# avx2 et cetera ...
+		if max_extension_support >= 7:
+			# EBX
+			ebx = self._run_asm(
+				self._zero_ecx(),
+				b"\xB8\x07\x00\x00\x00" # mov eax,7
+				b"\x0f\xa2"         # cpuid
+				b"\x89\xD8"         # mov ax,bx
+				b"\xC3"             # ret
+			)
+
+			# ECX
+			ecx = self._run_asm(
+				self._zero_ecx(),
+				b"\xB8\x07\x00\x00\x00" # mov eax,7
+				b"\x0f\xa2"         # cpuid
+				b"\x89\xC8"         # mov ax,cx
+				b"\xC3"             # ret
+			)
+
+			# Get the extended CPU flags
+			extended_flags = {
+				#'fsgsbase' : is_bit_set(ebx, 0),
+				#'IA32_TSC_ADJUST' : is_bit_set(ebx, 1),
+				'sgx' : is_bit_set(ebx, 2),
+				'bmi1' : is_bit_set(ebx, 3),
+				'hle' : is_bit_set(ebx, 4),
+				'avx2' : is_bit_set(ebx, 5),
+				#'reserved' : is_bit_set(ebx, 6),
+				'smep' : is_bit_set(ebx, 7),
+				'bmi2' : is_bit_set(ebx, 8),
+				'erms' : is_bit_set(ebx, 9),
+				'invpcid' : is_bit_set(ebx, 10),
+				'rtm' : is_bit_set(ebx, 11),
+				'pqm' : is_bit_set(ebx, 12),
+				#'FPU CS and FPU DS deprecated' : is_bit_set(ebx, 13),
+				'mpx' : is_bit_set(ebx, 14),
+				'pqe' : is_bit_set(ebx, 15),
+				'avx512f' : is_bit_set(ebx, 16),
+				'avx512dq' : is_bit_set(ebx, 17),
+				'rdseed' : is_bit_set(ebx, 18),
+				'adx' : is_bit_set(ebx, 19),
+				'smap' : is_bit_set(ebx, 20),
+				'avx512ifma' : is_bit_set(ebx, 21),
+				'pcommit' : is_bit_set(ebx, 22),
+				'clflushopt' : is_bit_set(ebx, 23),
+				'clwb' : is_bit_set(ebx, 24),
+				'intel_pt' : is_bit_set(ebx, 25),
+				'avx512pf' : is_bit_set(ebx, 26),
+				'avx512er' : is_bit_set(ebx, 27),
+				'avx512cd' : is_bit_set(ebx, 28),
+				'sha' : is_bit_set(ebx, 29),
+				'avx512bw' : is_bit_set(ebx, 30),
+				'avx512vl' : is_bit_set(ebx, 31),
+
+				'prefetchwt1' : is_bit_set(ecx, 0),
+				'avx512vbmi' : is_bit_set(ecx, 1),
+				'umip' : is_bit_set(ecx, 2),
+				'pku' : is_bit_set(ecx, 3),
+				'ospke' : is_bit_set(ecx, 4),
+				#'reserved' : is_bit_set(ecx, 5),
+				'avx512vbmi2' : is_bit_set(ecx, 6),
+				#'reserved' : is_bit_set(ecx, 7),
+				'gfni' : is_bit_set(ecx, 8),
+				'vaes' : is_bit_set(ecx, 9),
+				'vpclmulqdq' : is_bit_set(ecx, 10),
+				'avx512vnni' : is_bit_set(ecx, 11),
+				'avx512bitalg' : is_bit_set(ecx, 12),
+				#'reserved' : is_bit_set(ecx, 13),
+				'avx512vpopcntdq' : is_bit_set(ecx, 14),
+				#'reserved' : is_bit_set(ecx, 15),
+				#'reserved' : is_bit_set(ecx, 16),
+				#'mpx0' : is_bit_set(ecx, 17),
+				#'mpx1' : is_bit_set(ecx, 18),
+				#'mpx2' : is_bit_set(ecx, 19),
+				#'mpx3' : is_bit_set(ecx, 20),
+				#'mpx4' : is_bit_set(ecx, 21),
+				'rdpid' : is_bit_set(ecx, 22),
+				#'reserved' : is_bit_set(ecx, 23),
+				#'reserved' : is_bit_set(ecx, 24),
+				#'reserved' : is_bit_set(ecx, 25),
+				#'reserved' : is_bit_set(ecx, 26),
+				#'reserved' : is_bit_set(ecx, 27),
+				#'reserved' : is_bit_set(ecx, 28),
+				#'reserved' : is_bit_set(ecx, 29),
+				'sgx_lc' : is_bit_set(ecx, 30),
+				#'reserved' : is_bit_set(ecx, 31)
+			}
+
+			# Get a list of only the flags that are true
+			extended_flags = [k for k, v in extended_flags.items() if v]
+			flags += extended_flags
 
 		# http://en.wikipedia.org/wiki/CPUID#EAX.3D80000001h:_Extended_Processor_Info_and_Feature_Bits
 		if max_extension_support >= 0x80000001:
-			# EBX # FIXME: This may need to be EDX instead
+			# EBX
 			ebx = self._run_asm(
 				b"\xB8\x01\x00\x00\x80" # mov ax,0x80000001
 				b"\x0f\xa2"         # cpuid
@@ -886,9 +1059,9 @@ class CPUID(object):
 				#'reserved' : is_bit_set(ecx, 31)
 			}
 
-		# Get a list of only the flags that are true
-		extended_flags = [k for k, v in extended_flags.items() if v]
-		flags += extended_flags
+			# Get a list of only the flags that are true
+			extended_flags = [k for k, v in extended_flags.items() if v]
+			flags += extended_flags
 
 		flags.sort()
 		return flags
@@ -1031,23 +1204,30 @@ class CPUID(object):
 
 		return ticks
 
-def actual_get_cpu_info_from_cpuid():
+def _actual_get_cpu_info_from_cpuid(queue):
 	'''
 	Warning! This function has the potential to crash the Python runtime.
 	Do not call it directly. Use the _get_cpu_info_from_cpuid function instead.
 	It will safely call this function in another process.
 	'''
+
+	# Pipe all output to nothing
+	sys.stdout = open(os.devnull, 'w')
+	sys.stderr = open(os.devnull, 'w')
+
 	# Get the CPU arch and bits
 	arch, bits = parse_arch(DataSource.raw_arch_string)
 
 	# Return none if this is not an X86 CPU
 	if not arch in ['X86_32', 'X86_64']:
-		return obj_to_b64({})
+		queue.put(obj_to_b64({}))
+		return
 
 	# Return none if SE Linux is in enforcing mode
 	cpuid = CPUID()
 	if cpuid.is_selinux_enforcing:
-		return obj_to_b64({})
+		queue.put(obj_to_b64({}))
+		return
 
 	# Get the cpu info from the CPUID register
 	max_extension_support = cpuid.get_max_extension_support()
@@ -1062,18 +1242,17 @@ def actual_get_cpu_info_from_cpuid():
 
 	# Get the Hz and scale
 	scale, hz_advertised = _get_hz_string_from_brand(processor_brand)
-
 	info = {
 	'vendor_id' : cpuid.get_vendor_id(),
 	'hardware' : '',
 	'brand' : processor_brand,
 
 	'hz_advertised' : to_friendly_hz(hz_advertised, scale),
-	'hz_actual' : to_friendly_hz(hz_actual, 6),
+	'hz_actual' : to_friendly_hz(hz_actual, 0),
 	'hz_advertised_raw' : to_raw_hz(hz_advertised, scale),
-	'hz_actual_raw' : to_raw_hz(hz_actual, 6),
+	'hz_actual_raw' : to_raw_hz(hz_actual, 0),
 
-	'l2_cache_size' : cache_info['size_kb'],
+	'l2_cache_size' : to_friendly_bytes(cache_info['size_kb']),
 	'l2_cache_line_size' : cache_info['line_size_b'],
 	'l2_cache_associativity' : hex(cache_info['associativity']),
 
@@ -1087,7 +1266,7 @@ def actual_get_cpu_info_from_cpuid():
 	}
 
 	info = {k: v for k, v in info.items() if v}
-	return obj_to_b64(info)
+	queue.put(obj_to_b64(info))
 
 def _get_cpu_info_from_cpuid():
 	'''
@@ -1095,6 +1274,7 @@ def _get_cpu_info_from_cpuid():
 	Returns {} on non X86 cpus.
 	Returns {} if SELinux is in enforcing mode.
 	'''
+	from multiprocessing import Process, Queue
 
 	# Return {} if can't cpuid
 	if not DataSource.can_cpuid:
@@ -1107,11 +1287,29 @@ def _get_cpu_info_from_cpuid():
 	if not arch in ['X86_32', 'X86_64']:
 		return {}
 
-	returncode, output = run_and_get_stdout([sys.executable, "-c", "import cpuinfo; print(cpuinfo.actual_get_cpu_info_from_cpuid())"])
-	if returncode != 0:
-		return {}
-	info = b64_to_obj(output)
-	return info
+	try:
+		# Start running the function in a subprocess
+		queue = Queue()
+		p = Process(target=_actual_get_cpu_info_from_cpuid, args=(queue,))
+		p.start()
+
+		# Wait for the process to end, while it is still alive
+		while p.is_alive():
+			p.join(0)
+
+		# Return {} if it failed
+		if p.exitcode != 0:
+			return {}
+
+		# Return the result, only if there is something to read
+		if not queue.empty():
+			output = queue.get()
+			return b64_to_obj(output)
+	except:
+		pass
+
+	# Return {} if everything failed
+	return {}
 
 def _get_cpu_info_from_proc_cpuinfo():
 	'''
@@ -1157,7 +1355,7 @@ def _get_cpu_info_from_proc_cpuinfo():
 		'hardware' : hardware,
 		'brand' : processor_brand,
 
-		'l2_cache_size' : cache_size,
+		'l3_cache_size' : to_friendly_bytes(cache_size),
 		'flags' : flags,
 		'vendor_id' : vendor_id,
 		'stepping' : stepping,
@@ -1201,7 +1399,10 @@ def _get_cpu_info_from_cpufreq_info():
 		if returncode != 0:
 			return {}
 
-		hz_brand = output.split('current CPU frequency is')[1].split('\n')[0].rsplit('.', 1)[0].lower().strip()
+		hz_brand = output.split('current CPU frequency is')[1].split('\n')[0]
+		i = hz_brand.find('Hz')
+		assert(i != -1)
+		hz_brand = hz_brand[0 : i+2].strip().lower()
 
 		if hz_brand.endswith('mhz'):
 			scale = 6
@@ -1255,10 +1456,6 @@ def _get_cpu_info_from_lscpu():
 		if brand:
 			info['brand'] = brand
 
-		brand = _get_field(False, output, None, None, 'Model name')
-		if brand:
-			info['brand'] = brand
-
 		family = _get_field(False, output, None, None, 'CPU family')
 		if family and family.isdigit():
 			info['family'] = int(family)
@@ -1270,6 +1467,22 @@ def _get_cpu_info_from_lscpu():
 		model = _get_field(False, output, None, None, 'Model')
 		if model and model.isdigit():
 			info['model'] = int(model)
+
+		l1_data_cache_size = _get_field(False, output, None, None, 'L1d cache')
+		if l1_data_cache_size:
+			info['l1_data_cache_size'] = to_friendly_bytes(l1_data_cache_size)
+
+		l1_instruction_cache_size = _get_field(False, output, None, None, 'L1i cache')
+		if l1_instruction_cache_size:
+			info['l1_instruction_cache_size'] = to_friendly_bytes(l1_instruction_cache_size)
+
+		l2_cache_size = _get_field(False, output, None, None, 'L2 cache')
+		if l2_cache_size:
+			info['l2_cache_size'] = to_friendly_bytes(l2_cache_size)
+
+		l3_cache_size = _get_field(False, output, None, None, 'L3 cache')
+		if l3_cache_size:
+			info['l3_cache_size'] = to_friendly_bytes(l3_cache_size)
 
 		# Flags
 		flags = _get_field(False, output, None, None, 'flags', 'Features')
@@ -1299,6 +1512,130 @@ def _get_cpu_info_from_dmesg():
 		return {}
 
 	return _parse_dmesg_output(output)
+
+
+# https://openpowerfoundation.org/wp-content/uploads/2016/05/LoPAPR_DRAFT_v11_24March2016_cmt1.pdf
+# page 767
+def _get_cpu_info_from_ibm_pa_features():
+	'''
+	Returns the CPU info gathered from lsprop /proc/device-tree/cpus/*/ibm,pa-features
+	Returns {} if lsprop is not found or ibm,pa-features does not have the desired info.
+	'''
+	try:
+		# Just return {} if there is no lsprop
+		if not DataSource.has_ibm_pa_features():
+			return {}
+
+		# If ibm,pa-features fails return {}
+		returncode, output = DataSource.ibm_pa_features()
+		if output == None or returncode != 0:
+			return {}
+
+		# Filter out invalid characters from output
+		value = output.split("ibm,pa-features")[1].lower()
+		value = [s for s in value if s in list('0123456789abcfed')]
+		value = ''.join(value)
+
+		# Get data converted to Uint32 chunks
+		left = int(value[0 : 8], 16)
+		right = int(value[8 : 16], 16)
+
+		# Get the CPU flags
+		flags = {
+			# Byte 0
+			'mmu' : is_bit_set(left, 0),
+			'fpu' : is_bit_set(left, 1),
+			'slb' : is_bit_set(left, 2),
+			'run' : is_bit_set(left, 3),
+			#'reserved' : is_bit_set(left, 4),
+			'dabr' : is_bit_set(left, 5),
+			'ne' : is_bit_set(left, 6),
+			'wtr' : is_bit_set(left, 7),
+
+			# Byte 1
+			'mcr' : is_bit_set(left, 8),
+			'dsisr' : is_bit_set(left, 9),
+			'lp' : is_bit_set(left, 10),
+			'ri' : is_bit_set(left, 11),
+			'dabrx' : is_bit_set(left, 12),
+			'sprg3' : is_bit_set(left, 13),
+			'rislb' : is_bit_set(left, 14),
+			'pp' : is_bit_set(left, 15),
+
+			# Byte 2
+			'vpm' : is_bit_set(left, 16),
+			'dss_2.05' : is_bit_set(left, 17),
+			#'reserved' : is_bit_set(left, 18),
+			'dar' : is_bit_set(left, 19),
+			#'reserved' : is_bit_set(left, 20),
+			'ppr' : is_bit_set(left, 21),
+			'dss_2.02' : is_bit_set(left, 22),
+			'dss_2.06' : is_bit_set(left, 23),
+
+			# Byte 3
+			'lsd_in_dscr' : is_bit_set(left, 24),
+			'ugr_in_dscr' : is_bit_set(left, 25),
+			#'reserved' : is_bit_set(left, 26),
+			#'reserved' : is_bit_set(left, 27),
+			#'reserved' : is_bit_set(left, 28),
+			#'reserved' : is_bit_set(left, 29),
+			#'reserved' : is_bit_set(left, 30),
+			#'reserved' : is_bit_set(left, 31),
+
+			# Byte 4
+			'sso_2.06' : is_bit_set(right, 0),
+			#'reserved' : is_bit_set(right, 1),
+			#'reserved' : is_bit_set(right, 2),
+			#'reserved' : is_bit_set(right, 3),
+			#'reserved' : is_bit_set(right, 4),
+			#'reserved' : is_bit_set(right, 5),
+			#'reserved' : is_bit_set(right, 6),
+			#'reserved' : is_bit_set(right, 7),
+
+			# Byte 5
+			'le' : is_bit_set(right, 8),
+			'cfar' : is_bit_set(right, 9),
+			'eb' : is_bit_set(right, 10),
+			'lsq_2.07' : is_bit_set(right, 11),
+			#'reserved' : is_bit_set(right, 12),
+			#'reserved' : is_bit_set(right, 13),
+			#'reserved' : is_bit_set(right, 14),
+			#'reserved' : is_bit_set(right, 15),
+
+			# Byte 6
+			'dss_2.07' : is_bit_set(right, 16),
+			#'reserved' : is_bit_set(right, 17),
+			#'reserved' : is_bit_set(right, 18),
+			#'reserved' : is_bit_set(right, 19),
+			#'reserved' : is_bit_set(right, 20),
+			#'reserved' : is_bit_set(right, 21),
+			#'reserved' : is_bit_set(right, 22),
+			#'reserved' : is_bit_set(right, 23),
+
+			# Byte 7
+			#'reserved' : is_bit_set(right, 24),
+			#'reserved' : is_bit_set(right, 25),
+			#'reserved' : is_bit_set(right, 26),
+			#'reserved' : is_bit_set(right, 27),
+			#'reserved' : is_bit_set(right, 28),
+			#'reserved' : is_bit_set(right, 29),
+			#'reserved' : is_bit_set(right, 30),
+			#'reserved' : is_bit_set(right, 31),
+		}
+
+		# Get a list of only the flags that are true
+		flags = [k for k, v in flags.items() if v]
+		flags.sort()
+
+		info = {
+			'flags' : flags
+		}
+		info = {k: v for k, v in info.items() if v}
+
+		return info
+	except:
+		return {}
+
 
 def _get_cpu_info_from_cat_var_run_dmesg_boot():
 	'''
@@ -1360,7 +1697,7 @@ def _get_cpu_info_from_sysctl():
 		'hz_advertised_raw' : to_raw_hz(hz_advertised, scale),
 		'hz_actual_raw' : to_raw_hz(hz_actual, 0),
 
-		'l2_cache_size' : cache_size,
+		'l2_cache_size' : to_friendly_bytes(cache_size),
 
 		'stepping' : stepping,
 		'model' : model,
@@ -1373,7 +1710,17 @@ def _get_cpu_info_from_sysctl():
 	except:
 		return {}
 
+
 def _get_cpu_info_from_sysinfo():
+	'''
+	Returns the CPU info gathered from sysinfo.
+	Returns {} if sysinfo is not found.
+	'''
+	info = _get_cpu_info_from_sysinfo_v1()
+	info.update(_get_cpu_info_from_sysinfo_v2())
+	return info
+
+def _get_cpu_info_from_sysinfo_v1():
 	'''
 	Returns the CPU info gathered from sysinfo.
 	Returns {} if sysinfo is not found.
@@ -1417,7 +1764,7 @@ def _get_cpu_info_from_sysinfo():
 		'hz_advertised_raw' : to_raw_hz(hz_advertised, scale),
 		'hz_actual_raw' : to_raw_hz(hz_actual, scale),
 
-		'l2_cache_size' : cache_size,
+		'l2_cache_size' : to_friendly_bytes(cache_size),
 
 		'stepping' : stepping,
 		'model' : model,
@@ -1428,6 +1775,150 @@ def _get_cpu_info_from_sysinfo():
 		info = {k: v for k, v in info.items() if v}
 		return info
 	except:
+		return {}
+
+def _get_cpu_info_from_sysinfo_v2():
+	'''
+	Returns the CPU info gathered from sysinfo.
+	Returns {} if sysinfo is not found.
+	'''
+	try:
+		# Just return {} if there is no sysinfo
+		if not DataSource.has_sysinfo():
+			return {}
+
+		# If sysinfo fails return {}
+		returncode, output = DataSource.sysinfo_cpu()
+		if output == None or returncode != 0:
+			return {}
+
+		# Various fields
+		vendor_id = '' #_get_field(False, output, None, None, 'CPU #0: ')
+		processor_brand = output.split('CPU #0: "')[1].split('"\n')[0]
+		cache_size = '' #_get_field(False, output, None, None, 'machdep.cpu.cache.size')
+		signature = output.split('Signature:')[1].split('\n')[0].strip()
+		#
+		stepping = int(signature.split('stepping ')[1].split(',')[0].strip())
+		model = int(signature.split('model ')[1].split(',')[0].strip())
+		family = int(signature.split('family ')[1].split(',')[0].strip())
+
+		# Flags
+		def get_subsection_flags(output):
+			retval = []
+			for line in output.split('\n')[1:]:
+				if not line.startswith('                '): break
+				for entry in line.strip().lower().split(' '):
+					retval.append(entry)
+			return retval
+
+		flags = get_subsection_flags(output.split('Features: ')[1]) + \
+				get_subsection_flags(output.split('Extended Features (0x00000001): ')[1]) + \
+				get_subsection_flags(output.split('Extended Features (0x80000001): ')[1])
+		flags.sort()
+
+		# Convert from GHz/MHz string to Hz
+		scale, hz_advertised = _get_hz_string_from_brand(processor_brand)
+		hz_actual = hz_advertised
+
+		info = {
+		'vendor_id' : vendor_id,
+		'brand' : processor_brand,
+
+		'hz_advertised' : to_friendly_hz(hz_advertised, scale),
+		'hz_actual' : to_friendly_hz(hz_actual, scale),
+		'hz_advertised_raw' : to_raw_hz(hz_advertised, scale),
+		'hz_actual_raw' : to_raw_hz(hz_actual, scale),
+
+		'l2_cache_size' : to_friendly_bytes(cache_size),
+
+		'stepping' : stepping,
+		'model' : model,
+		'family' : family,
+		'flags' : flags
+		}
+
+		info = {k: v for k, v in info.items() if v}
+		return info
+	except:
+		return {}
+
+def _get_cpu_info_from_wmic():
+	'''
+	Returns the CPU info gathered from WMI.
+	Returns {} if not on Windows, or wmic is not installed.
+	'''
+
+	try:
+		# Just return {} if not Windows or there is no wmic
+		if not DataSource.is_windows or not DataSource.has_wmic():
+			return {}
+
+		returncode, output = DataSource.wmic_cpu()
+		if output == None or returncode != 0:
+			return {}
+
+		# Break the list into key values pairs
+		value = output.split("\n")
+		value = [s.rstrip().split('=') for s in value if '=' in s]
+		value = {k: v for k, v in value if v}
+
+		# Get the advertised MHz
+		processor_brand = value.get('Name')
+		scale_advertised, hz_advertised = _get_hz_string_from_brand(processor_brand)
+
+		# Get the actual MHz
+		hz_actual = value.get('CurrentClockSpeed')
+		scale_actual = 6
+		if hz_actual:
+			hz_actual = to_hz_string(hz_actual)
+
+		# Get cache sizes
+		l2_cache_size = value.get('L2CacheSize')
+		if l2_cache_size:
+			l2_cache_size = l2_cache_size + ' KB'
+
+		l3_cache_size = value.get('L3CacheSize')
+		if l3_cache_size:
+			l3_cache_size = l3_cache_size + ' KB'
+
+		# Get family, model, and stepping
+		family, model, stepping = '', '', ''
+		description = value.get('Description') or value.get('Caption')
+		entries = description.split(' ')
+
+		if 'Family' in entries and entries.index('Family') < len(entries)-1:
+			i = entries.index('Family')
+			family = int(entries[i + 1])
+
+		if 'Model' in entries and entries.index('Model') < len(entries)-1:
+			i = entries.index('Model')
+			model = int(entries[i + 1])
+
+		if 'Stepping' in entries and entries.index('Stepping') < len(entries)-1:
+			i = entries.index('Stepping')
+			stepping = int(entries[i + 1])
+
+		info = {
+			'vendor_id' : value.get('Manufacturer'),
+			'brand' : processor_brand,
+
+			'hz_advertised' : to_friendly_hz(hz_advertised, scale_advertised),
+			'hz_actual' : to_friendly_hz(hz_actual, scale_actual),
+			'hz_advertised_raw' : to_raw_hz(hz_advertised, scale_advertised),
+			'hz_actual_raw' : to_raw_hz(hz_actual, scale_actual),
+
+			'l2_cache_size' : l2_cache_size,
+			'l3_cache_size' : l3_cache_size,
+
+			'stepping' : stepping,
+			'model' : model,
+			'family' : family,
+		}
+
+		info = {k: v for k, v in info.items() if v}
+		return info
+	except:
+		#raise # NOTE: To have this throw on error, uncomment this line
 		return {}
 
 def _get_cpu_info_from_registry():
@@ -1591,12 +2082,17 @@ def CopyNewFields(info, new_info):
 		'hz_advertised_raw', 'hz_actual_raw', 'arch', 'bits', 'count',
 		'raw_arch_string', 'l2_cache_size', 'l2_cache_line_size',
 		'l2_cache_associativity', 'stepping', 'model', 'family',
-		'processor_type', 'extended_model', 'extended_family', 'flags'
+		'processor_type', 'extended_model', 'extended_family', 'flags',
+		'l3_cache_size', 'l1_data_cache_size', 'l1_instruction_cache_size'
 	]
 
 	for key in keys:
 		if new_info.get(key, None) and not info.get(key, None):
 			info[key] = new_info[key]
+		elif key == 'flags' and new_info.get('flags'):
+			for f in new_info['flags']:
+				if f not in info['flags']: info['flags'].append(f)
+			info['flags'].sort()
 
 def get_cpu_info():
 	'''
@@ -1607,13 +2103,21 @@ def get_cpu_info():
 	# Get the CPU arch and bits
 	arch, bits = parse_arch(DataSource.raw_arch_string)
 
+	friendly_maxsize = { 2**31-1: '32 bit', 2**63-1: '64 bit' }.get(sys.maxsize) or 'unknown bits'
+	friendly_version = "{0}.{1}.{2}.{3}.{4}".format(*sys.version_info)
+	PYTHON_VERSION = "{0} ({1})".format(friendly_version, friendly_maxsize)
+
 	info = {
+		'python_version' : PYTHON_VERSION,
 		'cpuinfo_version' : CPUINFO_VERSION,
 		'arch' : arch,
 		'bits' : bits,
 		'count' : DataSource.cpu_count,
 		'raw_arch_string' : DataSource.raw_arch_string,
 	}
+
+	# Try the Windows wmic
+	CopyNewFields(info, _get_cpu_info_from_wmic())
 
 	# Try the Windows registry
 	CopyNewFields(info, _get_cpu_info_from_registry())
@@ -1639,6 +2143,9 @@ def get_cpu_info():
 	# Try /var/run/dmesg.boot
 	CopyNewFields(info, _get_cpu_info_from_cat_var_run_dmesg_boot())
 
+	# Try lsprop ibm,pa-features
+	CopyNewFields(info, _get_cpu_info_from_ibm_pa_features())
+
 	# Try sysinfo
 	CopyNewFields(info, _get_cpu_info_from_sysinfo())
 
@@ -1662,7 +2169,8 @@ def main():
 
 	info = get_cpu_info()
 	if info:
-		print('cpuinfo version: {0}'.format(info.get('cpuinfo_version', '')))
+		print('Python Version: {0}'.format(info.get('python_version', '')))
+		print('Cpuinfo Version: {0}'.format(info.get('cpuinfo_version', '')))
 		print('Vendor ID: {0}'.format(info.get('vendor_id', '')))
 		print('Hardware Raw: {0}'.format(info.get('hardware', '')))
 		print('Brand: {0}'.format(info.get('brand', '')))
@@ -1676,10 +2184,12 @@ def main():
 
 		print('Raw Arch String: {0}'.format(info.get('raw_arch_string', '')))
 
+		print('L1 Data Cache Size: {0}'.format(info.get('l1_data_cache_size', '')))
+		print('L1 Instruction Cache Size: {0}'.format(info.get('l1_instruction_cache_size', '')))
 		print('L2 Cache Size: {0}'.format(info.get('l2_cache_size', '')))
 		print('L2 Cache Line Size: {0}'.format(info.get('l2_cache_line_size', '')))
 		print('L2 Cache Associativity: {0}'.format(info.get('l2_cache_associativity', '')))
-
+		print('L3 Cache Size: {0}'.format(info.get('l3_cache_size', '')))
 		print('Stepping: {0}'.format(info.get('stepping', '')))
 		print('Model: {0}'.format(info.get('model', '')))
 		print('Family: {0}'.format(info.get('family', '')))
@@ -1693,6 +2203,8 @@ def main():
 
 
 if __name__ == '__main__':
+	from multiprocessing import freeze_support
+	freeze_support()
 	main()
 else:
 	_check_arch()

--- a/setup.py
+++ b/setup.py
@@ -31,1024 +31,1030 @@ import distutils.spawn
 # This is also what pandas does.
 from setuptools.command.build_ext import build_ext
 
-# For guessing the capabilities of the CPU for C-Blosc
-try:
-    import cpuinfo
-    cpu_info = cpuinfo.get_cpu_info()
-    cpu_flags = cpu_info['flags']
-except Exception as e:
-    print('cpuinfo failed, assuming no CPU features:', e)
-    cpu_flags = []
-
-# The name for the pkg-config utility
-PKG_CONFIG = 'pkg-config'
-
-
-# Fetch the requisites
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-
-
-class BuildExtensions(build_ext):
-    """Subclass setuptools build_ext command
-
-    BuildExtensions does two things
-    1) it makes sure numpy is available
-    2) it injects numpy's core/include directory in the include_dirs parameter
-       of all extensions
-    3) it runs the original build_ext command
-    """
-
-    def run(self):
-        # According to
-        # https://pip.pypa.io/en/stable/reference/pip_install.html#installation-order
-        # at this point we can be sure pip has already installed numpy
-        numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
-
-        for ext in self.extensions:
-            if (hasattr(ext, 'include_dirs') and
-                    numpy_incl not in ext.include_dirs):
-                ext.include_dirs.append(numpy_incl)
-
-        build_ext.run(self)
-
-
-cmdclass = {'build_ext': BuildExtensions}
-setuptools_kwargs = {}
-
-
-# Some functions for showing errors and warnings.
-def _print_admonition(kind, head, body):
-    tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
-
-    print(".. %s:: %s" % (kind.upper(), head))
-    for line in tw.wrap(body):
-        print(line)
-
-
-def exit_with_error(head, body=''):
-    _print_admonition('error', head, body)
-    sys.exit(1)
-
-
-def print_warning(head, body=''):
-    _print_admonition('warning', head, body)
-
-
-# The minimum required versions
-min_python_version = (2, 6)
-# Check for Python
-if sys.version_info < min_python_version:
-    exit_with_error("You need Python 2.6 or greater to install PyTables!")
-print("* Using Python %s" % sys.version.splitlines()[0])
-
-# Minimum required versions for numpy, numexpr and HDF5
-with open(os.path.join('tables', 'req_versions.py')) as fd:
-    _min_versions = {}
-    exec(fd.read(), _min_versions)
-
-    min_hdf5_version = _min_versions['min_hdf5_version']
-    min_blosc_version = _min_versions['min_blosc_version']
-    min_blosc_bitshuffle_version = _min_versions['min_blosc_bitshuffle_version']
-
-
-with open('VERSION') as fd:
-    VERSION = fd.read().strip()
-
-# ----------------------------------------------------------------------
-
-debug = '--debug' in sys.argv
-
-# Global variables
-lib_dirs = []
-inc_dirs = [os.path.join('hdf5-blosc', 'src')]
-optional_libs = []
-data_files = []    # list of data files to add to packages (mainly for DLL's)
-
-default_header_dirs = None
-default_library_dirs = None
-default_runtime_dirs = None
-
-
-def add_from_path(envname, dirs):
+if __name__ == '__main__':
+    # `cpuinfo.py` uses multiprocessing to check CPUID flags. On Windows, the 
+    # entire setup script needs to be protected as a result
+    # For guessing the capabilities of the CPU for C-Blosc
     try:
-        dirs.extend(os.environ[envname].split(os.pathsep))
-    except KeyError:
-        pass
+        import cpuinfo
+        cpu_info = cpuinfo.get_cpu_info()
+        cpu_flags = cpu_info['flags']
+    except Exception as e:
+        print('cpuinfo failed, assuming no CPU features:', e)
+        cpu_flags = []
+
+    # The name for the pkg-config utility
+    PKG_CONFIG = 'pkg-config'
 
 
-def add_from_flags(envname, flag_key, dirs):
-    for flag in os.environ.get(envname, "").split():
-        if flag.startswith(flag_key):
-            dirs.append(flag[len(flag_key):])
+    # Fetch the requisites
+    with open('requirements.txt') as f:
+        requirements = f.read().splitlines()
 
 
-if os.name == 'posix':
-    prefixes = ('/usr/local', '/sw', '/opt', '/opt/local', '/usr', '/')
+    class BuildExtensions(build_ext):
+        """Subclass setuptools build_ext command
 
-    default_header_dirs = []
-    add_from_path("CPATH", default_header_dirs)
-    add_from_path("C_INCLUDE_PATH", default_header_dirs)
-    add_from_flags("CPPFLAGS", "-I", default_header_dirs)
-    add_from_flags("CFLAGS", "-I", default_header_dirs)
-    default_header_dirs.extend(
-        os.path.join(_tree, 'include') for _tree in prefixes
-    )
-
-    default_library_dirs = []
-    add_from_flags("LDFLAGS", "-L", default_library_dirs)
-    default_library_dirs.extend(
-        os.path.join(_tree, _arch) for _tree in prefixes
-        for _arch in ('lib64', 'lib'))
-    default_runtime_dirs = default_library_dirs
-
-elif os.name == 'nt':
-    default_header_dirs = []  # no default, must be given explicitly
-    default_library_dirs = []  # no default, must be given explicitly
-    default_runtime_dirs = [  # look for DLL files in ``%PATH%``
-        _path for _path in os.environ['PATH'].split(';')]
-    # Add the \Windows\system to the runtime list (necessary for Vista)
-    default_runtime_dirs.append('\\windows\\system')
-    # Add the \path_to_python\DLLs and tables package to the list
-    default_runtime_dirs.extend(
-        [os.path.join(sys.prefix, 'Lib\\site-packages\\tables')])
-
-
-# Gcc 4.0.1 on Mac OS X 10.4 does not seem to include the default
-# header and library paths.  See ticket #18.
-if sys.platform.lower().startswith('darwin'):
-    inc_dirs.extend(default_header_dirs)
-    lib_dirs.extend(default_library_dirs)
-
-
-def _find_file_path(name, locations, prefixes=('',), suffixes=('',)):
-    for prefix in prefixes:
-        for suffix in suffixes:
-            for location in locations:
-                path = os.path.join(location, prefix + name + suffix)
-                if os.path.isfile(path):
-                    return path
-    return None
-
-
-class BasePackage(object):
-    _library_prefixes = []
-    _library_suffixes = []
-    _runtime_prefixes = []
-    _runtime_suffixes = []
-    _component_dirs = []
-
-    def __init__(self, name, tag, header_name, library_name,
-                 target_function=None):
-        self.name = name
-        self.tag = tag
-        self.header_name = header_name
-        self.library_name = library_name
-        self.runtime_name = library_name
-        self.target_function = target_function
-
-    def find_header_path(self, locations=default_header_dirs):
-        return _find_file_path(self.header_name, locations, suffixes=['.h'])
-
-    def find_library_path(self, locations=default_library_dirs):
-        return _find_file_path(
-            self.library_name, locations,
-            self._library_prefixes, self._library_suffixes)
-
-    def find_runtime_path(self, locations=default_runtime_dirs):
+        BuildExtensions does two things
+        1) it makes sure numpy is available
+        2) it injects numpy's core/include directory in the include_dirs parameter
+        of all extensions
+        3) it runs the original build_ext command
         """
-        returns True if the runtime can be found
-        returns None otherwise
-        """
-        # An explicit path can not be provided for runtime libraries.
-        # (The argument is accepted for compatibility with previous methods.)
 
-        # dlopen() won't tell us where the file is, just whether
-        # success occurred, so this returns True instead of a filename
-        for prefix in self._runtime_prefixes:
-            for suffix in self._runtime_suffixes:
-                try:
-                    ctypes.CDLL(prefix + self.runtime_name + suffix)
-                    return True
-                except OSError:
-                    pass
+        def run(self):
+            # According to
+            # https://pip.pypa.io/en/stable/reference/pip_install.html#installation-order
+            # at this point we can be sure pip has already installed numpy
+            numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
 
-    def _pkg_config(self, flags):
+            for ext in self.extensions:
+                if (hasattr(ext, 'include_dirs') and
+                        numpy_incl not in ext.include_dirs):
+                    ext.include_dirs.append(numpy_incl)
+
+            build_ext.run(self)
+
+
+    cmdclass = {'build_ext': BuildExtensions}
+    setuptools_kwargs = {}
+
+
+    # Some functions for showing errors and warnings.
+    def _print_admonition(kind, head, body):
+        tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
+
+        print(".. %s:: %s" % (kind.upper(), head))
+        for line in tw.wrap(body):
+            print(line)
+
+
+    def exit_with_error(head, body=''):
+        _print_admonition('error', head, body)
+        sys.exit(1)
+
+
+    def print_warning(head, body=''):
+        _print_admonition('warning', head, body)
+
+
+    # The minimum required versions
+    min_python_version = (2, 6)
+    # Check for Python
+    if sys.version_info < min_python_version:
+        exit_with_error("You need Python 2.6 or greater to install PyTables!")
+    print("* Using Python %s" % sys.version.splitlines()[0])
+
+    # Minimum required versions for numpy, numexpr and HDF5
+    with open(os.path.join('tables', 'req_versions.py')) as fd:
+        _min_versions = {}
+        exec(fd.read(), _min_versions)
+
+        min_hdf5_version = _min_versions['min_hdf5_version']
+        min_blosc_version = _min_versions['min_blosc_version']
+        min_blosc_bitshuffle_version = _min_versions['min_blosc_bitshuffle_version']
+
+
+    with open('VERSION') as fd:
+        VERSION = fd.read().strip()
+
+    # ----------------------------------------------------------------------
+
+    debug = '--debug' in sys.argv
+
+    # Global variables
+    lib_dirs = []
+    inc_dirs = [os.path.join('hdf5-blosc', 'src')]
+    optional_libs = []
+    data_files = []    # list of data files to add to packages (mainly for DLL's)
+
+    default_header_dirs = None
+    default_library_dirs = None
+    default_runtime_dirs = None
+
+
+    def add_from_path(envname, dirs):
         try:
-            cmd = [PKG_CONFIG] + flags.split() + [self.library_name]
-            config = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            dirs.extend(os.environ[envname].split(os.pathsep))
+        except KeyError:
+            pass
 
-        # subprocess.CalledProcessError is only available in Python >= 2.7
-        # except (OSError, subprocess.CalledProcessError):
-        except Exception:
-            return []
-        else:
-            return config.decode().strip().split()
 
-    def find_directories(self, location, use_pkgconfig=False):
-        dirdata = [
-            (self.header_name, self.find_header_path, default_header_dirs),
-            (self.library_name, self.find_library_path, default_library_dirs),
-            (self.runtime_name, self.find_runtime_path, default_runtime_dirs),
-        ]
+    def add_from_flags(envname, flag_key, dirs):
+        for flag in os.environ.get(envname, "").split():
+            if flag.startswith(flag_key):
+                dirs.append(flag[len(flag_key):])
 
-        locations = []
-        if location:
-            # The path of a custom install of the package has been
-            # provided, so the directories where the components
-            # (headers, libraries, runtime) are going to be searched
-            # are constructed by appending platform-dependent
-            # component directories to the given path.
-            # Remove leading and trailing '"' chars that can mislead
-            # the finding routines on Windows machines
-            locations = [
-                os.path.join(location.strip('"'), compdir)
-                for compdir in self._component_dirs
+
+    if os.name == 'posix':
+        prefixes = ('/usr/local', '/sw', '/opt', '/opt/local', '/usr', '/')
+
+        default_header_dirs = []
+        add_from_path("CPATH", default_header_dirs)
+        add_from_path("C_INCLUDE_PATH", default_header_dirs)
+        add_from_flags("CPPFLAGS", "-I", default_header_dirs)
+        add_from_flags("CFLAGS", "-I", default_header_dirs)
+        default_header_dirs.extend(
+            os.path.join(_tree, 'include') for _tree in prefixes
+        )
+
+        default_library_dirs = []
+        add_from_flags("LDFLAGS", "-L", default_library_dirs)
+        default_library_dirs.extend(
+            os.path.join(_tree, _arch) for _tree in prefixes
+            for _arch in ('lib64', 'lib'))
+        default_runtime_dirs = default_library_dirs
+
+    elif os.name == 'nt':
+        default_header_dirs = []  # no default, must be given explicitly
+        default_library_dirs = []  # no default, must be given explicitly
+        default_runtime_dirs = [  # look for DLL files in ``%PATH%``
+            _path for _path in os.environ['PATH'].split(';')]
+        # Add the \Windows\system to the runtime list (necessary for Vista)
+        default_runtime_dirs.append('\\windows\\system')
+        # Add the \path_to_python\DLLs and tables package to the list
+        default_runtime_dirs.extend(
+            [os.path.join(sys.prefix, 'Lib\\site-packages\\tables')])
+
+
+    # Gcc 4.0.1 on Mac OS X 10.4 does not seem to include the default
+    # header and library paths.  See ticket #18.
+    if sys.platform.lower().startswith('darwin'):
+        inc_dirs.extend(default_header_dirs)
+        lib_dirs.extend(default_library_dirs)
+
+
+    def _find_file_path(name, locations, prefixes=('',), suffixes=('',)):
+        for prefix in prefixes:
+            for suffix in suffixes:
+                for location in locations:
+                    path = os.path.join(location, prefix + name + suffix)
+                    if os.path.isfile(path):
+                        return path
+        return None
+
+
+    class BasePackage(object):
+        _library_prefixes = []
+        _library_suffixes = []
+        _runtime_prefixes = []
+        _runtime_suffixes = []
+        _component_dirs = []
+
+        def __init__(self, name, tag, header_name, library_name,
+                    target_function=None):
+            self.name = name
+            self.tag = tag
+            self.header_name = header_name
+            self.library_name = library_name
+            self.runtime_name = library_name
+            self.target_function = target_function
+
+        def find_header_path(self, locations=default_header_dirs):
+            return _find_file_path(self.header_name, locations, suffixes=['.h'])
+
+        def find_library_path(self, locations=default_library_dirs):
+            return _find_file_path(
+                self.library_name, locations,
+                self._library_prefixes, self._library_suffixes)
+
+        def find_runtime_path(self, locations=default_runtime_dirs):
+            """
+            returns True if the runtime can be found
+            returns None otherwise
+            """
+            # An explicit path can not be provided for runtime libraries.
+            # (The argument is accepted for compatibility with previous methods.)
+
+            # dlopen() won't tell us where the file is, just whether
+            # success occurred, so this returns True instead of a filename
+            for prefix in self._runtime_prefixes:
+                for suffix in self._runtime_suffixes:
+                    try:
+                        ctypes.CDLL(prefix + self.runtime_name + suffix)
+                        return True
+                    except OSError:
+                        pass
+
+        def _pkg_config(self, flags):
+            try:
+                cmd = [PKG_CONFIG] + flags.split() + [self.library_name]
+                config = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
+            # subprocess.CalledProcessError is only available in Python >= 2.7
+            # except (OSError, subprocess.CalledProcessError):
+            except Exception:
+                return []
+            else:
+                return config.decode().strip().split()
+
+        def find_directories(self, location, use_pkgconfig=False):
+            dirdata = [
+                (self.header_name, self.find_header_path, default_header_dirs),
+                (self.library_name, self.find_library_path, default_library_dirs),
+                (self.runtime_name, self.find_runtime_path, default_runtime_dirs),
             ]
 
-        if use_pkgconfig:
-            # header
-            pkgconfig_header_dirs = self._pkg_config('--cflags')
-            pkgconfig_header_dirs = [
-                d.lstrip('-I') for d in pkgconfig_header_dirs
-                if d.startswith('-I')
-            ]
-            if pkgconfig_header_dirs:
-                print('* pkg-config header dirs for %s:' % self.name,
-                      ', '.join(pkgconfig_header_dirs))
+            locations = []
+            if location:
+                # The path of a custom install of the package has been
+                # provided, so the directories where the components
+                # (headers, libraries, runtime) are going to be searched
+                # are constructed by appending platform-dependent
+                # component directories to the given path.
+                # Remove leading and trailing '"' chars that can mislead
+                # the finding routines on Windows machines
+                locations = [
+                    os.path.join(location.strip('"'), compdir)
+                    for compdir in self._component_dirs
+                ]
 
-            # library
-            pkgconfig_library_dirs = self._pkg_config('--libs-only-L')
-            pkgconfig_library_dirs = [
-                d.lstrip('-L') for d in pkgconfig_library_dirs
-                if d.startswith('-L')
-            ]
-            if pkgconfig_library_dirs:
-                print('* pkg-config library dirs for %s:' % self.name,
-                      ', '.join(pkgconfig_library_dirs))
+            if use_pkgconfig:
+                # header
+                pkgconfig_header_dirs = self._pkg_config('--cflags')
+                pkgconfig_header_dirs = [
+                    d.lstrip('-I') for d in pkgconfig_header_dirs
+                    if d.startswith('-I')
+                ]
+                if pkgconfig_header_dirs:
+                    print('* pkg-config header dirs for %s:' % self.name,
+                        ', '.join(pkgconfig_header_dirs))
 
-            # runtime
-            pkgconfig_runtime_dirs = pkgconfig_library_dirs
+                # library
+                pkgconfig_library_dirs = self._pkg_config('--libs-only-L')
+                pkgconfig_library_dirs = [
+                    d.lstrip('-L') for d in pkgconfig_library_dirs
+                    if d.startswith('-L')
+                ]
+                if pkgconfig_library_dirs:
+                    print('* pkg-config library dirs for %s:' % self.name,
+                        ', '.join(pkgconfig_library_dirs))
 
-            pkgconfig_dirs = [
-                pkgconfig_header_dirs,
-                pkgconfig_library_dirs,
-                pkgconfig_runtime_dirs,
-            ]
-        else:
-            pkgconfig_dirs = [None, None, None]
+                # runtime
+                pkgconfig_runtime_dirs = pkgconfig_library_dirs
 
-        directories = [None, None, None]  # headers, libraries, runtime
-        for idx, (name, find_path, default_dirs) in enumerate(dirdata):
-            path = find_path(locations or pkgconfig_dirs[idx] or default_dirs)
-            if path:
-                if path is True:
-                    directories[idx] = True
-                    continue
+                pkgconfig_dirs = [
+                    pkgconfig_header_dirs,
+                    pkgconfig_library_dirs,
+                    pkgconfig_runtime_dirs,
+                ]
+            else:
+                pkgconfig_dirs = [None, None, None]
 
-                # Take care of not returning a directory component
-                # included in the name.  For instance, if name is
-                # 'foo/bar' and path is '/path/foo/bar.h', do *not*
-                # take '/path/foo', but just '/path'.  This also works
-                # for name 'libfoo.so' and path '/path/libfoo.so'.
-                # This has been modified to just work over include files.
-                # For libraries, its names can be something like 'bzip2'
-                # and if they are located in places like:
-                #  \stuff\bzip2-1.0.3\lib\bzip2.lib
-                # then, the directory will be returned as '\stuff' (!!)
-                # F. Alted 2006-02-16
-                if idx == 0:
-                    directories[idx] = os.path.dirname(path[:path.rfind(name)])
-                else:
-                    directories[idx] = os.path.dirname(path)
+            directories = [None, None, None]  # headers, libraries, runtime
+            for idx, (name, find_path, default_dirs) in enumerate(dirdata):
+                path = find_path(locations or pkgconfig_dirs[idx] or default_dirs)
+                if path:
+                    if path is True:
+                        directories[idx] = True
+                        continue
 
-        return tuple(directories)
+                    # Take care of not returning a directory component
+                    # included in the name.  For instance, if name is
+                    # 'foo/bar' and path is '/path/foo/bar.h', do *not*
+                    # take '/path/foo', but just '/path'.  This also works
+                    # for name 'libfoo.so' and path '/path/libfoo.so'.
+                    # This has been modified to just work over include files.
+                    # For libraries, its names can be something like 'bzip2'
+                    # and if they are located in places like:
+                    #  \stuff\bzip2-1.0.3\lib\bzip2.lib
+                    # then, the directory will be returned as '\stuff' (!!)
+                    # F. Alted 2006-02-16
+                    if idx == 0:
+                        directories[idx] = os.path.dirname(path[:path.rfind(name)])
+                    else:
+                        directories[idx] = os.path.dirname(path)
 
-
-class PosixPackage(BasePackage):
-    _library_prefixes = ['lib']
-    _library_suffixes = ['.so', '.dylib', '.a']
-    _runtime_prefixes = _library_prefixes
-    _runtime_suffixes = ['.so', '.dylib']
-    _component_dirs = ['include', 'lib', 'lib64']
-
-
-class WindowsPackage(BasePackage):
-    _library_prefixes = ['']
-    _library_suffixes = ['.lib']
-    _runtime_prefixes = ['']
-    _runtime_suffixes = ['.dll']
-
-    # lookup in '.' seems necessary for LZO2
-    _component_dirs = ['include', 'lib', 'dll', 'bin', '.']
-
-    def find_runtime_path(self, locations=default_runtime_dirs):
-        # An explicit path can not be provided for runtime libraries.
-        # (The argument is accepted for compatibility with previous methods.)
-        return _find_file_path(
-            self.runtime_name, default_runtime_dirs,
-            self._runtime_prefixes, self._runtime_suffixes)
+            return tuple(directories)
 
 
-# Get the HDF5 version provided the 'H5public.h' header
-def get_hdf5_version(headername):
-    major_version = -1
-    minor_version = -1
-    release_version = -1
-    with open(headername) as fd:
-        for line in fd:
-            if 'H5_VERS_MAJOR' in line:
+    class PosixPackage(BasePackage):
+        _library_prefixes = ['lib']
+        _library_suffixes = ['.so', '.dylib', '.a']
+        _runtime_prefixes = _library_prefixes
+        _runtime_suffixes = ['.so', '.dylib']
+        _component_dirs = ['include', 'lib', 'lib64']
+
+
+    class WindowsPackage(BasePackage):
+        _library_prefixes = ['']
+        _library_suffixes = ['.lib']
+        _runtime_prefixes = ['']
+        _runtime_suffixes = ['.dll']
+
+        # lookup in '.' seems necessary for LZO2
+        _component_dirs = ['include', 'lib', 'dll', 'bin', '.']
+
+        def find_runtime_path(self, locations=default_runtime_dirs):
+            # An explicit path can not be provided for runtime libraries.
+            # (The argument is accepted for compatibility with previous methods.)
+            return _find_file_path(
+                self.runtime_name, default_runtime_dirs,
+                self._runtime_prefixes, self._runtime_suffixes)
+
+
+    # Get the HDF5 version provided the 'H5public.h' header
+    def get_hdf5_version(headername):
+        major_version = -1
+        minor_version = -1
+        release_version = -1
+        with open(headername) as fd:
+            for line in fd:
+                if 'H5_VERS_MAJOR' in line:
+                    major_version = int(re.split("\s+", line)[2])
+                if 'H5_VERS_MINOR' in line:
+                    minor_version = int(re.split("\s+", line)[2])
+                if 'H5_VERS_RELEASE' in line:
+                    release_version = int(re.split("\s+", line)[2])
+                if (major_version != -1 and minor_version != -1 and
+                        release_version != -1):
+                    break
+        if (major_version == -1 or minor_version == -1 or
+                release_version == -1):
+            exit_with_error("Unable to detect HDF5 library version!")
+        return LooseVersion("%s.%s.%s" % (major_version, minor_version,
+                                        release_version))
+
+
+    # Get the Blosc version provided the 'blosc.h' header
+    def get_blosc_version(headername):
+        major_version = -1
+        minor_version = -1
+        release_version = -1
+        for line in open(headername):
+            if 'BLOSC_VERSION_MAJOR' in line:
                 major_version = int(re.split("\s+", line)[2])
-            if 'H5_VERS_MINOR' in line:
+            if 'BLOSC_VERSION_MINOR' in line:
                 minor_version = int(re.split("\s+", line)[2])
-            if 'H5_VERS_RELEASE' in line:
+            if 'BLOSC_VERSION_RELEASE' in line:
                 release_version = int(re.split("\s+", line)[2])
             if (major_version != -1 and minor_version != -1 and
                     release_version != -1):
                 break
-    if (major_version == -1 or minor_version == -1 or
-            release_version == -1):
-        exit_with_error("Unable to detect HDF5 library version!")
-    return LooseVersion("%s.%s.%s" % (major_version, minor_version,
-                                      release_version))
+        if (major_version == -1 or minor_version == -1 or
+                release_version == -1):
+            exit_with_error("Unable to detect Blosc library version!")
+        return "%s.%s.%s" % (major_version, minor_version, release_version)
 
 
-# Get the Blosc version provided the 'blosc.h' header
-def get_blosc_version(headername):
-    major_version = -1
-    minor_version = -1
-    release_version = -1
-    for line in open(headername):
-        if 'BLOSC_VERSION_MAJOR' in line:
-            major_version = int(re.split("\s+", line)[2])
-        if 'BLOSC_VERSION_MINOR' in line:
-            minor_version = int(re.split("\s+", line)[2])
-        if 'BLOSC_VERSION_RELEASE' in line:
-            release_version = int(re.split("\s+", line)[2])
-        if (major_version != -1 and minor_version != -1 and
-                release_version != -1):
-            break
-    if (major_version == -1 or minor_version == -1 or
-            release_version == -1):
-        exit_with_error("Unable to detect Blosc library version!")
-    return "%s.%s.%s" % (major_version, minor_version, release_version)
+    _cp = convert_path
+    if os.name == 'posix':
+        _Package = PosixPackage
+        _platdep = {  # package tag -> platform-dependent components
+            'HDF5': ['hdf5'],
+            'LZO2': ['lzo2'],
+            'LZO': ['lzo'],
+            'BZ2': ['bz2'],
+            'BLOSC': ['blosc'],
+        }
 
+    elif os.name == 'nt':
+        _Package = WindowsPackage
+        _platdep = {  # package tag -> platform-dependent components
+            'HDF5': ['hdf5', 'hdf5'],
+            'LZO2': ['lzo2', 'lzo2'],
+            'LZO': ['liblzo', 'lzo1'],
+            'BZ2': ['bzip2', 'bzip2'],
+            'BLOSC': ['blosc', 'blosc'],
+        }
 
-_cp = convert_path
-if os.name == 'posix':
-    _Package = PosixPackage
-    _platdep = {  # package tag -> platform-dependent components
-        'HDF5': ['hdf5'],
-        'LZO2': ['lzo2'],
-        'LZO': ['lzo'],
-        'BZ2': ['bz2'],
-        'BLOSC': ['blosc'],
-    }
+        # Copy the next DLL's to binaries by default.
+        try:
+            # We define BUILDWHEEL in appveyor.yml
+            # include zlib from conda:
+            if os.environ['APPVEYOR'] and os.environ['BUILDWHEEL']:
+                # Conda HDF5 is linked to zlib.dll (from conda package zlib)
+                # but szip.dll is not included in conda
+                dll_files = [os.environ['CONDA_PREFIX']+'\\Library\\bin\\zlib.dll']
+        except KeyError:
+            # Update these paths for your own system!
+            dll_files = [
+                    # '\\windows\\system\\zlib1.dll',
+                    # '\\windows\\system\\szip.dll',
+                    ]
 
-elif os.name == 'nt':
-    _Package = WindowsPackage
-    _platdep = {  # package tag -> platform-dependent components
-        'HDF5': ['hdf5', 'hdf5'],
-        'LZO2': ['lzo2', 'lzo2'],
-        'LZO': ['liblzo', 'lzo1'],
-        'BZ2': ['bzip2', 'bzip2'],
-        'BLOSC': ['blosc', 'blosc'],
-    }
+        if debug:
+            _platdep['HDF5'] = ['hdf5_D', 'hdf5_D']
 
-    # Copy the next DLL's to binaries by default.
-    try:
-        # We define BUILDWHEEL in appveyor.yml
-        # include zlib from conda:
-        if os.environ['APPVEYOR'] and os.environ['BUILDWHEEL']:
-            # Conda HDF5 is linked to zlib.dll (from conda package zlib)
-            # but szip.dll is not included in conda
-            dll_files = [os.environ['CONDA_PREFIX']+'\\Library\\bin\\zlib.dll']
-    except KeyError:
-        # Update these paths for your own system!
-        dll_files = [
-                 # '\\windows\\system\\zlib1.dll',
-                 # '\\windows\\system\\szip.dll',
-                 ]
-
-    if debug:
-        _platdep['HDF5'] = ['hdf5_D', 'hdf5_D']
-
-else:
-    _Package = None
-    _platdep = {}
-    exit_with_error('Unsupported OS: %s' % os.name)
-
-
-hdf5_package = _Package("HDF5", 'HDF5', 'H5public', *_platdep['HDF5'])
-hdf5_package.target_function = 'H5close'
-lzo2_package = _Package("LZO 2", 'LZO2', _cp('lzo/lzo1x'), *_platdep['LZO2'])
-lzo2_package.target_function = 'lzo_version_date'
-lzo1_package = _Package("LZO 1", 'LZO', 'lzo1x', *_platdep['LZO'])
-lzo1_package.target_function = 'lzo_version_date'
-bzip2_package = _Package("bzip2", 'BZ2', 'bzlib', *_platdep['BZ2'])
-bzip2_package.target_function = 'BZ2_bzlibVersion'
-blosc_package = _Package("blosc", 'BLOSC', 'blosc', *_platdep['BLOSC'])
-blosc_package.target_function = 'blosc_list_compressors'  # Blosc >= 1.3
-
-
-# -----------------------------------------------------------------
-
-def_macros = [('NDEBUG', 1)]
-# Define macros for Windows platform
-if os.name == 'nt':
-    def_macros.append(('WIN32', 1))
-    def_macros.append(('_HDF5USEDLL_', 1))
-    def_macros.append(('H5_BUILT_AS_DYNAMIC_LIB', 1))
-
-# Allow setting the HDF5 dir and additional link flags either in
-# the environment or on the command line.
-# First check the environment...
-HDF5_DIR = os.environ.get('HDF5_DIR', '')
-LZO_DIR = os.environ.get('LZO_DIR', '')
-BZIP2_DIR = os.environ.get('BZIP2_DIR', '')
-BLOSC_DIR = os.environ.get('BLOSC_DIR', '')
-LFLAGS = os.environ.get('LFLAGS', '').split()
-# in GCC-style compilers, -w in extra flags will get rid of copious
-# 'uninitialized variable' Cython warnings. However, this shouldn't be
-# the default as it will suppress *all* the warnings, which definitely
-# is not a good idea.
-CFLAGS = os.environ.get('CFLAGS', '').split()
-LIBS = os.environ.get('LIBS', '').split()
-CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
-# We start using pkg-config since some distributions are putting HDF5
-# (and possibly other libraries) in exotic locations.  See issue #442.
-if distutils.spawn.find_executable(PKG_CONFIG):
-    USE_PKGCONFIG = os.environ.get('USE_PKGCONFIG', 'TRUE')
-else:
-    USE_PKGCONFIG = 'FALSE'
-
-# ...then the command line.
-# Handle --hdf5=[PATH] --lzo=[PATH] --bzip2=[PATH] --blosc=[PATH]
-# --lflags=[FLAGS] --cflags=[FLAGS] and --debug
-args = sys.argv[:]
-for arg in args:
-    if arg.find('--hdf5=') == 0:
-        HDF5_DIR = expanduser(arg.split('=')[1])
-        sys.argv.remove(arg)
-    elif arg.find('--lzo=') == 0:
-        LZO_DIR = expanduser(arg.split('=')[1])
-        sys.argv.remove(arg)
-    elif arg.find('--bzip2=') == 0:
-        BZIP2_DIR = expanduser(arg.split('=')[1])
-        sys.argv.remove(arg)
-    elif arg.find('--blosc=') == 0:
-        BLOSC_DIR = expanduser(arg.split('=')[1])
-        sys.argv.remove(arg)
-    elif arg.find('--lflags=') == 0:
-        LFLAGS = arg.split('=')[1].split()
-        sys.argv.remove(arg)
-    elif arg.find('--cflags=') == 0:
-        CFLAGS = arg.split('=')[1].split()
-        sys.argv.remove(arg)
-    elif arg.find('--debug') == 0:
-        # For debugging (mainly compression filters)
-        if os.name != 'nt':  # to prevent including dlfcn.h by utils.c!!!
-            def_macros = [('DEBUG', 1)]
-        # Don't delete this argument. It maybe useful for distutils
-        # when adding more flags later on
-        # sys.argv.remove(arg)
-    elif arg.find('--use-pkgconfig') == 0:
-        USE_PKGCONFIG = arg.split('=')[1]
-        CONDA_PREFIX = ''
-        sys.argv.remove(arg)
-    elif arg.find('--no-conda') == 0:
-        CONDA_PREFIX = ''
-        sys.argv.remove(arg)
-
-USE_PKGCONFIG = True if USE_PKGCONFIG.upper() == 'TRUE' else False
-print('* USE_PKGCONFIG:', USE_PKGCONFIG)
-
-
-# For windows, search for the hdf5 dll in the path and use it if found.
-# This is much more convenient than having to manually set an environment
-# variable to rebuild pytables
-if not HDF5_DIR and os.name == 'nt':
-    import ctypes.util
-    if not debug:
-        libdir = (ctypes.util.find_library('hdf5.dll') or
-                  ctypes.util.find_library('hdf5dll.dll'))
     else:
-        libdir = (ctypes.util.find_library('hdf5_D.dll') or
-                  ctypes.util.find_library('hdf5ddll.dll'))
-    # Like 'C:\\Program Files\\HDF Group\\HDF5\\1.8.8\\bin\\hdf5dll.dll'
-    if libdir:
-        # Strip off the filename
-        libdir = os.path.dirname(libdir)
-        # Strip off the 'bin' directory
-        HDF5_DIR = os.path.dirname(libdir)
-        print("* Found HDF5 using system PATH ('%s')" % libdir)
+        _Package = None
+        _platdep = {}
+        exit_with_error('Unsupported OS: %s' % os.name)
 
 
-if CONDA_PREFIX:
-    print('* Found conda env: ``%s``' % CONDA_PREFIX)
+    hdf5_package = _Package("HDF5", 'HDF5', 'H5public', *_platdep['HDF5'])
+    hdf5_package.target_function = 'H5close'
+    lzo2_package = _Package("LZO 2", 'LZO2', _cp('lzo/lzo1x'), *_platdep['LZO2'])
+    lzo2_package.target_function = 'lzo_version_date'
+    lzo1_package = _Package("LZO 1", 'LZO', 'lzo1x', *_platdep['LZO'])
+    lzo1_package.target_function = 'lzo_version_date'
+    bzip2_package = _Package("bzip2", 'BZ2', 'bzlib', *_platdep['BZ2'])
+    bzip2_package.target_function = 'BZ2_bzlibVersion'
+    blosc_package = _Package("blosc", 'BLOSC', 'blosc', *_platdep['BLOSC'])
+    blosc_package.target_function = 'blosc_list_compressors'  # Blosc >= 1.3
+
+
+    # -----------------------------------------------------------------
+
+    def_macros = [('NDEBUG', 1)]
+    # Define macros for Windows platform
     if os.name == 'nt':
-        CONDA_PREFIX += '\\Library'
+        def_macros.append(('WIN32', 1))
+        def_macros.append(('_HDF5USEDLL_', 1))
+        def_macros.append(('H5_BUILT_AS_DYNAMIC_LIB', 1))
 
-# The next flag for the C compiler is needed for finding the C headers for
-# the Cython extensions
-CFLAGS.append("-Isrc")
-
-# Force the 1.8.x HDF5 API even if the library as been compiled to use the
-# 1.6.x API by default
-CFLAGS.extend([
-    "-DH5_USE_18_API",
-    "-DH5Acreate_vers=2",
-    "-DH5Aiterate_vers=2",
-    "-DH5Dcreate_vers=2",
-    "-DH5Dopen_vers=2",
-    "-DH5Eclear_vers=2",
-    "-DH5Eprint_vers=2",
-    "-DH5Epush_vers=2",
-    "-DH5Eset_auto_vers=2",
-    "-DH5Eget_auto_vers=2",
-    "-DH5Ewalk_vers=2",
-    "-DH5E_auto_t_vers=2",
-    "-DH5Gcreate_vers=2",
-    "-DH5Gopen_vers=2",
-    "-DH5Pget_filter_vers=2",
-    "-DH5Pget_filter_by_id_vers=2",
-    # "-DH5Pinsert_vers=2",
-    # "-DH5Pregister_vers=2",
-    # "-DH5Rget_obj_type_vers=2",
-    "-DH5Tarray_create_vers=2",
-    # "-DH5Tcommit_vers=2",
-    "-DH5Tget_array_dims_vers=2",
-    # "-DH5Topen_vers=2",
-    "-DH5Z_class_t_vers=2",
-])
-# H5Oget_info_by_name seems to have performance issues (see gh-402), so we
-# need to use teh deprecated H5Gget_objinfo function
-# CFLAGS.append("-DH5_NO_DEPRECATED_SYMBOLS")
-
-# Do not use numpy deprecated API
-# CFLAGS.append("-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
-
-# Try to locate the compulsory and optional libraries.
-lzo2_enabled = False
-compiler = new_compiler()
-for (package, location) in [(hdf5_package, HDF5_DIR),
-                            (lzo2_package, LZO_DIR),
-                            (lzo1_package, LZO_DIR),
-                            (bzip2_package, BZIP2_DIR),
-                            (blosc_package, BLOSC_DIR)]:
-
-    if package.tag == 'LZO' and lzo2_enabled:
-        print("* Skipping detection of %s since %s has already been found."
-              % (lzo1_package.name, lzo2_package.name))
-        continue  # do not use LZO 1 if LZO 2 is available
-
-    # if a package location is not specified, try to find it in conda env
-    if not location and CONDA_PREFIX:
-        location = CONDA_PREFIX
-
-    # looking for lzo/lzo1x.h but pkgconfig already returns '/usr/include/lzo'
-    use_pkgconfig = USE_PKGCONFIG if package.tag != 'LZO2' else False
-
-    (hdrdir, libdir, rundir) = package.find_directories(
-        location, use_pkgconfig=use_pkgconfig)
-
-    # check if HDF5 library uses old DLL naming scheme
-    if hdrdir and package.tag == 'HDF5':
-        hdf5_header = os.path.join(hdrdir, "H5public.h")
-        hdf5_version = get_hdf5_version(hdf5_header)
-        if hdf5_version < min_hdf5_version:
-            exit_with_error(
-                "Unsupported HDF5 version! HDF5 v%s+ required. "
-                "Found version v%s" % (min_hdf5_version, hdf5_version))
-
-        if os.name == 'nt' and hdf5_version < "1.8.10":
-            # Change in DLL naming happened in 1.8.10
-            hdf5_old_dll_name = 'hdf5dll' if not debug else 'hdf5ddll'
-            package.library_name = hdf5_old_dll_name
-            package.runtime_name = hdf5_old_dll_name
-            _platdep['HDF5'] = [hdf5_old_dll_name, hdf5_old_dll_name]
-            _, libdir, rundir = package.find_directories(
-                location, use_pkgconfig=USE_PKGCONFIG)
-
-    # check if the library is in the standard compiler paths
-    if not libdir and package.target_function:
-        libdir = compiler.has_function(package.target_function,
-                                       libraries=(package.library_name,))
-
-    if not (hdrdir and libdir):
-        if package.tag in ['HDF5']:  # these are compulsory!
-            pname, ptag = package.name, package.tag
-            exit_with_error(
-                "Could not find a local %s installation." % pname,
-                "You may need to explicitly state "
-                "where your local %(name)s headers and library can be found "
-                "by setting the ``%(tag)s_DIR`` environment variable "
-                "or by using the ``--%(ltag)s`` command-line option."
-                % dict(name=pname, tag=ptag, ltag=ptag.lower()))
-        if package.tag == 'BLOSC':  # this is optional, but comes with sources
-            print("* Could not find %s headers and library; "
-                  "using internal sources." % package.name)
-        else:
-            print("* Could not find %s headers and library; "
-                  "disabling support for it." % package.name)
-
-        continue  # look for the next library
-
-    if libdir in ("", True):
-        print("* Found %s headers at ``%s``, the library is located in the "
-              "standard system search dirs." % (package.name, hdrdir))
+    # Allow setting the HDF5 dir and additional link flags either in
+    # the environment or on the command line.
+    # First check the environment...
+    HDF5_DIR = os.environ.get('HDF5_DIR', '')
+    LZO_DIR = os.environ.get('LZO_DIR', '')
+    BZIP2_DIR = os.environ.get('BZIP2_DIR', '')
+    BLOSC_DIR = os.environ.get('BLOSC_DIR', '')
+    LFLAGS = os.environ.get('LFLAGS', '').split()
+    # in GCC-style compilers, -w in extra flags will get rid of copious
+    # 'uninitialized variable' Cython warnings. However, this shouldn't be
+    # the default as it will suppress *all* the warnings, which definitely
+    # is not a good idea.
+    CFLAGS = os.environ.get('CFLAGS', '').split()
+    LIBS = os.environ.get('LIBS', '').split()
+    CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+    # We start using pkg-config since some distributions are putting HDF5
+    # (and possibly other libraries) in exotic locations.  See issue #442.
+    if distutils.spawn.find_executable(PKG_CONFIG):
+        USE_PKGCONFIG = os.environ.get('USE_PKGCONFIG', 'TRUE')
     else:
-        print("* Found %s headers at ``%s``, library at ``%s``."
-              % (package.name, hdrdir, libdir))
+        USE_PKGCONFIG = 'FALSE'
 
-    if hdrdir not in default_header_dirs:
-        inc_dirs.append(hdrdir)  # save header directory if needed
-    if libdir not in default_library_dirs and libdir not in ("", True):
-        # save library directory if needed
-        if os.name == "nt":
-            # Important to quote the libdir for Windows (Vista) systems
-            lib_dirs.append('"%s"' % libdir)
+    # ...then the command line.
+    # Handle --hdf5=[PATH] --lzo=[PATH] --bzip2=[PATH] --blosc=[PATH]
+    # --lflags=[FLAGS] --cflags=[FLAGS] and --debug
+    args = sys.argv[:]
+    for arg in args:
+        if arg.find('--hdf5=') == 0:
+            HDF5_DIR = expanduser(arg.split('=')[1])
+            sys.argv.remove(arg)
+        elif arg.find('--lzo=') == 0:
+            LZO_DIR = expanduser(arg.split('=')[1])
+            sys.argv.remove(arg)
+        elif arg.find('--bzip2=') == 0:
+            BZIP2_DIR = expanduser(arg.split('=')[1])
+            sys.argv.remove(arg)
+        elif arg.find('--blosc=') == 0:
+            BLOSC_DIR = expanduser(arg.split('=')[1])
+            sys.argv.remove(arg)
+        elif arg.find('--lflags=') == 0:
+            LFLAGS = arg.split('=')[1].split()
+            sys.argv.remove(arg)
+        elif arg.find('--cflags=') == 0:
+            CFLAGS = arg.split('=')[1].split()
+            sys.argv.remove(arg)
+        elif arg.find('--debug') == 0:
+            # For debugging (mainly compression filters)
+            if os.name != 'nt':  # to prevent including dlfcn.h by utils.c!!!
+                def_macros = [('DEBUG', 1)]
+            # Don't delete this argument. It maybe useful for distutils
+            # when adding more flags later on
+            # sys.argv.remove(arg)
+        elif arg.find('--use-pkgconfig') == 0:
+            USE_PKGCONFIG = arg.split('=')[1]
+            CONDA_PREFIX = ''
+            sys.argv.remove(arg)
+        elif arg.find('--no-conda') == 0:
+            CONDA_PREFIX = ''
+            sys.argv.remove(arg)
+
+    USE_PKGCONFIG = True if USE_PKGCONFIG.upper() == 'TRUE' else False
+    print('* USE_PKGCONFIG:', USE_PKGCONFIG)
+
+
+    # For windows, search for the hdf5 dll in the path and use it if found.
+    # This is much more convenient than having to manually set an environment
+    # variable to rebuild pytables
+    if not HDF5_DIR and os.name == 'nt':
+        import ctypes.util
+        if not debug:
+            libdir = (ctypes.util.find_library('hdf5.dll') or
+                    ctypes.util.find_library('hdf5dll.dll'))
         else:
-            lib_dirs.append(libdir)
+            libdir = (ctypes.util.find_library('hdf5_D.dll') or
+                    ctypes.util.find_library('hdf5ddll.dll'))
+        # Like 'C:\\Program Files\\HDF Group\\HDF5\\1.8.8\\bin\\hdf5dll.dll'
+        if libdir:
+            # Strip off the filename
+            libdir = os.path.dirname(libdir)
+            # Strip off the 'bin' directory
+            HDF5_DIR = os.path.dirname(libdir)
+            print("* Found HDF5 using system PATH ('%s')" % libdir)
 
-    if package.tag not in ['HDF5']:
-        # Keep record of the optional libraries found.
-        optional_libs.append(package.tag)
-        def_macros.append(('HAVE_%s_LIB' % package.tag, 1))
 
-    if hdrdir and package.tag == 'BLOSC':
-        blosc_header = os.path.join(hdrdir, "blosc.h")
-        blosc_version = get_blosc_version(blosc_header)
-        if blosc_version < min_blosc_version:
-            optional_libs.pop()  # Remove Blosc from the discovered libs
+    if CONDA_PREFIX:
+        print('* Found conda env: ``%s``' % CONDA_PREFIX)
+        if os.name == 'nt':
+            CONDA_PREFIX += '\\Library'
+
+    # The next flag for the C compiler is needed for finding the C headers for
+    # the Cython extensions
+    CFLAGS.append("-Isrc")
+
+    # Force the 1.8.x HDF5 API even if the library as been compiled to use the
+    # 1.6.x API by default
+    CFLAGS.extend([
+        "-DH5_USE_18_API",
+        "-DH5Acreate_vers=2",
+        "-DH5Aiterate_vers=2",
+        "-DH5Dcreate_vers=2",
+        "-DH5Dopen_vers=2",
+        "-DH5Eclear_vers=2",
+        "-DH5Eprint_vers=2",
+        "-DH5Epush_vers=2",
+        "-DH5Eset_auto_vers=2",
+        "-DH5Eget_auto_vers=2",
+        "-DH5Ewalk_vers=2",
+        "-DH5E_auto_t_vers=2",
+        "-DH5Gcreate_vers=2",
+        "-DH5Gopen_vers=2",
+        "-DH5Pget_filter_vers=2",
+        "-DH5Pget_filter_by_id_vers=2",
+        # "-DH5Pinsert_vers=2",
+        # "-DH5Pregister_vers=2",
+        # "-DH5Rget_obj_type_vers=2",
+        "-DH5Tarray_create_vers=2",
+        # "-DH5Tcommit_vers=2",
+        "-DH5Tget_array_dims_vers=2",
+        # "-DH5Topen_vers=2",
+        "-DH5Z_class_t_vers=2",
+    ])
+    # H5Oget_info_by_name seems to have performance issues (see gh-402), so we
+    # need to use teh deprecated H5Gget_objinfo function
+    # CFLAGS.append("-DH5_NO_DEPRECATED_SYMBOLS")
+
+    # Do not use numpy deprecated API
+    # CFLAGS.append("-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
+
+    # Try to locate the compulsory and optional libraries.
+    lzo2_enabled = False
+    compiler = new_compiler()
+    for (package, location) in [(hdf5_package, HDF5_DIR),
+                                (lzo2_package, LZO_DIR),
+                                (lzo1_package, LZO_DIR),
+                                (bzip2_package, BZIP2_DIR),
+                                (blosc_package, BLOSC_DIR)]:
+
+        if package.tag == 'LZO' and lzo2_enabled:
+            print("* Skipping detection of %s since %s has already been found."
+                % (lzo1_package.name, lzo2_package.name))
+            continue  # do not use LZO 1 if LZO 2 is available
+
+        # if a package location is not specified, try to find it in conda env
+        if not location and CONDA_PREFIX:
+            location = CONDA_PREFIX
+
+        # looking for lzo/lzo1x.h but pkgconfig already returns '/usr/include/lzo'
+        use_pkgconfig = USE_PKGCONFIG if package.tag != 'LZO2' else False
+
+        (hdrdir, libdir, rundir) = package.find_directories(
+            location, use_pkgconfig=use_pkgconfig)
+
+        # check if HDF5 library uses old DLL naming scheme
+        if hdrdir and package.tag == 'HDF5':
+            hdf5_header = os.path.join(hdrdir, "H5public.h")
+            hdf5_version = get_hdf5_version(hdf5_header)
+            if hdf5_version < min_hdf5_version:
+                exit_with_error(
+                    "Unsupported HDF5 version! HDF5 v%s+ required. "
+                    "Found version v%s" % (min_hdf5_version, hdf5_version))
+
+            if os.name == 'nt' and hdf5_version < "1.8.10":
+                # Change in DLL naming happened in 1.8.10
+                hdf5_old_dll_name = 'hdf5dll' if not debug else 'hdf5ddll'
+                package.library_name = hdf5_old_dll_name
+                package.runtime_name = hdf5_old_dll_name
+                _platdep['HDF5'] = [hdf5_old_dll_name, hdf5_old_dll_name]
+                _, libdir, rundir = package.find_directories(
+                    location, use_pkgconfig=USE_PKGCONFIG)
+
+        # check if the library is in the standard compiler paths
+        if not libdir and package.target_function:
+            libdir = compiler.has_function(package.target_function,
+                                        libraries=(package.library_name,))
+
+        if not (hdrdir and libdir):
+            if package.tag in ['HDF5']:  # these are compulsory!
+                pname, ptag = package.name, package.tag
+                exit_with_error(
+                    "Could not find a local %s installation." % pname,
+                    "You may need to explicitly state "
+                    "where your local %(name)s headers and library can be found "
+                    "by setting the ``%(tag)s_DIR`` environment variable "
+                    "or by using the ``--%(ltag)s`` command-line option."
+                    % dict(name=pname, tag=ptag, ltag=ptag.lower()))
+            if package.tag == 'BLOSC':  # this is optional, but comes with sources
+                print("* Could not find %s headers and library; "
+                    "using internal sources." % package.name)
+            else:
+                print("* Could not find %s headers and library; "
+                    "disabling support for it." % package.name)
+
+            continue  # look for the next library
+
+        if libdir in ("", True):
+            print("* Found %s headers at ``%s``, the library is located in the "
+                "standard system search dirs." % (package.name, hdrdir))
+        else:
+            print("* Found %s headers at ``%s``, library at ``%s``."
+                % (package.name, hdrdir, libdir))
+
+        if hdrdir not in default_header_dirs:
+            inc_dirs.append(hdrdir)  # save header directory if needed
+        if libdir not in default_library_dirs and libdir not in ("", True):
+            # save library directory if needed
+            if os.name == "nt":
+                # Important to quote the libdir for Windows (Vista) systems
+                lib_dirs.append('"%s"' % libdir)
+            else:
+                lib_dirs.append(libdir)
+
+        if package.tag not in ['HDF5']:
+            # Keep record of the optional libraries found.
+            optional_libs.append(package.tag)
+            def_macros.append(('HAVE_%s_LIB' % package.tag, 1))
+
+        if hdrdir and package.tag == 'BLOSC':
+            blosc_header = os.path.join(hdrdir, "blosc.h")
+            blosc_version = get_blosc_version(blosc_header)
+            if blosc_version < min_blosc_version:
+                optional_libs.pop()  # Remove Blosc from the discovered libs
+                print_warning(
+                    "Unsupported Blosc version installed! Blosc %s+ required. "
+                    "Found version %s.  Using internal Blosc sources." % (
+                        min_blosc_version, blosc_version))
+            if blosc_version < min_blosc_bitshuffle_version:
+                print_warning(
+                    "This Blosc version does not support the BitShuffle filter. "
+                    "Minimum desirable version is %s.  Found version: %s" % (
+                        min_blosc_bitshuffle_version, blosc_version))
+
+        if not rundir:
+            loc = {
+                'posix': "the default library paths.",
+                'nt': "any of the directories in %%PATH%%.",
+            }[os.name]
+
             print_warning(
-                "Unsupported Blosc version installed! Blosc %s+ required. "
-                "Found version %s.  Using internal Blosc sources." % (
-                    min_blosc_version, blosc_version))
-        if blosc_version < min_blosc_bitshuffle_version:
-            print_warning(
-                "This Blosc version does not support the BitShuffle filter. "
-                "Minimum desirable version is %s.  Found version: %s" % (
-                    min_blosc_bitshuffle_version, blosc_version))
+                "Could not find the %s runtime." % package.name,
+                "The %(name)s shared library was *not* found in %(loc)s "
+                "In case of runtime problems, please remember to install it."
+                % dict(name=package.name, loc=loc)
+            )
 
-    if not rundir:
-        loc = {
-            'posix': "the default library paths.",
-            'nt': "any of the directories in %%PATH%%.",
-        }[os.name]
+        if os.name == "nt":
+            # LZO DLLs cannot be copied to the binary package for license reasons
+            if package.tag not in ['LZO', 'LZO2']:
+                dll_file = _platdep[package.tag][1] + '.dll'
+                # If DLL is not in rundir, do nothing.  This can be useful
+                # for BZIP2, that can be linked either statically (.LIB)
+                # or dinamically (.DLL)
+                if rundir is not None:
+                    dll_files.append(os.path.join(rundir, dll_file))
 
-        print_warning(
-            "Could not find the %s runtime." % package.name,
-            "The %(name)s shared library was *not* found in %(loc)s "
-            "In case of runtime problems, please remember to install it."
-            % dict(name=package.name, loc=loc)
-        )
+        if package.tag == 'LZO2':
+            lzo2_enabled = True
+
+    if lzo2_enabled:
+        lzo_package = lzo2_package
+    else:
+        lzo_package = lzo1_package
+
+    # ------------------------------------------------------------------------------
+
+    cython_extnames = [
+        'utilsextension',
+        'hdf5extension',
+        'tableextension',
+        'linkextension',
+        '_comp_lzo',
+        '_comp_bzip2',
+        'lrucacheextension',
+        'indexesextension',
+    ]
+
+
+    def get_cython_extfiles(extnames):
+        extdir = 'tables'
+        extfiles = {}
+
+        for extname in extnames:
+            extfile = os.path.join(extdir, extname)
+            extpfile = '%s.pyx' % extfile
+            extcfile = '%s.c' % extfile
+
+            if not exists(extcfile) or newer(extpfile, extcfile):
+                # This is the only place where Cython is needed, but every
+                # developer should have it installed, so it should not be
+                # a hard requisite
+                from Cython.Build import cythonize
+                cythonize(extpfile)
+            extfiles[extname] = extcfile
+
+        return extfiles
+
+
+    cython_extfiles = get_cython_extfiles(cython_extnames)
+
+    # Update the version.h file if this file is newer
+    if newer('VERSION', 'src/version.h'):
+        with open('src/version.h', 'w') as fd:
+            fd.write('#define PYTABLES_VERSION "%s"\n' % VERSION)
+
+    # --------------------------------------------------------------------
+
+    # Package information for ``setuptools``
+    # PyTables contains data files for tests.
+    setuptools_kwargs['zip_safe'] = False
+
+    setuptools_kwargs['install_requires'] = requirements
+
+    # Detect packages automatically.
+    setuptools_kwargs['packages'] = find_packages(exclude=['*.bench'])
+
+    # Entry points for automatic creation of scripts.
+    setuptools_kwargs['entry_points'] = {
+        'console_scripts': [
+            'ptdump = tables.scripts.ptdump:main',
+            'ptrepack = tables.scripts.ptrepack:main',
+            'pt2to3 = tables.scripts.pt2to3:main',
+            'pttree = tables.scripts.pttree:main',
+        ],
+    }
+
+    # Test suites.
+    setuptools_kwargs['test_suite'] = 'tables.tests.test_all.suite'
+    setuptools_kwargs['scripts'] = []
+
+    # Copy additional data for packages that need it.
+    setuptools_kwargs['package_data'] = {
+        'tables.tests': ['*.h5', '*.mat'],
+        'tables.nodes.tests': ['*.dat', '*.xbm', '*.h5'],
+    }
+
+
+    # Having the Python version included in the package name makes managing a
+    # system with multiple versions of Python much easier.
+
+    def find_name(base='tables'):
+        """If "--name-with-python-version" is on the command line then
+        append "-pyX.Y" to the base name"""
+        name = base
+        if '--name-with-python-version' in sys.argv:
+            name += '-py%i.%i' % (sys.version_info[0], sys.version_info[1])
+            sys.argv.remove('--name-with-python-version')
+        return name
+
+
+    name = find_name()
 
     if os.name == "nt":
-        # LZO DLLs cannot be copied to the binary package for license reasons
-        if package.tag not in ['LZO', 'LZO2']:
-            dll_file = _platdep[package.tag][1] + '.dll'
-            # If DLL is not in rundir, do nothing.  This can be useful
-            # for BZIP2, that can be linked either statically (.LIB)
-            # or dinamically (.DLL)
-            if rundir is not None:
-                dll_files.append(os.path.join(rundir, dll_file))
+        # Add DLL's to the final package for windows
+        data_files.extend([
+            ('Lib/site-packages/%s' % name, dll_files),
+        ])
 
-    if package.tag == 'LZO2':
-        lzo2_enabled = True
+    ADDLIBS = [hdf5_package.library_name]
 
-if lzo2_enabled:
-    lzo_package = lzo2_package
-else:
-    lzo_package = lzo1_package
+    # List of Blosc file dependencies
+    blosc_sources = ["hdf5-blosc/src/blosc_filter.c"]
+    if 'BLOSC' not in optional_libs:
+        if not os.environ.get('PYTABLES_NO_EMBEDDED_LIBS', None) is None:
+            exit_with_error(
+                "Unable to find the blosc library. "
+                "The embedded copy of the blosc sources can't be used because "
+                "the PYTABLES_NO_EMBEDDED_LIBS environment variable has been "
+                "specified).")
 
-# ------------------------------------------------------------------------------
-
-cython_extnames = [
-    'utilsextension',
-    'hdf5extension',
-    'tableextension',
-    'linkextension',
-    '_comp_lzo',
-    '_comp_bzip2',
-    'lrucacheextension',
-    'indexesextension',
-]
-
-
-def get_cython_extfiles(extnames):
-    extdir = 'tables'
-    extfiles = {}
-
-    for extname in extnames:
-        extfile = os.path.join(extdir, extname)
-        extpfile = '%s.pyx' % extfile
-        extcfile = '%s.c' % extfile
-
-        if not exists(extcfile) or newer(extpfile, extcfile):
-            # This is the only place where Cython is needed, but every
-            # developer should have it installed, so it should not be
-            # a hard requisite
-            from Cython.Build import cythonize
-            cythonize(extpfile)
-        extfiles[extname] = extcfile
-
-    return extfiles
-
-
-cython_extfiles = get_cython_extfiles(cython_extnames)
-
-# Update the version.h file if this file is newer
-if newer('VERSION', 'src/version.h'):
-    with open('src/version.h', 'w') as fd:
-        fd.write('#define PYTABLES_VERSION "%s"\n' % VERSION)
-
-# --------------------------------------------------------------------
-
-# Package information for ``setuptools``
-# PyTables contains data files for tests.
-setuptools_kwargs['zip_safe'] = False
-
-setuptools_kwargs['install_requires'] = requirements
-
-# Detect packages automatically.
-setuptools_kwargs['packages'] = find_packages(exclude=['*.bench'])
-
-# Entry points for automatic creation of scripts.
-setuptools_kwargs['entry_points'] = {
-    'console_scripts': [
-        'ptdump = tables.scripts.ptdump:main',
-        'ptrepack = tables.scripts.ptrepack:main',
-        'pt2to3 = tables.scripts.pt2to3:main',
-        'pttree = tables.scripts.pttree:main',
-    ],
-}
-
-# Test suites.
-setuptools_kwargs['test_suite'] = 'tables.tests.test_all.suite'
-setuptools_kwargs['scripts'] = []
-
-# Copy additional data for packages that need it.
-setuptools_kwargs['package_data'] = {
-    'tables.tests': ['*.h5', '*.mat'],
-    'tables.nodes.tests': ['*.dat', '*.xbm', '*.h5'],
-}
-
-
-# Having the Python version included in the package name makes managing a
-# system with multiple versions of Python much easier.
-
-def find_name(base='tables'):
-    """If "--name-with-python-version" is on the command line then
-    append "-pyX.Y" to the base name"""
-    name = base
-    if '--name-with-python-version' in sys.argv:
-        name += '-py%i.%i' % (sys.version_info[0], sys.version_info[1])
-        sys.argv.remove('--name-with-python-version')
-    return name
-
-
-name = find_name()
-
-if os.name == "nt":
-    # Add DLL's to the final package for windows
-    data_files.extend([
-        ('Lib/site-packages/%s' % name, dll_files),
-    ])
-
-ADDLIBS = [hdf5_package.library_name]
-
-# List of Blosc file dependencies
-blosc_sources = ["hdf5-blosc/src/blosc_filter.c"]
-if 'BLOSC' not in optional_libs:
-    if not os.environ.get('PYTABLES_NO_EMBEDDED_LIBS', None) is None:
-        exit_with_error(
-            "Unable to find the blosc library. "
-            "The embedded copy of the blosc sources can't be used because "
-            "the PYTABLES_NO_EMBEDDED_LIBS environment variable has been "
-            "specified).")
-
-    # Compiling everything from sources
-    # Blosc + BloscLZ sources
-    blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                      if 'avx2' not in f and 'sse2' not in f]
-    # LZ4 sources
-    blosc_sources += glob.glob('c-blosc/internal-complibs/lz4*/*.c')
-    # Snappy sources
-    blosc_sources += glob.glob('c-blosc/internal-complibs/snappy*/*.cc')
-    # Zlib sources
-    blosc_sources += glob.glob('c-blosc/internal-complibs/zlib*/*.c')
-    # Zstd sources
-    blosc_sources += glob.glob('c-blosc/internal-complibs/zstd*/*/*.c')
-    # Finally, add all the include dirs...
-    inc_dirs += [os.path.join('c-blosc', 'blosc')]
-    inc_dirs += glob.glob('c-blosc/internal-complibs/*')
-    inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*/common')
-    inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*')
-    # ...and the macros for all the compressors supported
-    def_macros += [('HAVE_LZ4', 1), ('HAVE_SNAPPY', 1), ('HAVE_ZLIB', 1),
-                   ('HAVE_ZSTD', 1)]
-
-    # Add extra flags for optimizing shuffle in include Blosc
-    def compiler_has_flags(compiler, flags):
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.c',
-                                         delete=False) as fd:
-            fd.write('int main() {return 0;}')
-
-        try:
-            compiler.compile([fd.name], extra_preargs=flags)
-        except Exception:
-            return False
-        else:
-            return True
-        finally:
-            os.remove(fd.name)
-
-    # SSE2
-    if 'sse2' in cpu_flags:
-        print('SSE2 detected')
-        CFLAGS.append('-DSHUFFLE_SSE2_ENABLED')
-        if os.name == 'nt':
-            # Windows always should have support for SSE2
-            # (present in all x86/amd64 architectures since 2003)
-            def_macros += [('__SSE2__', 1)]
-        else:
-            # On UNIX, both gcc and clang understand -msse2
-            CFLAGS.append('-msse2')
+        # Compiling everything from sources
+        # Blosc + BloscLZ sources
         blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                          if 'sse2' in f]
-    # AVX2
-    # Detection code for AVX2 only works for gcc/clang, not for MSVC yet
-    if ('avx2' in cpu_flags and
-            compiler_has_flags(compiler, ["-mavx2"])):
-                print('AVX2 detected')
-                CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
-                CFLAGS.append('-mavx2')
-                blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                                  if 'avx2' in f]
-else:
-    ADDLIBS += ['blosc']
+                        if 'avx2' not in f and 'sse2' not in f]
+        # LZ4 sources
+        blosc_sources += glob.glob('c-blosc/internal-complibs/lz4*/*.c')
+        # Snappy sources
+        blosc_sources += glob.glob('c-blosc/internal-complibs/snappy*/*.cc')
+        # Zlib sources
+        blosc_sources += glob.glob('c-blosc/internal-complibs/zlib*/*.c')
+        # Zstd sources
+        blosc_sources += glob.glob('c-blosc/internal-complibs/zstd*/*/*.c')
+        # Finally, add all the include dirs...
+        inc_dirs += [os.path.join('c-blosc', 'blosc')]
+        inc_dirs += glob.glob('c-blosc/internal-complibs/*')
+        inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*/common')
+        inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*')
+        # ...and the macros for all the compressors supported
+        def_macros += [('HAVE_LZ4', 1), ('HAVE_SNAPPY', 1), ('HAVE_ZLIB', 1),
+                    ('HAVE_ZSTD', 1)]
+
+        # Add extra flags for optimizing shuffle in include Blosc
+        def compiler_has_flags(compiler, flags):
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.c',
+                                            delete=False) as fd:
+                fd.write('int main() {return 0;}')
+
+            try:
+                compiler.compile([fd.name], extra_preargs=flags)
+            except Exception:
+                return False
+            else:
+                return True
+            finally:
+                os.remove(fd.name)
+
+        # SSE2
+        if 'sse2' in cpu_flags:
+            print('SSE2 detected')
+            CFLAGS.append('-DSHUFFLE_SSE2_ENABLED')
+            if os.name == 'nt':
+                # Windows always should have support for SSE2
+                # (present in all x86/amd64 architectures since 2003)
+                def_macros += [('__SSE2__', 1)]
+            else:
+                # On UNIX, both gcc and clang understand -msse2
+                CFLAGS.append('-msse2')
+            blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
+                            if 'sse2' in f]
+        # AVX2
+        # Detection code for AVX2 only works for gcc/clang, not for MSVC yet
+        if ('avx2' in cpu_flags and
+                compiler_has_flags(compiler, ["-mavx2"])):
+                    print('AVX2 detected')
+                    CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
+                    CFLAGS.append('-mavx2')
+                    blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
+                                    if 'avx2' in f]
+    else:
+        ADDLIBS += ['blosc']
 
 
-utilsExtension_libs = LIBS + ADDLIBS
-hdf5Extension_libs = LIBS + ADDLIBS
-tableExtension_libs = LIBS + ADDLIBS
-linkExtension_libs = LIBS + ADDLIBS
-indexesExtension_libs = LIBS + ADDLIBS
-lrucacheExtension_libs = []    # Doesn't need external libraries
+    utilsExtension_libs = LIBS + ADDLIBS
+    hdf5Extension_libs = LIBS + ADDLIBS
+    tableExtension_libs = LIBS + ADDLIBS
+    linkExtension_libs = LIBS + ADDLIBS
+    indexesExtension_libs = LIBS + ADDLIBS
+    lrucacheExtension_libs = []    # Doesn't need external libraries
 
-# Compressor modules only need other libraries if they are enabled.
-_comp_lzo_libs = LIBS[:]
-_comp_bzip2_libs = LIBS[:]
-for (package, complibs) in [(lzo_package, _comp_lzo_libs),
-                            (bzip2_package, _comp_bzip2_libs)]:
+    # Compressor modules only need other libraries if they are enabled.
+    _comp_lzo_libs = LIBS[:]
+    _comp_bzip2_libs = LIBS[:]
+    for (package, complibs) in [(lzo_package, _comp_lzo_libs),
+                                (bzip2_package, _comp_bzip2_libs)]:
 
-    if package.tag in optional_libs:
-        complibs.extend([hdf5_package.library_name, package.library_name])
-
-
-extensions = [
-    Extension("tables.utilsextension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['utilsextension'],
-                       "src/utils.c",
-                       "src/H5ARRAY.c",
-                       "src/H5ATTR.c",
-                       ] + blosc_sources,
-              library_dirs=lib_dirs,
-              libraries=utilsExtension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables.hdf5extension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['hdf5extension'],
-                       "src/utils.c",
-                       "src/typeconv.c",
-                       "src/H5ARRAY.c",
-                       "src/H5ARRAY-opt.c",
-                       "src/H5VLARRAY.c",
-                       "src/H5ATTR.c",
-                       ] + blosc_sources,
-              library_dirs=lib_dirs,
-              libraries=hdf5Extension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables.tableextension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['tableextension'],
-                       "src/utils.c",
-                       "src/typeconv.c",
-                       "src/H5TB-opt.c",
-                       "src/H5ATTR.c",
-                       ] + blosc_sources,
-              library_dirs=lib_dirs,
-              libraries=tableExtension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables._comp_lzo",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['_comp_lzo'],
-                       "src/H5Zlzo.c"],
-              library_dirs=lib_dirs,
-              libraries=_comp_lzo_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables._comp_bzip2",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['_comp_bzip2'],
-                       "src/H5Zbzip2.c"],
-              library_dirs=lib_dirs,
-              libraries=_comp_bzip2_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables.linkextension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['linkextension']],
-              library_dirs=lib_dirs,
-              libraries=tableExtension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables.lrucacheextension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['lrucacheextension']],
-              library_dirs=lib_dirs,
-              libraries=lrucacheExtension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-    Extension("tables.indexesextension",
-              include_dirs=inc_dirs,
-              define_macros=def_macros,
-              sources=[cython_extfiles['indexesextension'],
-                       "src/H5ARRAY-opt.c",
-                       "src/idx-opt.c"],
-              library_dirs=lib_dirs,
-              libraries=indexesExtension_libs,
-              extra_link_args=LFLAGS,
-              extra_compile_args=CFLAGS),
-
-]
+        if package.tag in optional_libs:
+            complibs.extend([hdf5_package.library_name, package.library_name])
 
 
-classifiers = """\
-Development Status :: 5 - Production/Stable
-Intended Audience :: Developers
-Intended Audience :: Information Technology
-Intended Audience :: Science/Research
-License :: OSI Approved :: BSD License
-Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 3
-Topic :: Database
-Topic :: Software Development :: Libraries :: Python Modules
-Operating System :: Microsoft :: Windows
-Operating System :: Unix
-"""
+    extensions = [
+        Extension("tables.utilsextension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['utilsextension'],
+                        "src/utils.c",
+                        "src/H5ARRAY.c",
+                        "src/H5ATTR.c",
+                        ] + blosc_sources,
+                library_dirs=lib_dirs,
+                libraries=utilsExtension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
 
-setup(
-    name=name,
-    version=VERSION,
-    description='Hierarchical datasets for Python',
-    long_description="""\
-PyTables is a package for managing hierarchical datasets and
-designed to efficently cope with extremely large amounts of
-data. PyTables is built on top of the HDF5 library and the
-NumPy package and features an object-oriented interface
-that, combined with C-code generated from Cython sources,
-makes of it a fast, yet extremely easy to use tool for
-interactively save and retrieve large amounts of data.
+        Extension("tables.hdf5extension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['hdf5extension'],
+                        "src/utils.c",
+                        "src/typeconv.c",
+                        "src/H5ARRAY.c",
+                        "src/H5ARRAY-opt.c",
+                        "src/H5VLARRAY.c",
+                        "src/H5ATTR.c",
+                        ] + blosc_sources,
+                library_dirs=lib_dirs,
+                libraries=hdf5Extension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
 
-""",
-    classifiers=[c for c in classifiers.split("\n") if c],
-    author=('Francesc Alted, Ivan Vilata,'
-            'Antonio Valentino, Anthony Scopatz et al.'),
-    author_email='pytables@pytables.org',
-    maintainer='PyTables maintainers',
-    maintainer_email='pytables@pytables.org',
-    url='http://www.pytables.org/',
-    license='BSD 2-Clause',
-    platforms=['any'],
-    ext_modules=extensions,
-    cmdclass=cmdclass,
-    data_files=data_files,
-    extra_require={
-        'doc': [
-            'sphinx >= 1.1',
-            'sphinx_rtd_theme',
-            'numpydoc',
-            'ipython']},
-    **setuptools_kwargs
-)
+        Extension("tables.tableextension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['tableextension'],
+                        "src/utils.c",
+                        "src/typeconv.c",
+                        "src/H5TB-opt.c",
+                        "src/H5ATTR.c",
+                        ] + blosc_sources,
+                library_dirs=lib_dirs,
+                libraries=tableExtension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+        Extension("tables._comp_lzo",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['_comp_lzo'],
+                        "src/H5Zlzo.c"],
+                library_dirs=lib_dirs,
+                libraries=_comp_lzo_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+        Extension("tables._comp_bzip2",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['_comp_bzip2'],
+                        "src/H5Zbzip2.c"],
+                library_dirs=lib_dirs,
+                libraries=_comp_bzip2_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+        Extension("tables.linkextension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['linkextension']],
+                library_dirs=lib_dirs,
+                libraries=tableExtension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+        Extension("tables.lrucacheextension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['lrucacheextension']],
+                library_dirs=lib_dirs,
+                libraries=lrucacheExtension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+        Extension("tables.indexesextension",
+                include_dirs=inc_dirs,
+                define_macros=def_macros,
+                sources=[cython_extfiles['indexesextension'],
+                        "src/H5ARRAY-opt.c",
+                        "src/idx-opt.c"],
+                library_dirs=lib_dirs,
+                libraries=indexesExtension_libs,
+                extra_link_args=LFLAGS,
+                extra_compile_args=CFLAGS),
+
+    ]
+
+
+    classifiers = """\
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 3
+    Topic :: Database
+    Topic :: Software Development :: Libraries :: Python Modules
+    Operating System :: Microsoft :: Windows
+    Operating System :: Unix
+    """
+
+    setup(
+        name=name,
+        version=VERSION,
+        description='Hierarchical datasets for Python',
+        long_description="""\
+    PyTables is a package for managing hierarchical datasets and
+    designed to efficently cope with extremely large amounts of
+    data. PyTables is built on top of the HDF5 library and the
+    NumPy package and features an object-oriented interface
+    that, combined with C-code generated from Cython sources,
+    makes of it a fast, yet extremely easy to use tool for
+    interactively save and retrieve large amounts of data.
+
+    """,
+        classifiers=[c for c in classifiers.split("\n") if c],
+        author=('Francesc Alted, Ivan Vilata,'
+                'Antonio Valentino, Anthony Scopatz et al.'),
+        author_email='pytables@pytables.org',
+        maintainer='PyTables maintainers',
+        maintainer_email='pytables@pytables.org',
+        url='http://www.pytables.org/',
+        license='BSD 2-Clause',
+        platforms=['any'],
+        ext_modules=extensions,
+        cmdclass=cmdclass,
+        data_files=data_files,
+        extra_require={
+            'doc': [
+                'sphinx >= 1.1',
+                'sphinx_rtd_theme',
+                'numpydoc',
+                'ipython']},
+        **setuptools_kwargs
+    )
+    
+elif __name__ == '__mp_main__':
+    pass

--- a/setup.py
+++ b/setup.py
@@ -881,14 +881,15 @@ if __name__ == '__main__':
             blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
                             if 'sse2' in f]
         # AVX2
-        # Detection code for AVX2 only works for gcc/clang, not for MSVC yet
-        if ('avx2' in cpu_flags and
-                compiler_has_flags(compiler, ["-mavx2"])):
-                    print('AVX2 detected')
-                    CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
-                    CFLAGS.append('-mavx2')
-                    blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                                    if 'avx2' in f]
+        if 'avx2' in cpu_flags:
+            print('AVX2 detected')
+            if os.name == 'nt' and compiler_has_flags(compiler, ['/arch:AVX2']):
+                def_macros += [('__AVX2__', 1)]
+            elif compiler_has_flags(compiler, ["-mavx2"]):
+                CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
+                CFLAGS.append('-mavx2')
+                blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
+                                if 'avx2' in f]
     else:
         ADDLIBS += ['blosc']
 
@@ -1055,6 +1056,6 @@ if __name__ == '__main__':
                 'ipython']},
         **setuptools_kwargs
     )
-    
+
 elif __name__ == '__mp_main__':
     pass

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import textwrap
 import subprocess
 from os.path import exists, expanduser
 import glob
+import platform
 
 # Using ``setuptools`` enables lots of goodies
 from setuptools import setup, find_packages
@@ -883,7 +884,10 @@ if __name__ == '__main__':
         # AVX2
         if 'avx2' in cpu_flags:
             print('AVX2 detected')
-            if os.name == 'nt' and compiler_has_flags(compiler, ['/arch:AVX2']):
+            if (os.name == 'nt' and 
+                    LooseVersion(platform.python_version()) >= LooseVersion('3.5.0')):
+                # Neither MSVC2008 for Python 2.7 or MSVC2010 for Python 3.4 have 
+                # sufficient AVX2 support
                 def_macros += [('__AVX2__', 1)]
             elif compiler_has_flags(compiler, ["-mavx2"]):
                 CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')

--- a/setup.py
+++ b/setup.py
@@ -884,11 +884,11 @@ if __name__ == '__main__':
         # AVX2
         if 'avx2' in cpu_flags:
             print('AVX2 detected')
-            if (os.name == 'nt' and 
-                    LooseVersion(platform.python_version()) >= LooseVersion('3.5.0')):
-                # Neither MSVC2008 for Python 2.7 or MSVC2010 for Python 3.4 have 
-                # sufficient AVX2 support
-                def_macros += [('__AVX2__', 1)]
+            if os.name == 'nt':
+                if LooseVersion(platform.python_version()) >= LooseVersion('3.5.0'):
+                    # Neither MSVC2008 for Python 2.7 or MSVC2010 for Python 3.4 have 
+                    # sufficient AVX2 support
+                    def_macros += [('__AVX2__', 1)]
             elif compiler_has_flags(compiler, ["-mavx2"]):
                 CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
                 CFLAGS.append('-mavx2')


### PR DESCRIPTION
- Enables AVX2 in the blosc macros for Windows builds.
- Updates `cpuinfo.py` to version `4.0.0`.
- Protects entire `setup.py` with a `if __name__ == '__main__'` block to avoid `cpuinfo` issue related to multiprocessing: https://github.com/workhorsy/py-cpuinfo/issues/108
