### PR TITLE
Fix computeblocksize computation to return an int (even with expectedrows a float)

### DIFF
--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -96,7 +96,7 @@ def computeblocksize(expectedrows, compoundsize, lowercompoundsize):
     if nlowerblocks > 2**20:
         # Protection against too large number of compound blocks
         nlowerblocks = 2**20
-    size = lowercompoundsize * nlowerblocks
+    size = int(lowercompoundsize * nlowerblocks)
     # We *need* superblocksize to be an exact multiple of the actual
     # compoundblock size (a ceil must be performed here!)
     size = ((size // compoundsize) + 1) * compoundsize


### PR DESCRIPTION
When `expectedrows` is provided by the user as a float, a bunch of functions fall apart, esp functions like `create_index`.
When big number of expected rows, it is quite natural to write things like `1e9` and everything mostly works until playing with indexes.
One other option would be to fail early if expectedrows is provided as a float, or to cast it right away in the `__init__()` methods. Not sure what you guys prefer.

Error trace like the following are obtained when setting expectedrows to a float:
```
  File "/usr/local/lib/python3.6/dist-packages/tables/table.py", line 3602, in create_index
    tmp_dir, _blocksizes, _verbose)
  File "/usr/local/lib/python3.6/dist-packages/tables/table.py", line 331, in _column__create_index
    index.optimize(verbose=verbose)
  File "/usr/local/lib/python3.6/dist-packages/tables/index.py", line 798, in optimize
    if self.swap('chunks', 'median'):
  File "/usr/local/lib/python3.6/dist-packages/tables/index.py", line 968, in swap
    self.swap_chunks(mode)
  File "/usr/local/lib/python3.6/dist-packages/tables/index.py", line 1207, in swap_chunks
    for nblock in range(self.nblocks):
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```