### PR TITLE
Fix Dictionary keys changed during iteration in unittests on python 3.8a4

### DIFF
--- a/tables/file.py
+++ b/tables/file.py
@@ -2849,7 +2849,7 @@ class File(hdf5extension.File, object):
 
         # Update alive and dead descendents.
         for cache in [self._node_manager.cache, self._node_manager.registry]:
-            for nodepath in cache:
+            for nodepath in list(cache):
                 if nodepath.startswith(oldprefix) and nodepath != oldprefix:
                     nodesuffix = nodepath[oldprefix_len:]
                     newnodepath = join_path(newpath, nodesuffix)


### PR DESCRIPTION
Fixes #733 (unittests fail on python 3.8a4)

Cache items are changed while looping over the cache items, this causes an
`Dictionary keys changed during iteration` error in python>=3.8.

This casts the cache to a list first and iterate over the list to prevent the error.

This might affect performance on very large HDF5 files where the nodecache may be very big. However this is only called while moving/renaming(?) a node:  [tables/group.py#L602](https://github.com/PyTables/PyTables/blob/a92a38c3c6d8a29e64ac12294a3a5e4847fea3d1/tables/group.py#L602) so IMO it should not be a significant problem.


