### PR TITLE
Fix slow import of tables

### DIFF
--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -18,8 +18,6 @@ import shutil
 import tempfile
 import warnings
 
-from pkg_resources import resource_filename
-
 from ... import open_file, file, NoSuchNodeError
 from ...nodes import filenode
 from ...tests.common import (
@@ -28,6 +26,7 @@ from ...tests.common import (
 
 
 def test_file(name):
+    from pkg_resources import resource_filename
     return resource_filename('tables.nodes.tests', name)
 
 

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -22,8 +22,6 @@ import tempfile
 import warnings
 from distutils.version import LooseVersion
 
-from pkg_resources import resource_filename
-
 import unittest
 
 import numpy
@@ -144,6 +142,7 @@ def print_versions():
 
 
 def test_filename(filename):
+    from pkg_resources import resource_filename
     return resource_filename('tables.tests', filename)
 
 


### PR DESCRIPTION
On my Windows workstation, `import tables` takes 3.3 s, about 3 s of which are spent in `import pkg_resources`.

Importing `pkg_resources` is known to be excruciatingly slow. See https://github.com/pypa/setuptools/issues/510

This PR moves the import of pkg_resources to the single test function where pkg_resources is used.