### PR TITLE
Remove never-executed code from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
 
 install:
   - pip install dist/*.tar.gz
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 
 script:
   - cd .. && python -m tables.tests.test_all


### PR DESCRIPTION
Python 2.6 is not supported anymore, so that 'if' is never executed