### PR TITLE
Fix light index optlevel > 6 chunksize

### DIFF
--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -158,11 +158,11 @@ def ccs_light(optlevel, chunksize, slicesize):
     elif optlevel in (3, 4, 5):
         pass
     elif optlevel in (6, 7, 8):
-        chunksize /= 2
+        chunksize //= 2
     elif optlevel == 9:
         # Reducing the chunksize and enlarging the slicesize is the
         # best way to reduce the entropy with the current algorithm.
-        chunksize /= 2
+        chunksize //= 2
         slicesize *= 2
     return chunksize, slicesize
 


### PR DESCRIPTION
Using a light index with optlevel above 6 result in a float chunksize value, which gets pytables to crash soon after.
This fixes it.