### PR TITLE
Solve numpy tostring DeprecationWarning

### DIFF
--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1130,7 +1130,7 @@ class VLStringAtom(_BufferedAtom):
         return numpy.string_(object_)
 
     def fromarray(self, array):
-        return array.tostring()
+        return array.tobytes()
 
 
 class VLUnicodeAtom(_BufferedAtom):
@@ -1221,4 +1221,4 @@ class ObjectAtom(_BufferedAtom):
         # record when in fact it is empty.
         if array.size == 0:
             return None
-        return pickle.loads(array.tostring())
+        return pickle.loads(array.tobytes())

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -255,7 +255,7 @@ class RawPyTablesIO(io.RawIOBase):
             n = stop - start
 
         # XXX This ought to work with anything that supports the buffer API
-        b[:n] = self._node.read(start, stop).tostring()
+        b[:n] = self._node.read(start, stop).tobytes()
 
         self._pos += n
 

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -2950,7 +2950,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test01b(self):
@@ -2982,7 +2982,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test02(self):
@@ -3015,7 +3015,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test03(self):
@@ -3050,7 +3050,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test04(self):
@@ -3085,7 +3085,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test05(self):
@@ -3117,7 +3117,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06a(self):
@@ -3149,7 +3149,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06b(self):
@@ -3187,7 +3187,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
 #         if common.verbose:
 #             print "Original table-->", repr(r2)
 #             print "Should look like-->", repr(r1)
-#         self.assertEqual(r1.tostring(), r2.tostring())
+#         self.assertEqual(r1.tobytes(), r2.tobytes())
 #         self.assertEqual(table.nrows, 4)
 
     def test07(self):
@@ -3218,7 +3218,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08(self):
@@ -3250,7 +3250,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09(self):
@@ -3285,7 +3285,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
 
@@ -3341,7 +3341,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test02(self):
@@ -3378,7 +3378,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test03(self):
@@ -3415,7 +3415,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test04(self):
@@ -3452,7 +3452,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test05(self):
@@ -3486,7 +3486,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06(self):
@@ -3520,7 +3520,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test07(self):
@@ -3554,7 +3554,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08(self):
@@ -3598,7 +3598,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test08b(self):
@@ -3642,7 +3642,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test09(self):
@@ -3691,7 +3691,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test09b(self):
@@ -3741,7 +3741,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
 
@@ -3784,7 +3784,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if self.reopen:
             self._reopen()
         r2 = self.h5file.root.recarray.read()
-        self.assertEqual(r.tostring(), r2.tostring())
+        self.assertEqual(r.tobytes(), r2.tobytes())
 
     def test01(self):
         """Checking saving a recarray with an offset in its buffer"""
@@ -3808,7 +3808,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             self._reopen()
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test02(self):
         "Checking saving a large recarray with an offset in its buffer"
@@ -3831,7 +3831,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             self._reopen()
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test03(self):
         """Checking saving a strided recarray with an offset in its buffer"""
@@ -3857,7 +3857,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             self._reopen()
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test04(self):
         """Checking appending several rows at once"""
@@ -3892,7 +3892,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test05(self):
@@ -3928,7 +3928,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06a(self):
@@ -3962,7 +3962,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06b(self):
@@ -3996,7 +3996,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test07a(self):
@@ -4029,7 +4029,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test07b(self):
@@ -4064,7 +4064,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test07c(self):
@@ -4119,7 +4119,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08a2(self):
@@ -4154,7 +4154,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08b(self):
@@ -4189,7 +4189,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08b2(self):
@@ -4225,7 +4225,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08c(self):
@@ -4262,7 +4262,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09a(self):
@@ -4298,7 +4298,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09b(self):
@@ -4334,7 +4334,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09c(self):
@@ -4370,7 +4370,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09d(self):
@@ -4407,7 +4407,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test10a(self):
@@ -4449,7 +4449,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test10b(self):
@@ -4490,7 +4490,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
 
@@ -5217,7 +5217,7 @@ class LargeRowSize(common.TempFileMixin, TestCase):
         # Read it again
         r2 = self.h5file.root.largerow.read()
 
-        self.assertEqual(r.tostring(), r2.tostring())
+        self.assertEqual(r.tobytes(), r2.tobytes())
 
     def test01(self):
         """Checking saving a Table with an extremely large rowsize"""
@@ -5229,7 +5229,7 @@ class LargeRowSize(common.TempFileMixin, TestCase):
 
         # Read it again
         r2 = self.h5file.root.largerow.read()
-        self.assertEqual(r.tostring(), r2.tostring())
+        self.assertEqual(r.tobytes(), r2.tobytes())
 
 
 class DefaultValues(common.TempFileMixin, TestCase):
@@ -5308,7 +5308,7 @@ class DefaultValues(common.TempFileMixin, TestCase):
         # It is probably due to some difference in the value of bits used
         # for patting (longdoubles use just 80 bits but are stored in 96 or
         # 128 bits in numpy arrays)
-        # self.assertEqual(r.tostring(), r2.tostring())
+        # self.assertEqual(r.tobytes(), r2.tobytes())
 
     def test01(self):
         """Checking saving a Table with default values (using different Row)"""
@@ -5382,7 +5382,7 @@ class DefaultValues(common.TempFileMixin, TestCase):
         # It is probably due to some difference in the value of bits used
         # for patting (longdoubles use just 80 bits but are stored in 96 or
         # 128 bits in numpy arrays)
-        # self.assertEqual(r.tostring(), r2.tostring())
+        # self.assertEqual(r.tobytes(), r2.tobytes())
 
 
 class OldRecordDefaultValues(DefaultValues):

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -1026,7 +1026,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Read it again
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r.tostring(), r2.tostring())
+        self.assertEqual(r.tobytes(), r2.tobytes())
 
     def test01(self):
         """Checking saving a recarray with an offset in its buffer"""
@@ -1052,7 +1052,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Read it again
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test02(self):
         """Checking saving a slice of a large recarray"""
@@ -1078,7 +1078,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Read it again
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test03(self):
         """Checking saving a slice of an strided recarray"""
@@ -1107,7 +1107,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Read it again
         r2 = self.h5file.root.recarray.read()
 
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test08a(self):
         """Checking modifying one column (single column version, list)"""
@@ -1141,7 +1141,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08b(self):
@@ -1178,7 +1178,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08b2(self):
@@ -1216,7 +1216,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
 
@@ -1270,8 +1270,8 @@ class DefaultValues(common.TempFileMixin, TestCase):
             print("Record values:")
             print(r)
 
-        # Both checks do work, however, tostring() seems more stringent.
-        self.assertEqual(r.tostring(), r2.tostring())
+        # Both checks do work, however, tobytes() seems more stringent.
+        self.assertEqual(r.tobytes(), r2.tobytes())
         # self.assertTrue(common.areArraysEqual(r,r2))
 
 
@@ -1404,7 +1404,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test01b(self):
@@ -1437,7 +1437,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test02(self):
@@ -1472,7 +1472,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test03(self):
@@ -1509,7 +1509,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test04(self):
@@ -1545,7 +1545,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test05(self):
@@ -1578,7 +1578,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06a(self):
@@ -1610,7 +1610,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06b(self):
@@ -1662,7 +1662,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08(self):
@@ -1695,7 +1695,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test09(self):
@@ -1730,7 +1730,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
 
@@ -1796,7 +1796,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test02(self):
@@ -1834,7 +1834,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test03(self):
@@ -1872,7 +1872,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test04(self):
@@ -1910,7 +1910,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test05(self):
@@ -1945,7 +1945,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test06(self):
@@ -1980,7 +1980,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test07(self):
@@ -2017,7 +2017,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, 4)
 
     def test08(self):
@@ -2062,7 +2062,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test08b(self):
@@ -2107,7 +2107,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test09(self):
@@ -2158,7 +2158,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
     def test09b(self):
@@ -2208,7 +2208,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original table-->", repr(r2))
             print("Should look like-->", repr(r1))
-        self.assertEqual(r1.tostring(), r2.tostring())
+        self.assertEqual(r1.tobytes(), r2.tobytes())
         self.assertEqual(table.nrows, nrows)
 
 


### PR DESCRIPTION
Since `numpy=1.19` `array.tostring()` is deprecated and should be replaced with `array.tobytes()` ([numpy release note reference](https://numpy.org/devdocs/release/1.19.0-notes.html#numpy-ndarray-tostring-is-deprecated-in-favor-of-tobytes))

This PR changes all of them, it passes the small test suite. 

No bump of the minimal `numpy` version is needed, as `tobytes()` was implemented in `numpy>=1.9`, which is already the minimal requirement.