### PR TITLE
Final asserts changes

### DIFF
--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -327,7 +327,7 @@ class BasicTestCase(TestCase):
                                       lambda: fileh.root.somearray.read(out=b))
                 else:
                     fileh.root.somearray.read(out=b)
-                self.assertTrue(type(b), numpy.ndarray)
+                self.assertIsInstance(b, numpy.ndarray)
         finally:
             # Then, delete the file
             os.remove(filename)
@@ -366,7 +366,7 @@ class BasicTestCase(TestCase):
                                       lambda: fileh.root.somearray.read(out=b))
                 else:
                     fileh.root.somearray.read(out=b)
-                self.assertTrue(type(b), numpy.ndarray)
+                self.assertIsInstance(b, numpy.ndarray)
         finally:
             # Then, delete the file
             os.remove(filename)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -957,9 +957,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         self.assertIsInstance(self.root.anarray.attrs.pq, numpy.float_)
         self.assertIsInstance(self.root.anarray.attrs.qr, numpy.float_)
         self.assertIsInstance(self.root.anarray.attrs.rs, numpy.float_)
-        self.assertTrue(self.root.anarray.attrs.pq, 1.0)
-        self.assertTrue(self.root.anarray.attrs.qr, 2.0)
-        self.assertTrue(self.root.anarray.attrs.rs, 3.0)
+        self.assertEqual(self.root.anarray.attrs.pq, 1.0)
+        self.assertEqual(self.root.anarray.attrs.qr, 2.0)
+        self.assertEqual(self.root.anarray.attrs.rs, 3.0)
 
     def test02b_setFloatAttributes(self):
         """Checking setting Float attributes (scalar, NumPy case)"""

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1175,7 +1175,7 @@ class OpenFileTestCase(common.TempFileMixin, TestCase):
         fd = self.h5file.fileno()
         if common.verbose:
             print("Value of fileno():", fd)
-        self.assertTrue(fd >= 0)
+        self.assertGreaterEqual(fd, 0)
 
 
 class NodeCacheOpenFile(OpenFileTestCase):
@@ -1231,7 +1231,7 @@ class CheckFileTestCase(common.TempFileMixin, TestCase):
 
         # When file is not an HDF5 format, always returns 0 or
         # negative value
-        self.assertTrue(version <= 0)
+        self.assertLessEqual(version, 0)
 
     def test01x_isHDF5File_nonexistent(self):
         """Identifying a nonexistent HDF5 file."""
@@ -1262,7 +1262,7 @@ class CheckFileTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print()
             print("\nPyTables format version number ==> %s" % version)
-        self.assertTrue(version >= "1.0")
+        self.assertGreaterEqual(version, "1.0")
 
     def test03_isPyTablesFile(self):
         """Checking is_pytables_file function (FALSE case)"""
@@ -1912,9 +1912,10 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
 
         try:
             tables.flavor.restrict_flavors(keep=[])
-            self.assertTrue(len(tables.flavor.alias_map) < len(alias_map))
-            self.assertTrue(len(
-                tables.flavor.converter_map) < len(converter_map))
+            self.assertLess(len(tables.flavor.alias_map), len(alias_map))
+            self.assertLess(
+                len(tables.flavor.converter_map),
+                len(converter_map))
         finally:
             tables.flavor.all_flavors[:] = all_flavors[:]
             tables.flavor.alias_map.update(alias_map)
@@ -2057,7 +2058,7 @@ class FilePropertyTestCase(TestCase):
 
         fs_filesize = os.stat(self.h5fname)[6]
 
-        self.assertTrue(h5_filesize >= datasize)
+        self.assertGreaterEqual(h5_filesize, datasize)
         self.assertEqual(h5_filesize, fs_filesize)
 
     def test01_null_userblock_size(self):

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -1768,7 +1768,7 @@ class Sec2DriverTestCase(DefaultDriverTestCase):
 
     def test_get_file_image(self):
         image = self.h5file.get_file_image()
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[
                              :4]], [137, 72, 68, 70])
@@ -1783,7 +1783,7 @@ class StdioDriverTestCase(DefaultDriverTestCase):
 
     def test_get_file_image(self):
         image = self.h5file.get_file_image()
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[
                              :4]], [137, 72, 68, 70])
@@ -1798,7 +1798,7 @@ class CoreDriverTestCase(DefaultDriverTestCase):
 
     def test_get_file_image(self):
         image = self.h5file.get_file_image()
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[
                              :4]], [137, 72, 68, 70])
@@ -2043,7 +2043,7 @@ class CoreDriverNoBackingStoreTestCase(TestCase):
 
         image = self.h5file.get_file_image()
 
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[
                              :4]], [137, 72, 68, 70])
@@ -2213,7 +2213,7 @@ class InMemoryCoreDriverTestCase(TestCase):
 
     def test_newFileW(self):
         image = self._create_image(self.h5fname, mode='w')
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[:4]], [137, 72, 68, 70])
         else:
@@ -2222,7 +2222,7 @@ class InMemoryCoreDriverTestCase(TestCase):
 
     def test_newFileA(self):
         image = self._create_image(self.h5fname, mode='a')
-        self.assertTrue(len(image) > 0)
+        self.assertGreater(len(image), 0)
         if sys.version_info[0] < 3:
             self.assertEqual([ord(i) for i in image[:4]], [137, 72, 68, 70])
         else:

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -1276,7 +1276,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(
             abs(self.array.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertEqual(self.array.size_in_memory, 10 * 1000 * 10 * 4)
-        self.assertTrue(self.array.size_on_disk < self.array.size_in_memory)
+        self.assertLess(self.array.size_on_disk, self.array.size_in_memory)
 
 
 class OffsetStrideTestCase(common.TempFileMixin, TestCase):

--- a/tables/tests/test_expression.py
+++ b/tables/tests/test_expression.py
@@ -998,7 +998,7 @@ class MaindimTestCase(common.TempFileMixin, TestCase):
         shape2[0] = 0
         a1 = self.h5file.create_earray(
             root, 'a1', atom=tables.Int32Col(), shape=shape)
-        self.assertTrue(a1.maindim, self.maindim)
+        self.assertEqual(a1.maindim, self.maindim)
         b1 = self.h5file.create_earray(
             root, 'b1', atom=tables.Int32Col(), shape=shape2)
         self.assertEqual(b1.maindim, 0)
@@ -1035,7 +1035,7 @@ class MaindimTestCase(common.TempFileMixin, TestCase):
         shape2[0] = 0
         a1 = self.h5file.create_earray(
             root, 'a1', atom=tables.Int32Col(), shape=shape)
-        self.assertTrue(a1.maindim, self.maindim)
+        self.assertEqual(a1.maindim, self.maindim)
         b1 = self.h5file.create_earray(
             root, 'b1', atom=tables.Int32Col(), shape=shape)
         c1 = self.h5file.create_earray(
@@ -1073,7 +1073,7 @@ class MaindimTestCase(common.TempFileMixin, TestCase):
         shape2[0] = 0
         a1 = self.h5file.create_earray(
             root, 'a1', atom=tables.Int32Col(), shape=shape)
-        self.assertTrue(a1.maindim, self.maindim)
+        self.assertEqual(a1.maindim, self.maindim)
         b1 = self.h5file.create_earray(
             root, 'b1', atom=tables.Int32Col(), shape=shape)
         c1 = self.h5file.create_earray(

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -2580,7 +2580,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
 
         # retrieve
         result = table.read_where('(values >= 0)')
-        self.assertTrue(len(result) == 4)
+        self.assertEqual(len(result), 4)
 
     def test_issue_327(self):
         table = self.h5file.create_table('/', 'table', dict(
@@ -2601,7 +2601,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         table.cols.values2.create_index()
 
         results2 = table.read_where('(values2 > 0)')
-        self.assertTrue(len(results2), 4)
+        self.assertEqual(len(results2), 4)
 
         results = table.read_where('(values > 0)')
         self.assertEqual(len(results), 2)
@@ -2626,7 +2626,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         table.cols.values2.create_index(_blocksizes=small_blocksizes)
 
         results2 = table.read_where('(values2 > 0)')
-        self.assertTrue(len(results2), 400)
+        self.assertEqual(len(results2), 400)
 
         results = table.read_where('(values > 0)')
         self.assertEqual(len(results), 200)
@@ -2651,7 +2651,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         table.cols.values2.create_csindex(_blocksizes=small_blocksizes)
 
         results2 = table.read_where('(values2 > 0)')
-        self.assertTrue(len(results2), 100*4)
+        self.assertEqual(len(results2), 100*4)
 
         results = table.read_where('(values > 0)')
         self.assertEqual(len(results), 100*2)

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3196,7 +3196,7 @@ class LastRowReuseBuffers(TestCase):
             nrow = random.randint(0, self.nelem-1)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertTrue(len(idx) > 0,
+            self.assertGreater(len(idx), 0,
                             "idx--> %s %s %s %s" % (idx, i, nrow, value))
             self.assertTrue(
                 nrow in idx,
@@ -3215,7 +3215,7 @@ class LastRowReuseBuffers(TestCase):
             nrow = random.randint(0, self.nelem-1)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertTrue(len(idx) > 0,
+            self.assertGreater(len(idx), 0,
                             "idx--> %s %s %s %s" % (idx, i, nrow, value))
             self.assertTrue(
                 nrow in idx,
@@ -3234,7 +3234,7 @@ class LastRowReuseBuffers(TestCase):
             nrow = random.randint(0, self.nelem-1)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertTrue(len(idx) > 0,
+            self.assertGreater(len(idx), 0,
                             "idx--> %s %s %s %s" % (idx, i, nrow, value))
             self.assertTrue(
                 nrow in idx,

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -286,12 +286,12 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
                     # Special expection. We have no way to distinguish between
                     # "l" and "i" typecode, and we can consider them the same
                     # to all practical effects
-                    self.assertTrue(b.dtype.char == "l" or b.dtype.char == "i")
+                    self.assertIn(b.dtype.char, ("l", "i"))
                 elif (a.dtype.char == "I" or a.dtype.char == "L"):
                     # Special expection. We have no way to distinguish between
                     # "L" and "I" typecode, and we can consider them the same
                     # to all practical effects
-                    self.assertTrue(b.dtype.char == "L" or b.dtype.char == "I")
+                    self.assertIn(b.dtype.char, ("L", "I"))
                 else:
                     self.assertTrue(allequal(a, b, "numpy"))
             elif np.dtype('l').itemsize == 8:
@@ -299,12 +299,12 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
                     # Special expection. We have no way to distinguish between
                     # "q" and "l" typecode in 64-bit platforms, and we can
                     # consider them the same to all practical effects
-                    self.assertTrue(b.dtype.char == "l" or b.dtype.char == "q")
+                    self.assertIn(b.dtype.char, ("l", "q"))
                 elif (a.dtype.char == "Q" or a.dtype.char == "L"):
                     # Special expection. We have no way to distinguish between
                     # "Q" and "L" typecode in 64-bit platforms, and we can
                     # consider them the same to all practical effects
-                    self.assertTrue(b.dtype.char == "L" or b.dtype.char == "Q")
+                    self.assertIn(b.dtype.char, ("L", "Q"))
                 else:
                     self.assertTrue(allequal(a, b, "numpy"))
 
@@ -370,7 +370,7 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
                 # Special expection. We have no way to distinguish between
                 # "l" and "i" typecode, and we can consider them the same
                 # to all practical effects
-                self.assertTrue(b.dtype.char == "l" or b.dtype.char == "i")
+                self.assertIn(b.dtype.char, ("l", "i"))
             else:
                 self.assertEqual(a.dtype.char, b.dtype.char)
 

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1927,7 +1927,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(
             abs(self.table.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertEqual(self.table.size_in_memory, 10 * 1000 * 10 * 4)
-        self.assertTrue(self.table.size_on_disk < self.table.size_in_memory)
+        self.assertLess(self.table.size_on_disk, self.table.size_in_memory)
 
 
 class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -1914,7 +1914,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
         self.assertEqual(r1.tostring(), r2.tostring())
-        self.assertTrue(table.nrows, 4)
+        self.assertEqual(table.nrows, 4)
 
     def test05(self):
         """Checking modifying one column (single element, Row.update)"""

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -120,7 +120,7 @@ class TimestampTestCase(TrackTimesMixin, common.TempFileMixin, TestCase):
                 else:
                     self.assertNotEqual(timestamps.ctime, 0)
                     tracked_ctimes.append(timestamps.ctime)
-            self.assertTrue(tracked_ctimes[1] >= tracked_ctimes[0])
+            self.assertGreaterEqual(tracked_ctimes[1], tracked_ctimes[0])
 
 
 class BitForBitTestCase(TrackTimesMixin, common.TempFileMixin, TestCase):

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -1162,7 +1162,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.byteorder, byteorder)
-            self.assertTrue(byteorders[row[0].dtype.byteorder], sys.byteorder)
+            self.assertEqual(byteorders[row[0].dtype.byteorder], sys.byteorder)
             self.assertEqual(vlarray.nrows, 2)
             self.assertTrue(allequal(row[0], numpy.array([4.3, 2.2, 4.3],
                                                          dtype=ttypes[atype])))
@@ -2679,7 +2679,7 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(vlarray.nrows, self.nrows)
         self.assertEqual(len(row[0]), 5)
         self.assertEqual(len(row[1]), 4)
-        self.assertTrue(len(row[2]), 5)
+        self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
             self.assertTrue(
                 allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
@@ -3065,7 +3065,7 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(vlarray.nrows, self.nrows)
         self.assertEqual(len(row[0]), 5)
         self.assertEqual(len(row[1]), 4)
-        self.assertTrue(len(row[2]), 5)
+        self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
             self.assertTrue(
                 allequal(row[0][x//2], numpy.arange(x, dtype='int32')))


### PR DESCRIPTION
Note about half of these change functionality. I assume they were mistyped originally. 

self.assertTrue(type(b), numpy.ndarray)
=>
self.assertIsInstance(b, numpy.ndarray)

self.assertTrue(a1.maindim, self.maindim)	
=>
self.assertEqual(a1.maindim, self.maindim)	
