### PR TITLE
setup.py: remove improperly escaped regexps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 
 import os
-import re
 import sys
 import ctypes
 import tempfile
@@ -362,11 +361,11 @@ if __name__ == '__main__':
         with open(headername) as fd:
             for line in fd:
                 if 'H5_VERS_MAJOR' in line:
-                    major_version = int(re.split("\s+", line)[2])
+                    major_version = int(line.split()[2])
                 if 'H5_VERS_MINOR' in line:
-                    minor_version = int(re.split("\s+", line)[2])
+                    minor_version = int(line.split()[2])
                 if 'H5_VERS_RELEASE' in line:
-                    release_version = int(re.split("\s+", line)[2])
+                    release_version = int(line.split()[2])
                 if (major_version != -1 and minor_version != -1 and
                         release_version != -1):
                     break
@@ -384,11 +383,11 @@ if __name__ == '__main__':
         release_version = -1
         for line in open(headername):
             if 'BLOSC_VERSION_MAJOR' in line:
-                major_version = int(re.split("\s+", line)[2])
+                major_version = int(line.split()[2])
             if 'BLOSC_VERSION_MINOR' in line:
-                minor_version = int(re.split("\s+", line)[2])
+                minor_version = int(line.split()[2])
             if 'BLOSC_VERSION_RELEASE' in line:
-                release_version = int(re.split("\s+", line)[2])
+                release_version = int(line.split()[2])
             if (major_version != -1 and minor_version != -1 and
                     release_version != -1):
                 break


### PR DESCRIPTION
python3.8 now warns about those. One solution would be to change each
of them to r'\s+' or '\\s+', but it turns out that using re is not
necessary at all, since the plain .split() does the exact same thing.