### PR TITLE
Adding Travis-Ci Support For Arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 arch:
     - amd64
-    - arm64
 language: python
 dist: xenial
 
@@ -9,6 +8,11 @@ python:
   - 3.6
   - 3.7
   - 3.8-dev
+
+jobs:
+  include:
+  - python: 3.7
+    arch: arm64
 
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+    - amd64
+    - arm64
 language: python
 dist: xenial
 


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.