### PR TITLE
Fix for Python3.9 on Debian

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -13,10 +13,11 @@ Changes from 3.6.1 to 3.6.x
 
 Improvements
 ------------
- - Windows: Significantly faster `import tables` PR #781. Thanks to Christoph Gohlke.  
+ - Windows: Significantly faster `import tables` PR #781. Thanks to Christoph Gohlke.
 
 Bugfixes
 --------
+ - Fix `pkg-config` (setup.py) for Python 3.9 on Debian. Thanks to Marco Sulla PR #792.
 
 Changes from 3.6.0 to 3.6.1
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -301,7 +301,7 @@ if __name__ == '__main__':
 
             directories = [None, None, None]  # headers, libraries, runtime
             for idx, (name, find_path, default_dirs) in enumerate(dirdata):
-                path = find_path(locations or pkgconfig_dirs[idx] or default_dirs)
+                path = find_path(pkgconfig_dirs[idx] or locations or default_dirs)
                 if path:
                     if path is True:
                         directories[idx] = True


### PR DESCRIPTION
This way, the directories found by `pkg-config` have precedence over the other dirs. With Python3.9 on Debian, without this change the `setup.py` does not work.