### PR TITLE
Fix bug in python2 version of test

### DIFF
--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -652,29 +652,7 @@ class ReadTestCase(common.TempFileMixin, TestCase):
         tblrepr = repr(tbl)
         # Remove the platform-dependent information (i.e. byteorder)
         tblrepr = "\n".join(tblrepr.split("\n")[:-2]) + "\n"
-        if sys.version_info[0] < 3:
-            template = """/test (Table(2,)) 'test00'
-  description := {
-  "x": Int32Col(shape=(2,), dflt=0, pos=0),
-  "Info": {
-    "value": ComplexCol(itemsize=16, shape=(), dflt=0j, pos=0),
-    "y2": Float64Col(shape=(), dflt=1.0, pos=1),
-    "Info2": {
-      "name": StringCol(itemsize=2, shape=(), dflt='', pos=0),
-      "value": ComplexCol(itemsize=16, shape=(2,), dflt=0j, pos=1),
-      "y3": Time64Col(shape=(2,), dflt=1.0, pos=2),
-      "z3": EnumCol(enum=Enum({%(value)s}), dflt='r', base=Int32Atom(shape=(), dflt=0), shape=(2,), pos=3)},
-    "name": StringCol(itemsize=2, shape=(), dflt='', pos=3),
-    "z2": UInt8Col(shape=(), dflt=1, pos=4)},
-  "color": StringCol(itemsize=2, shape=(), dflt=' ', pos=2),
-  "info": {
-    "Name": StringCol(itemsize=2, shape=(), dflt='', pos=0),
-    "Value": ComplexCol(itemsize=16, shape=(), dflt=0j, pos=1)},
-  "y": Float64Col(shape=(2, 2), dflt=1.0, pos=4),
-  "z": UInt8Col(shape=(), dflt=1, pos=5)}
-"""
-        else:
-            template = """/test (Table(2,)) 'test00'
+        template = """/test (Table(2,)) 'test00'
   description := {
   "x": Int32Col(shape=(2,), dflt=0, pos=0),
   "Info": {


### PR DESCRIPTION
this is mostly an FYI that you can clean up more python2 only code

Also there's a bug on line 666 (maybe that was a sign) where in the python2 branch you always set dflt='r' instead of dflt='%(default)s'