### PR TITLE
Ensure offsets are always an integer

### DIFF
--- a/tables/index.py
+++ b/tables/index.py
@@ -593,7 +593,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             idx = numpy.empty(len(arr), "uint%d" % (indsize * 8))
             lbucket = self.lbucket
             # Fill the idx with the bucket indices
-            offset = lbucket - ((nrow * (slicesize % lbucket)) % lbucket)
+            offset = int(lbucket - ((nrow * (slicesize % lbucket)) % lbucket))
             idx[0:offset] = 0
             for i in range(offset, slicesize, lbucket):
                 idx[i:i + lbucket] = (i + lbucket - 1) // lbucket
@@ -1226,7 +1226,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 ul = self.nelementsILR // cs
                 bounds = numpy.concatenate((bounds, self.bebounds[:ul]))
             sbounds_idx = bounds.argsort(kind=defsort)
-            offset = nblock * nsb
+            offset = int(nblock * nsb)
             # Swap sorted and indices following the new order
             self.get_neworder(sbounds_idx, sorted, tmp_sorted, sortedLR,
                               nslices, offset, self.dtype)


### PR DESCRIPTION
I've run into a few instances where calling `Table.reindex()` fails with the following:

```
Traceback (most recent call last):
  File "test_indexing.py", line 218, in <module>
    test_query_times(fname)
  File "test_indexing.py", line 138, in test_query_times
    table.reindex()
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 2762, in reindex
    self._do_reindex(dirty=False)
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 2745, in _do_reindex
    indexedrows = indexcol._do_reindex(dirty)
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 3657, in _do_reindex
    kind=kind, optlevel=optlevel, filters=filters))
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 3609, in create_index
    tmp_dir, _blocksizes, _verbose)
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 328, in _column__create_index
    self.pathname, 0, table.nrows, lastrow=True, update=False)
  File ".../env/lib/python3.6/site-packages/tables/table.py", line 2557, in _add_rows_to_index
    update=update)
  File ".../env/lib/python3.6/site-packages/tables/index.py", line 739, in append_last_row
    larr, arr, idx = self.initial_append(xarr, nrows, reduction)
  File ".../env/lib/python3.6/site-packages/tables/index.py", line 597, in initial_append
    idx[0:offset] = 0
TypeError: slice indices must be integers or None or have an __index__ method
```

After a little digging, I see that a few offset calculations may end up producing floats, while others are explicitly cast as an integer. This is a small change, but I've converted the remaining offsets to integers.