### PR TITLE
Clean up appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   PACKAGE_NAME: tables
-  BUILD_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 cython bzip2"
-  TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 mock"
+  BUILD_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 cython bzip2 hdf5"
+  TEST_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2"
   # Make setup.py include conda specific dll's in wheel
   BUILDWHEEL: True
 
@@ -16,27 +16,12 @@ environment:
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-      HDF5_VERSION: "1.8"
-
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      HDF5_VERSION: "1.10"
 
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
-      HDF5_VERSION: "1.8"
-
-    - PYTHON: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: "3.7"
-      PYTHON_ARCH: "64"
-      HDF5_VERSION: "1.10"
 
 install:
-  # this installs the appropriate Miniconda (Py2/Py3, 32/64 bit),
-  # as well as pip, conda-build, and the binstar CLI
-  #- powershell .\\ci\\appveyor\\install.ps1
   - powershell .\\ci\\appveyor\\missing-headers.ps1
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
@@ -44,11 +29,6 @@ build_script:
   - conda config --add channels conda-forge
   - conda create --yes -n build_env python=%PYTHON_VERSION% %BUILD_DEPENDS%
   - activate build_env
-
-  # Install HDF5 Library
-  # Add tomkooij channel for HDF5 v1.10 conda packages
-  - conda config --add channels http://conda.anaconda.org/tomkooij
-  - conda install --yes hdf5=%HDF5_VERSION%
 
   # Build wheel
   - "%CMD_IN_ENV% python setup.py bdist_wheel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 # doc/source/usersguide/installation.rst
 numpy>=1.9.3
 numexpr>=2.6.2
-mock>=2.0


### PR DESCRIPTION
HDF5 1.10 is now in conda default
Drop HDF5 1.8
Drop mock depency