### PR TITLE
setup.py fix egg/wheel on windows: correct dll loc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,6 @@ if __name__ == '__main__':
     lib_dirs = []
     inc_dirs = [os.path.join('hdf5-blosc', 'src')]
     optional_libs = []
-    data_files = []    # list of data files to add to packages (mainly for DLL's)
 
     default_header_dirs = None
     default_library_dirs = None
@@ -809,11 +808,13 @@ if __name__ == '__main__':
     setuptools_kwargs['scripts'] = []
 
     # Copy additional data for packages that need it.
-    setuptools_kwargs['package_data'] = {
+    package_data = {
         'tables.tests': ['*.h5', '*.mat'],
         'tables.nodes.tests': ['*.dat', '*.xbm', '*.h5'],
     }
-
+    if os.name == 'nt':
+        # add hdf5.dll to egg or wheel
+        package_data['tables'] = ['*.dll']
 
     # Having the Python version included in the package name makes managing a
     # system with multiple versions of Python much easier.
@@ -829,12 +830,6 @@ if __name__ == '__main__':
 
 
     name = find_name()
-
-    if os.name == "nt":
-        # Add DLL's to the final package for windows
-        data_files.extend([
-            ('Lib/site-packages/%s' % name, dll_files),
-        ])
 
     ADDLIBS = [hdf5_package.library_name]
 
@@ -1067,7 +1062,7 @@ interactively save and retrieve large amounts of data.
         platforms=['any'],
         ext_modules=extensions,
         cmdclass=cmdclass,
-        data_files=data_files,
+        package_data=package_data,
         extra_require={
             'doc': [
                 'sphinx >= 1.1',


### PR DESCRIPTION
The current `setup.py` works for (windows) wheels. (We use manylinux/auditwheel for Linux/Mac). But eggs are broken!

Specify *.dll in `package_data` so that wheels and eggs
include hdf5.dll in the correct folder. (site-packages\tables)
This is required for python 3.8 on windows due to stricter dll resolution.

TODO:
 - [x] Check that hdf5.dll is correctly included in wheels/eggs
 - [ ] Check wheelbuilding: will `bzip2.dll` or `blosc.dll` be included when building wheels at MacPython/pytables-wheels with this branch?
 - [ ] Fix `dll_files` var in `setup.py`: it is unused now, check that it can be removed altogether. (Mac/Linux?)
 - [ ] test `zlib.dll` for the wheelbuilder (conda `hdf5.dll` is dynamically linked against `zlib.dll`)
 - [ ] test `blosc.dll` for eggs and wheels

Fixes #766