### PR TITLE
Use assertIsInstance in tests

### DIFF
--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -746,9 +746,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertTrue(isinstance(self.root.anarray.attrs.pq, numpy.bool_))
-        self.assertTrue(isinstance(self.root.anarray.attrs.qr, numpy.bool_))
-        self.assertTrue(isinstance(self.root.anarray.attrs.rs, numpy.bool_))
+        self.assertIsinstance(self.root.anarray.attrs.pq, numpy.bool_)
+        self.assertIsinstance(self.root.anarray.attrs.qr, numpy.bool_)
+        self.assertIsinstance(self.root.anarray.attrs.rs, numpy.bool_)
         self.assertEqual(self.root.anarray.attrs.pq, True)
         self.assertEqual(self.root.anarray.attrs.qr, False)
         self.assertEqual(self.root.anarray.attrs.rs, True)


### PR DESCRIPTION
I got this as a lint suggestion. When I ran the single file locally it failed but so did other tests that had passed with test_all.

If this fails then unittest is setup differently than I expect and sorry for the extra notification.