### PR TITLE
Travis CI: test against python 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 
 python:
+  - 3.5
   - 3.6
   - 3.7
   - 3.8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
-sudo: false
+dist: xenial
 
 python:
-  - 3.5
   - 3.6
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - 3.7
+  - 3.8-dev
 
 addons:
   apt_packages:


### PR DESCRIPTION
Add python 3.8 dev to travis
Cleanup .travis.yml: Use xenial for all builds