### PR TITLE
Replace deprecated time.clock with time.perf_counter

### DIFF
--- a/bench/bsddb-table-bench.py
+++ b/bench/bsddb-table-bench.py
@@ -239,16 +239,16 @@ if __name__ == "__main__":
     # Catch the hdf5 file passed as the last argument
     file = pargs[0]
 
-    t1 = time.clock()
+    t1 = time.perf_counter()
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize, verbose)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     tapprows = round(t2 - t1, 3)
 
-    t1 = time.clock()
+    t1 = time.perf_counter()
     psyco.bind(readFile)
     readFile(file, recsize, verbose)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     treadrows = round(t2 - t1, 3)
 
     print("Rows written:", rowsw, " Row size:", rowsz)

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -30,11 +30,11 @@ print("recarray shape in test ==>", r2.shape)
 
 print("Assignment in recarray original")
 print("-------------------------------")
-t1 = time.clock()
+t1 = time.perf_counter()
 for row in range(reclen):
     #r1.field("b")[row] = "changed"
     r1.field("c")[row] = float(row ** 2)
-t2 = time.clock()
+t2 = time.perf_counter()
 origtime = round(t2 - t1, 3)
 print("Assign time:", origtime, " Rows/s:", int(reclen / (origtime + delta)))
 # print "Field b on row 2 after re-assign:", r1.field("c")[2]
@@ -42,12 +42,12 @@ print()
 
 print("Assignment in recarray modified")
 print("-------------------------------")
-t1 = time.clock()
+t1 = time.perf_counter()
 for row in range(reclen):
     rec = r2._row(row)  # select the row to be changed
     # rec.b = "changed"      # change the "b" field
     rec.c = float(row ** 2)  # Change the "c" field
-t2 = time.clock()
+t2 = time.perf_counter()
 ttime = round(t2 - t1, 3)
 print("Assign time:", ttime, " Rows/s:", int(reclen / (ttime + delta)),
       end=' ')
@@ -57,24 +57,24 @@ print()
 
 print("Selection in recarray original")
 print("------------------------------")
-t1 = time.clock()
+t1 = time.perf_counter()
 for row in range(reclen):
     rec = r1[row]
     if rec.field("a") < 3:
         print("This record pass the cut ==>", rec.field("c"), "(row", row, ")")
-t2 = time.clock()
+t2 = time.perf_counter()
 origtime = round(t2 - t1, 3)
 print("Select time:", origtime, " Rows/s:", int(reclen / (origtime + delta)))
 print()
 
 print("Selection in recarray modified")
 print("------------------------------")
-t1 = time.clock()
+t1 = time.perf_counter()
 for row in range(reclen):
     rec = r2._row(row)
     if rec.a < 3:
         print("This record pass the cut ==>", rec.c, "(row", row, ")")
-t2 = time.clock()
+t2 = time.perf_counter()
 ttime = round(t2 - t1, 3)
 print("Select time:", ttime, " Rows/s:", int(reclen / (ttime + delta)),
       end=' ')
@@ -84,9 +84,9 @@ print()
 print("Printing in recarray original")
 print("------------------------------")
 f = open("test.out", "w")
-t1 = time.clock()
+t1 = time.perf_counter()
 f.write(str(r1))
-t2 = time.clock()
+t2 = time.perf_counter()
 origtime = round(t2 - t1, 3)
 f.close()
 os.unlink("test.out")
@@ -95,9 +95,9 @@ print()
 print("Printing in recarray modified")
 print("------------------------------")
 f = open("test2.out", "w")
-t1 = time.clock()
+t1 = time.perf_counter()
 f.write(str(r2))
-t2 = time.clock()
+t2 = time.perf_counter()
 ttime = round(t2 - t1, 3)
 f.close()
 os.unlink("test2.out")

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -92,7 +92,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
                                None, nrows)
 
     t1 = time.time()
-    cpu1 = time.clock()
+    cpu1 = time.perf_counter()
     nrowsbuf = table.nrowsinbuf
     minimum = 0
     maximum = nrows
@@ -115,7 +115,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     table.flush()
     rowswritten += nrows
     time1 = time.time() - t1
-    tcpu1 = time.clock() - cpu1
+    tcpu1 = time.perf_counter() - cpu1
     print("Time for filling:", round(time1, 3),
           "Krows/s:", round(nrows / 1000. / time1, 3), end=' ')
     fileh.close()
@@ -127,14 +127,14 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     rowsize = table.rowsize
     if index:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         # Index all entries
         if not heavy:
             indexrows = table.cols.var1.create_index(filters=filters)
         for colname in ['var2', 'var3']:
             table.colinstances[colname].create_index(filters=filters)
         time2 = time.time() - t1
-        tcpu2 = time.clock() - cpu1
+        tcpu2 = time.perf_counter() - cpu1
         print("Time for indexing:", round(time2, 3),
               "iKrows/s:", round(indexrows / 1000. / time2, 3), end=' ')
     else:
@@ -250,7 +250,7 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
         # The interval for look values at. This is aproximately equivalent to
         # the number of elements to select
         rnd = numpy.random.randint(table.nrows)
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         t1 = time.time()
         if atom == "string":
             val = str(rnd)[-4:]
@@ -284,17 +284,17 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
         if i == 0:
             # First iteration
             time1 = time.time() - t1
-            tcpu1 = time.clock() - cpu1
+            tcpu1 = time.perf_counter() - cpu1
         else:
             if indexmode == "indexed":
                 # if indexed, wait until the 5th iteration (in order to
                 # insure that the index is effectively cached) to take times
                 if i >= 5:
                     time2 += time.time() - t1
-                    tcpu2 += time.clock() - cpu1
+                    tcpu2 += time.perf_counter() - cpu1
             else:
                 time2 += time.time() - t1
-                tcpu2 += time.clock() - cpu1
+                tcpu2 += time.perf_counter() - cpu1
 
     if riter > 1:
         if indexmode == "indexed" and riter >= 5:

--- a/bench/searchsorted-bench.py
+++ b/bench/searchsorted-bench.py
@@ -295,13 +295,13 @@ if __name__ == "__main__":
             if shuffle:
                 print("Suffling...")
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, nrows, filters,
                                     atom, recsize, index, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -316,14 +316,14 @@ if __name__ == "__main__":
             psyco.bind(readFile)
             psyco.bind(searchFile)
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if rng or item:
             (rowsr, uncomprB, niter) = searchFile(file, atom, verbose, item)
         else:
             for i in range(1):
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/bench/searchsorted-bench2.py
+++ b/bench/searchsorted-bench2.py
@@ -295,13 +295,13 @@ if __name__ == "__main__":
             if shuffle:
                 print("Suffling...")
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, nrows, filters,
                                     atom, recsize, index, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -316,14 +316,14 @@ if __name__ == "__main__":
             psyco.bind(readFile)
             psyco.bind(searchFile)
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if rng or item:
             (rowsr, uncomprB, niter) = searchFile(file, atom, verbose, item)
         else:
             for i in range(1):
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -178,16 +178,16 @@ if __name__ == "__main__":
     # Catch the hdf5 file passed as the last argument
     file = pargs[0]
 
-    t1 = time.clock()
+    t1 = time.perf_counter()
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     tapprows = round(t2 - t1, 3)
 
-    t1 = time.clock()
+    t1 = time.perf_counter()
     psyco.bind(readFile)
     readFile(file, recsize)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     treadrows = round(t2 - t1, 3)
 
     print("Rows written:", rowsw, " Row size:", rowsz)

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -123,7 +123,7 @@ CREATE INDEX ivar3 ON small(var3);
         # Insert rows
         SQL = "insert into small values(NULL, %s)" % place_holders
         time1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         # This way of filling is to copy the PyTables benchmark
         nrowsbuf = 1000
         minimum = 0
@@ -149,7 +149,7 @@ CREATE INDEX ivar3 ON small(var3);
                 cursor.execute(SQL, fields)
             conn.commit()
         t1 = round(time.time() - time1, 5)
-        tcpu1 = round(time.clock() - cpu1, 5)
+        tcpu1 = round(time.perf_counter() - cpu1, 5)
         rowsecf = nrows / t1
         size1 = os.stat(dbfile)[6]
         print("******** Results for writing nrows = %s" % (nrows), "*********")
@@ -160,7 +160,7 @@ CREATE INDEX ivar3 ON small(var3);
     # Indexem
     if indexmode == "indexed":
         time1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if not heavy:
             cursor.execute("CREATE INDEX ivar1 ON small(var1)")
             conn.commit()
@@ -169,7 +169,7 @@ CREATE INDEX ivar3 ON small(var3);
         cursor.execute("CREATE INDEX ivar3 ON small(var3)")
         conn.commit()
         t2 = round(time.time() - time1, 5)
-        tcpu2 = round(time.clock() - cpu1, 5)
+        tcpu2 = round(time.perf_counter() - cpu1, 5)
         rowseci = nrows / t2
         print(("Index time:", t2, ", IKRows/s:",
               round((nrows / 10. ** 3) / t2, 3),))
@@ -284,7 +284,7 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
         for i in range(riter):
             rnd = random.randrange(nrows)
             time1 = time.time()
-            cpu1 = time.clock()
+            cpu1 = time.perf_counter()
             if atom == "string":
                 #cursor.execute(SQL1, "1111")
                 cursor.execute(SQL1, str(rnd)[-4:])
@@ -299,7 +299,7 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
                     "atom must take a value in ['string','int','float']")
             if i == 0:
                 t1 = time.time() - time1
-                tcpu1 = time.clock() - cpu1
+                tcpu1 = time.perf_counter() - cpu1
             else:
                 if indexmode == "indexed":
                     # if indexed, wait until the 5th iteration to take
@@ -307,10 +307,10 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
                     # effectively cached)
                     if i >= 5:
                         time2 += time.time() - time1
-                        cpu2 += time.clock() - cpu1
+                        cpu2 += time.perf_counter() - cpu1
                 else:
                     time2 += time.time() - time1
-                    time2 += time.clock() - cpu1
+                    time2 += time.perf_counter() - cpu1
         if riter > 1:
             if indexmode == "indexed" and riter >= 5:
                 correction = 5

--- a/bench/stress-test.py
+++ b/bench/stress-test.py
@@ -265,14 +265,14 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
         print("Compression library:", complib)
     if testwrite:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if usearray:
             (rowsw, rowsz) = createFileArr(file, ngroups, ntables, nrows)
         else:
             (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                         complevel, complib, recsize)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -284,14 +284,14 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
 
     if testread:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if usearray:
             (rowsr, rowsz, bufsz) = readFileArr(file,
                                                 ngroups, recsize, verbose)
         else:
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/bench/stress-test2.py
+++ b/bench/stress-test2.py
@@ -200,13 +200,13 @@ if __name__ == "__main__":
         print("Compression library:", complib)
     if testwrite:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                     complevel, complib, recsize)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -218,12 +218,12 @@ if __name__ == "__main__":
 
     if testread:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
         (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/bench/stress-test3.py
+++ b/bench/stress-test3.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         print("Compression library:", complib)
     if testwrite:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         if usearray:
@@ -254,7 +254,7 @@ if __name__ == "__main__":
             (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                         complevel, complib, recsize)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -266,7 +266,7 @@ if __name__ == "__main__":
 
     if testread:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
         if usearray:
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         else:
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -372,7 +372,7 @@ if __name__ == "__main__":
             if shuffle:
                 print("Suffling...")
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         if profile:
@@ -389,7 +389,7 @@ if __name__ == "__main__":
         else:
             (rowsw, rowsz) = createFile(file, iterations, filters, recsize)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         tapprows = round(t2 - t1, 3)
         cpuapprows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpuapprows / tapprows, 2) * 100)
@@ -401,7 +401,7 @@ if __name__ == "__main__":
 
     if testread:
         t1 = time.time()
-        cpu1 = time.clock()
+        cpu1 = time.perf_counter()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
             # psyco.bind(readField)
@@ -413,7 +413,7 @@ if __name__ == "__main__":
             for i in range(1):
                 (rowsr, rowsz) = readFile(file, recsize, verbose)
         t2 = time.time()
-        cpu2 = time.clock()
+        cpu2 = time.perf_counter()
         treadrows = round(t2 - t1, 3)
         cpureadrows = round(cpu2 - cpu1, 3)
         tpercent = int(round(cpureadrows / treadrows, 2) * 100)

--- a/tables/index.py
+++ b/tables/index.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 import warnings
 
-from time import time, clock
+from time import time, perf_counter
 
 import numpy
 
@@ -847,7 +847,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
         if self.verbose:
             t1 = time()
-            c1 = clock()
+            c1 = perf_counter()
         ss = self.slicesize
         tmp = self.tmp
         ranges = tmp.ranges[:]
@@ -953,7 +953,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         self.compute_overlaps(self.tmp, "do_complete_sort()", self.verbose)
         if self.verbose:
             t = round(time() - t1, 4)
-            c = round(clock() - c1, 4)
+            c = round(perf_counter() - c1, 4)
             print("time: %s. clock: %s" % (t, c))
 
     def swap(self, what, mode=None):
@@ -968,7 +968,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
         if self.verbose:
             t1 = time()
-            c1 = clock()
+            c1 = perf_counter()
         if what == "chunks":
             self.swap_chunks(mode)
         elif what == "slices":
@@ -982,7 +982,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         rmult = len(mult.nonzero()[0]) / float(len(mult))
         if self.verbose:
             t = round(time() - t1, 4)
-            c = round(clock() - c1, 4)
+            c = round(perf_counter() - c1, 4)
             print("time: %s. clock: %s" % (t, c))
         # Check that entropy is actually decreasing
         if what == "chunks" and self.last_tover > 0. and self.last_nover > 0:


### PR DESCRIPTION
`time.clock` will be removed in Python 3.8 after being deprecated in Python 3.3

```
$ python3.7 -c 'from time import clock; clock()'
-c:1: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
```

The Fedora linux distribution is starting to build Python packages with beta releases of Pyhton 3.8 in other to detect possible problems. This PR substitutes calls to `time.clock`, that will been removed in Python 3.8, with `time.perf_counter`

The related issue is #744
