### PR TITLE
Update tutorials.rst

### DIFF
--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -331,7 +331,7 @@ naming* (h5file.root) instead of with an absolute path string ("/").
 
 Now, create the first of the two Array objects we've just mentioned::
 
-    >>> h5file.create_array(gcolumns, 'pressure', array(pressure), "Pressure column selection")
+    >>> h5file.create_array(gcolumns, 'pressure', numpy.array(pressure), "Pressure column selection")
     /columns/pressure (Array(3,)) 'Pressure column selection'
       atom := Float64Atom(shape=(), dflt=0.0)
       maindim := 0


### PR DESCRIPTION
array(pressure) is confusing as it implies array() is part of tables, which leads to "module not callable" error. Since the tutorial introduces numpy import as "import numpy", numpy.array() is preferred.