### PR TITLE
Update super usage

### DIFF
--- a/cpuinfo.py
+++ b/cpuinfo.py
@@ -65,7 +65,7 @@ if platform.system().lower() == 'windows':
 				# to get --onefile mode working.
 				os.putenv('_MEIPASS2', sys._MEIPASS)
 			try:
-				super(_Popen, self).__init__(*args, **kw)
+				super().__init__(*args, **kw)
 			finally:
 				if hasattr(sys, 'frozen'):
 					# On some platforms (e.g. AIX) 'os.unsetenv()' is not

--- a/doc/source/cookbook/custom_data_types.rst
+++ b/doc/source/cookbook/custom_data_types.rst
@@ -34,12 +34,12 @@ Submitted by Kevin R. Thornton.
                      title="", filters=None,
                      expectedrows=EXPECTED_ROWS_TABLE,
                      chunkshape=None, byteorder=None, _log=True):
-            super(DerivedFromTable, self).__init__(parentNode, name,
-                                              description=description, title=title,
-                                              filters=filters,
-                                              expectedrows=expectedrows,
-                                              chunkshape=chunkshape, byteorder=byteorder,
-                                              _log=_log)
+            super().__init__(parentNode, name,
+                             description=description, title=title,
+                             filters=filters,
+                             expectedrows=expectedrows,
+                             chunkshape=chunkshape, byteorder=byteorder,
+                             _log=_log)
 
         def read(self, start=None, stop=None, step=None, field=None):
             print("HERE!")

--- a/examples/multiprocess_access_benchmarks.py
+++ b/examples/multiprocess_access_benchmarks.py
@@ -40,7 +40,7 @@ def create_file(array_size):
 class PipeReceive(multiprocessing.Process):
 
     def __init__(self, receiver_pipe, result_send):
-        super(PipeReceive, self).__init__()
+        super().__init__()
         self.receiver_pipe = receiver_pipe
         self.result_send = result_send
 
@@ -84,7 +84,7 @@ def read_and_send_pipe(send_type, array_size):
 class MemmapReceive(multiprocessing.Process):
 
     def __init__(self, path_recv, result_send):
-        super(MemmapReceive, self).__init__()
+        super().__init__()
         self.path_recv = path_recv
         self.result_send = result_send
 
@@ -136,7 +136,7 @@ def read_and_send_memmap(send_type, array_size):
 class SocketReceive(multiprocessing.Process):
 
     def __init__(self, socket_family, address, result_send, array_nbytes):
-        super(SocketReceive, self).__init__()
+        super().__init__()
         self.socket_family = socket_family
         self.address = address
         self.result_send = result_send

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -44,7 +44,7 @@ class FileAccess(multiprocessing.Process):
         self.write_queue = write_queue
         self.shutdown = shutdown
         self.block_period = .01
-        super(FileAccess, self).__init__()
+        super().__init__()
 
     def run(self):
         self.h5_file = tables.open_file(self.h5_path, 'r+')
@@ -104,7 +104,7 @@ class DataProcessor(multiprocessing.Process):
         self.proc_num = proc_num
         self.array_size = array_size
         self.output_file = output_file
-        super(DataProcessor, self).__init__()
+        super().__init__()
 
     def run(self):
         self.output_file = open(self.output_file, 'w')

--- a/tables/array.py
+++ b/tables/array.py
@@ -189,8 +189,8 @@ class Array(hdf5extension.Array, Leaf):
         """The index of the enlargeable dimension."""
 
         # Ordinary arrays have no filters: leaf is created with default ones.
-        super(Array, self).__init__(parentnode, name, new, Filters(),
-                                    byteorder, _log, track_times)
+        super().__init__(parentnode, name, new, Filters(), byteorder, _log,
+                         track_times)
 
     def _g_create(self):
         """Save a new array in file."""

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -289,7 +289,7 @@ class AttributeSet(hdf5extension.AttributeSet, object):
         Only PY3 supports this special method.
         """
         return list(set(c for c in
-                    super(AttributeSet, self).__dir__() + self._v_attrnames
+                    super().__dir__() + self._v_attrnames
                     if c.isidentifier()))
 
     def __getattr__(self, name):

--- a/tables/description.py
+++ b/tables/description.py
@@ -224,7 +224,7 @@ class Col(atom.Atom, metaclass=type):
     # ~~~~~~~~~~~~~~~
     def __repr__(self):
         # Reuse the atom representation.
-        atomrepr = super(Col, self).__repr__()
+        atomrepr = super().__repr__()
         lpar = atomrepr.index('(')
         rpar = atomrepr.rindex(')')
         atomargs = atomrepr[lpar + 1:rpar]

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -155,9 +155,8 @@ class EArray(CArray):
         """The expected number of rows to be stored in the array."""
 
         # Call the parent (CArray) init code
-        super(EArray, self).__init__(parentnode, name, atom, shape, title,
-                                     filters, chunkshape, byteorder, _log,
-                                     track_times)
+        super().__init__(parentnode, name, atom, shape, title, filters,
+                         chunkshape, byteorder, _log, track_times)
 
     # Public and private methods
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -110,7 +110,7 @@ class HDF5ExtError(RuntimeError):
 
     def __init__(self, *args, **kargs):
 
-        super(HDF5ExtError, self).__init__(*args)
+        super().__init__(*args)
 
         self._h5bt_policy = kargs.get('h5bt', self.DEFAULT_H5_BACKTRACE_POLICY)
 
@@ -162,14 +162,14 @@ class HDF5ExtError(RuntimeError):
             ])
 
             if len(self.args) == 1 and isinstance(self.args[0], str):
-                msg = super(HDF5ExtError, self).__str__()
+                msg = super().__str__()
                 msg = "%s\n\n%s" % (bt, msg)
             elif self.h5backtrace[-1][-1]:
                 msg = "%s\n\n%s" % (bt, self.h5backtrace[-1][-1])
             else:
                 msg = bt
         else:
-            msg = super(HDF5ExtError, self).__str__()
+            msg = super().__str__()
 
         return msg
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -343,7 +343,7 @@ class _DictCache(dict):
         if nslots < 1:
             raise ValueError("Invalid number of slots: %d" % nslots)
         self.nslots = nslots
-        super(_DictCache, self).__init__()
+        super().__init__()
 
     def __setitem__(self, key, value):
         # Check if we are running out of space
@@ -353,12 +353,12 @@ class _DictCache(dict):
                 "maximum number (%d); be ready to see PyTables asking for "
                 "*lots* of memory and possibly slow I/O." % (
                     self.nslots), PerformanceWarning)
-        super(_DictCache, self).__setitem__(key, value)
+        super().__setitem__(key, value)
 
 
 class NodeManager(object):
     def __init__(self, nslots=64, node_factory=None):
-        super(NodeManager, self).__init__()
+        super().__init__()
 
         self.registry = weakref.WeakValueDictionary()
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -232,7 +232,7 @@ class Group(hdf5extension.Group, Node):
         """
 
         # Finally, set up this object as a node.
-        super(Group, self).__init__(parentnode, name, _log)
+        super().__init__(parentnode, name, _log)
 
     def _g_post_init_hook(self):
         if self._v_new:
@@ -279,7 +279,7 @@ class Group(hdf5extension.Group, Node):
             self._v_unknown.containerref = selfref
             self._v_hidden.containerref = selfref
 
-        super(Group, self).__del__()
+        super().__del__()
 
     def _g_get_child_group_class(self, childname):
         """Get the class of a not-yet-loaded group child.
@@ -591,7 +591,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
     def _g_move(self, newparent, newname):
         # Move the node to the new location.
         oldpath = self._v_pathname
-        super(Group, self)._g_move(newparent, newname)
+        super()._g_move(newparent, newname)
         newpath = self._v_pathname
 
         # Update location information in children.  This node shouldn't
@@ -811,7 +811,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         """
 
         try:
-            super(Group, self).__delattr__(name)  # nothing particular
+            super().__delattr__(name)  # nothing particular
         except AttributeError as ae:
             hint = " (use ``node._f_remove()`` if you want to remove a node)"
             raise ae.__class__(str(ae) + hint)
@@ -822,7 +822,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         Only PY3 supports this special method.
         """
         subnods = [c for c in self._v_children if c.isidentifier()]
-        return super(Group, self).__dir__() + subnods
+        return super().__dir__() + subnods
 
     def __getattr__(self, name):
         """Get a Python attribute or child node called name.
@@ -882,7 +882,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
                 "to access the child node"
                 % (self._v_pathname, name), NaturalNameWarning)
 
-        super(Group, self).__setattr__(name, value)
+        super().__setattr__(name, value)
 
     def _f_flush(self):
         """Flush this Group."""
@@ -906,7 +906,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             self._g_close_group()
 
         # Close myself as a node.
-        super(Group, self)._f_close()
+        super()._f_close()
 
     def _f_close(self):
         """Close this group and all its descendents.
@@ -957,7 +957,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             self._g_close_descendents()
 
         # Remove the node itself from the hierarchy.
-        super(Group, self)._g_remove(recursive, force)
+        super()._g_remove(recursive, force)
 
     def _f_copy(self, newparent=None, newname=None,
                 overwrite=False, recursive=False, createparents=False,
@@ -991,7 +991,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         """
 
-        return super(Group, self)._f_copy(
+        return super()._f_copy(
             newparent, newname,
             overwrite, recursive, createparents, **kwargs)
 

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1154,7 +1154,7 @@ cdef class Leaf(Node):
       self.type_id = -1
       self.base_type_id = -1
       self.disk_type_id = -1
-    super(Leaf, self)._g_new(where, name, init)
+    super()._g_new(where, name, init)
 
   cdef _get_type_ids(self):
     """Get the disk and native HDF5 types associated with this leaf.

--- a/tables/index.py
+++ b/tables/index.py
@@ -392,13 +392,13 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         self._openFile = open_file
         """The `open_file()` function, to avoid a circular import."""
 
-        super(Index, self).__init__(parentnode, name, title, new, filters)
+        super().__init__(parentnode, name, title, new, filters)
 
     def _g_post_init_hook(self):
         if self._v_new:
             # The version for newly created indexes
             self._v_version = obversion
-        super(Index, self)._g_post_init_hook()
+        super()._g_post_init_hook()
 
         # Index arrays must only be created for new indexes
         if not self._v_new:
@@ -2115,7 +2115,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
         # Index removal is always recursive,
         # no matter what `recursive` says.
-        super(Index, self)._f_remove(True)
+        super()._f_remove(True)
 
     def __str__(self):
         """This provides a more compact representation than __repr__"""

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -104,7 +104,7 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
             shape = None
             chunkshape = None
 
-        super(IndexArray, self).__init__(
+        super().__init__(
             parentnode, name, atom, shape, title, filters,
             chunkshape=chunkshape, byteorder=byteorder)
 

--- a/tables/indexesextension.pyx
+++ b/tables/indexesextension.pyx
@@ -583,7 +583,7 @@ cdef class CacheArray(Array):
     return
 
   def _g_close(self):
-    super(Array, self)._g_close()
+    super()._g_close()
     # Release specific resources of this class
     if self.mem_space_id > 0:
       H5Sclose(self.mem_space_id)
@@ -1486,7 +1486,7 @@ cdef class IndexArray(Array):
 
 
   def _g_close(self):
-    super(Array, self)._g_close()
+    super()._g_close()
     # Release specific resources of this class
     if self.mem_space_id > 0:
       H5Sclose(self.mem_space_id)

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -283,7 +283,7 @@ class Leaf(Node):
         # is a lazy property that automatically handles their loading.
 
 
-        super(Leaf, self).__init__(parentnode, name, _log)
+        super().__init__(parentnode, name, _log)
 
     def __len__(self):
         """Return the length of the main dimension of the leaf data.
@@ -327,7 +327,7 @@ class Leaf(Node):
 
         """
 
-        super(Leaf, self)._g_post_init_hook()
+        super()._g_post_init_hook()
         if self._v_new:  # set flavor of new node
             if self._flavor is None:
                 self._flavor = internal_flavor
@@ -763,7 +763,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         self._g_close()
 
         # Close myself as a node.
-        super(Leaf, self)._f_close()
+        super()._f_close()
 
     def close(self, flush=True):
         """Close this node in the tree.

--- a/tables/link.py
+++ b/tables/link.py
@@ -89,7 +89,7 @@ class Link(Node):
         self.target = target
         """The path string to the pointed node."""
 
-        super(Link, self).__init__(parentnode, name, _log)
+        super().__init__(parentnode, name, _log)
 
     # Public and tailored versions for copy, move, rename and remove methods
     def copy(self, newparent=None, newname=None,
@@ -349,7 +349,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
         """The external file handler, if the link has been dereferenced.
         In case the link has not been dereferenced yet, its value is
         None."""
-        super(ExternalLink, self).__init__(parentnode, name, target, _log)
+        super().__init__(parentnode, name, target, _log)
 
     def _get_filename_node(self):
         """Return the external filename and nodepath from `self.target`."""
@@ -411,7 +411,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
         """Especific close for external links."""
 
         self.umount()
-        super(ExternalLink, self)._f_close()
+        super()._f_close()
 
     def __str__(self):
         """Return a short string representation of the link.

--- a/tables/lrucacheextension.pyx
+++ b/tables/lrucacheextension.pyx
@@ -324,7 +324,7 @@ cdef class ObjectCache(BaseCache):
 
     """
 
-    super(ObjectCache, self).__init__(nslots, name)
+    super().__init__(nslots, name)
     self.cachesize = 0
     self.maxcachesize = maxcachesize
     # maxobjsize will be the same as the maximum cache size
@@ -501,7 +501,7 @@ cdef class NumCache(BaseCache):
     if nslots >= 1<<16:
       # nslots can't be higher than 2**16. Will silently trunk the number.
       nslots = <long>((1<<16)-1)  # Cast makes cython happy here
-    super(NumCache, self).__init__(nslots, name)
+    super().__init__(nslots, name)
     self.itemsize = dtype.itemsize
     self.__dict = {}
     # The cache object where all data will go

--- a/tables/misc/proxydict.py
+++ b/tables/misc/proxydict.py
@@ -37,7 +37,7 @@ class ProxyDict(dict):
 
     def __setitem__(self, key, value):
         # Values are not actually stored to avoid extra references.
-        super(ProxyDict, self).__setitem__(key, None)
+        super().__setitem__(key, None)
 
     def __repr__(self):
         return object.__repr__(self)

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -59,7 +59,7 @@ class RawPyTablesIO(io.RawIOBase):
     ]
 
     def __init__(self, node, mode=None):
-        super(RawPyTablesIO, self).__init__()
+        super().__init__()
 
         self._check_node(node)
         self._check_attributes(node)
@@ -162,7 +162,7 @@ class RawPyTablesIO(io.RawIOBase):
                 warnings.warn("host PyTables file is already closed!")
 
         try:
-            super(RawPyTablesIO, self).close()
+            super().close()
         finally:
             # Release node object to allow closing the file.
             self._node = None
@@ -386,7 +386,7 @@ class RawPyTablesIO(io.RawIOBase):
 
         """
 
-        super(RawPyTablesIO, self)._checkClosed()
+        super()._checkClosed()
         if getattr(self._node, '_v_file', None) is None:
             raise ValueError("host PyTables file is already closed!")
 

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -82,7 +82,7 @@ class ClosedFileTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(ClosedFileTestCase, self).setUp()
+        super().setUp()
         self.fnode = filenode.new_node(self.h5file, where='/', name='test')
         self.fnode.close()
 
@@ -94,7 +94,7 @@ class ClosedFileTestCase(TempFileMixin, TestCase):
         """
 
         self.fnode = None
-        super(ClosedFileTestCase, self).tearDown()
+        super().tearDown()
 
     # All these tests mey seem odd, but Python (2.3) files
     # do test whether the file is not closed regardless of their mode.
@@ -186,7 +186,7 @@ class WriteFileTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(WriteFileTestCase, self).setUp()
+        super().setUp()
         self.fnode = filenode.new_node(self.h5file, where='/', name='test')
         self.datafname = test_file(self.datafname)
 
@@ -199,7 +199,7 @@ class WriteFileTestCase(TempFileMixin, TestCase):
 
         self.fnode.close()
         self.fnode = None
-        super(WriteFileTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_WriteFile(self):
         """Writing a whole file node."""
@@ -277,7 +277,7 @@ class OpenFileTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(OpenFileTestCase, self).setUp()
+        super().setUp()
         fnode = filenode.new_node(self.h5file, where='/', name='test')
         fnode.close()
 
@@ -350,7 +350,7 @@ class ReadFileTestCase(TempFileMixin, TestCase):
         self.datafname = test_file(self.datafname)
         self.datafile = open(self.datafname, 'rb')
 
-        super(ReadFileTestCase, self).setUp()
+        super().setUp()
 
         fnode = filenode.new_node(self.h5file, where='/', name='test')
         copyFileToFile(self.datafile, fnode)
@@ -372,7 +372,7 @@ class ReadFileTestCase(TempFileMixin, TestCase):
         self.datafile.close()
         self.datafile = None
 
-        super(ReadFileTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_CompareFile(self):
         """Reading and comparing a whole file node."""
@@ -431,7 +431,7 @@ class ReadlineTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(ReadlineTestCase, self).setUp()
+        super().setUp()
 
         linesep = self.line_separator
 
@@ -459,7 +459,7 @@ class ReadlineTestCase(TempFileMixin, TestCase):
 
         self.fnode.close()
         self.fnode = None
-        super(ReadlineTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_Readline(self):
         """Reading individual lines."""
@@ -608,7 +608,7 @@ class MonoReadlineTestCase(ReadlineTestCase):
 #          * 'h5file', the writable, temporary HDF5 file with a '/test' node
 #          * 'fnode', the writable file node in '/test'
 #        """
-#        super(LineSeparatorTestCase, self).setUp()
+#        super().setUp()
 #        self.fnode = filenode.new_node(self.h5file, where='/', name='test')
 #
 #    def tearDown(self):
@@ -618,7 +618,7 @@ class MonoReadlineTestCase(ReadlineTestCase):
 #        """
 #        self.fnode.close()
 #        self.fnode = None
-#        super(LineSeparatorTestCase, self).tearDown()
+#        super().tearDown()
 #
 #    def test00_DefaultLineSeparator(self):
 #        "Default line separator."
@@ -663,7 +663,7 @@ class AttrsTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(AttrsTestCase, self).setUp()
+        super().setUp()
         self.fnode = filenode.new_node(self.h5file, where='/', name='test')
 
     def tearDown(self):
@@ -675,7 +675,7 @@ class AttrsTestCase(TempFileMixin, TestCase):
 
         self.fnode.close()
         self.fnode = None
-        super(AttrsTestCase, self).tearDown()
+        super().tearDown()
 
     # This no longer works since type and type version attributes
     # are now system attributes.  ivb(2004-12-29)
@@ -765,7 +765,7 @@ class ClosedH5FileTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(ClosedH5FileTestCase, self).setUp()
+        super().setUp()
         self.fnode = filenode.new_node(self.h5file, where='/', name='test')
         self.h5file.close()
 
@@ -788,7 +788,7 @@ class ClosedH5FileTestCase(TempFileMixin, TestCase):
             warnings.filterwarnings('default', category=UserWarning)
 
         self.fnode = None
-        super(ClosedH5FileTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_Write(self):
         """Writing to a file node in a closed PyTables file."""
@@ -820,7 +820,7 @@ class OldVersionTestCase(TestCase):
 
         """
 
-        super(OldVersionTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(suffix='.h5')
 
         self.oldh5fname = test_file(self.oldh5fname)
@@ -841,7 +841,7 @@ class OldVersionTestCase(TestCase):
         self.h5file.close()
         self.h5file = None
         os.remove(self.h5fname)
-        super(OldVersionTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_Read(self):
         """Reading an old version file node."""
@@ -916,7 +916,7 @@ class DirectReadWriteTestCase(TempFileMixin, TestCase):
 
         """
 
-        super(DirectReadWriteTestCase, self).setUp()
+        super().setUp()
         self.datafname = test_file(self.datafname)
         self.testfname = tempfile.mktemp()
         self.testh5fname = tempfile.mktemp(suffix=".h5")
@@ -935,7 +935,7 @@ class DirectReadWriteTestCase(TempFileMixin, TestCase):
         if os.access(self.testh5fname, os.R_OK):
             os.remove(self.testh5fname)
         shutil.rmtree(self.testdir)
-        super(DirectReadWriteTestCase, self).tearDown()
+        super().tearDown()
 
     def test01_WriteToFilename(self):
         # write contents of datafname to h5 testfile

--- a/tables/table.py
+++ b/tables/table.py
@@ -832,8 +832,8 @@ class Table(tableextension.Table, Leaf):
                                  % (chunkshape,))
             self._v_chunkshape = tuple(SizeType(s) for s in chunkshape)
 
-        super(Table, self).__init__(parentnode, name, new, filters,
-                                    byteorder, _log, track_times)
+        super().__init__(parentnode, name, new, filters, byteorder, _log,
+                         track_times)
 
     def _g_post_init_hook(self):
         # We are putting here the index-related issues
@@ -843,7 +843,7 @@ class Table(tableextension.Table, Leaf):
         # First, get back the flavor of input data (if any) for
         # `Leaf._g_post_init_hook()`.
         self._flavor, self._descflavor = self._descflavor, None
-        super(Table, self)._g_post_init_hook()
+        super()._g_post_init_hook()
 
         # Create a cols accessor.
         self.cols = Cols(self, self.description)
@@ -2642,7 +2642,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         self.remove_rows(start=n, stop=n + 1)
 
     def _g_update_dependent(self):
-        super(Table, self)._g_update_dependent()
+        super()._g_update_dependent()
 
         # Update the new path in columns
         self.cols._g_update_table_location(self)
@@ -2661,7 +2661,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         itgpathname = _index_pathname_of(self)
 
         # First, move the table to the new location.
-        super(Table, self)._g_move(newparent, newname)
+        super()._g_move(newparent, newname)
 
         # Then move the associated index group (if any).
         try:
@@ -2685,7 +2685,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             self.indexed = False   # there are indexes no more
 
         # Remove the leaf itself from the hierarchy.
-        super(Table, self)._g_remove(recursive, force)
+        super()._g_remove(recursive, force)
 
     def _set_column_indexing(self, colpathname, indexed):
         """Mark the referred column as indexed or non-indexed."""
@@ -2884,7 +2884,7 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         """
 
-        return super(Table, self).copy(
+        return super().copy(
             newparent, newname, overwrite, createparents, **kwargs)
 
     def flush(self):
@@ -2905,7 +2905,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 # Finally, re-index any dirty column
                 self.reindex_dirty()
 
-        super(Table, self).flush()
+        super().flush()
 
     def _g_pre_kill_hook(self):
         """Code to be called before killing the node."""
@@ -2970,7 +2970,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             cols._g_close()
 
         # Close myself as a leaf.
-        super(Table, self)._f_close(False)
+        super()._f_close(False)
 
     def __repr__(self):
         """This provides column metainfo in addition to standard __str__"""

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -230,7 +230,7 @@ def areArraysEqual(arr1, arr2):
 
 class PyTablesTestCase(unittest.TestCase):
     def tearDown(self):
-        super(PyTablesTestCase, self).tearDown()
+        super().tearDown()
         for key in self.__dict__:
             if self.__dict__[key].__class__.__name__ not in ('instancemethod'):
                 self.__dict__[key] = None
@@ -298,7 +298,7 @@ class TestFileMixin(object):
     open_kwargs = {}
 
     def setUp(self):
-        super(TestFileMixin, self).setUp()
+        super().setUp()
         self.h5file = tables.open_file(
             self.h5fname, title=self._getName(), **self.open_kwargs)
 
@@ -306,7 +306,7 @@ class TestFileMixin(object):
         """Close ``h5file``."""
 
         self.h5file.close()
-        super(TestFileMixin, self).tearDown()
+        super().tearDown()
 
 
 class TempFileMixin(object):
@@ -324,7 +324,7 @@ class TempFileMixin(object):
 
         """
 
-        super(TempFileMixin, self).setUp()
+        super().setUp()
         self.h5fname = self._getTempFileName()
         self.h5file = tables.open_file(
             self.h5fname, self.open_mode, title=self._getName(),
@@ -336,7 +336,7 @@ class TempFileMixin(object):
         self.h5file.close()
         self.h5file = None
         os.remove(self.h5fname)   # comment this for debugging purposes only
-        super(TempFileMixin, self).tearDown()
+        super().tearDown()
 
     def _reopen(self, mode='r', **kwargs):
         """Reopen ``h5file`` in the specified ``mode``.

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -544,7 +544,7 @@ class Basic32DTestCase(BasicTestCase):
 class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(ReadOutArgumentTests, self).setUp()
+        super().setUp()
         self.size = 1000
 
     def create_array(self):
@@ -623,7 +623,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(SizeOnDiskInMemoryPropertyTestCase, self).setUp()
+        super().setUp()
         self.array_size = (10, 10)
         self.array = self.h5file.create_array(
             '/', 'somearray', numpy.zeros(self.array_size, 'i4'))
@@ -641,7 +641,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     """
 
     def setUp(self):
-        super(UnalignedAndComplexTestCase, self).setUp()
+        super().setUp()
         self.root = self.h5file.root
 
     def write_read(self, testArray):
@@ -2018,7 +2018,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 class PointSelectionTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(PointSelectionTestCase, self).setUp()
+        super().setUp()
         # Limits for selections
         self.limits = [
             (0, 1),  # just one element
@@ -2225,7 +2225,7 @@ class PointSelection4(PointSelectionTestCase):
 class FancySelectionTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(FancySelectionTestCase, self).setUp()
+        super().setUp()
 
         M, N, O = self.shape
 
@@ -2393,7 +2393,7 @@ class FancySelection4(FancySelectionTestCase):
 class CopyNativeHDF5MDAtom(TestCase):
 
     def setUp(self):
-        super(CopyNativeHDF5MDAtom, self).setUp()
+        super().setUp()
         filename = test_filename("array_mdatom.h5")
         self.h5file = tables.open_file(filename, "r")
         self.arr = self.h5file.root.arr
@@ -2405,7 +2405,7 @@ class CopyNativeHDF5MDAtom(TestCase):
         self.h5file.close()
         self.copyh.close()
         os.remove(self.copy)
-        super(CopyNativeHDF5MDAtom, self).tearDown()
+        super().tearDown()
 
     def test01_copy(self):
         """Checking that native MD atoms are copied as-is"""
@@ -2426,7 +2426,7 @@ class CopyNativeHDF5MDAtom(TestCase):
 class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(AccessClosedTestCase, self).setUp()
+        super().setUp()
 
         a = numpy.zeros((10, 10))
         self.array = self.h5file.create_array(self.h5file.root, 'array', a)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -30,7 +30,7 @@ class Record(IsDescription):
 
 class CreateTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(CreateTestCase, self).setUp()
+        super().setUp()
         self.root = self.h5file.root
 
         # Create a table object
@@ -689,7 +689,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
         self.open_kwargs = {'allow_padding': self.allow_padding}
-        super(TypesTestCase, self).setUp()
+        super().setUp()
         self.root = self.h5file.root
 
         # Create an array object
@@ -1619,7 +1619,7 @@ class NoSysAttrsTestCase(common.TempFileMixin, TestCase):
     open_kwargs = dict(pytables_sys_attrs=False)
 
     def setUp(self):
-        super(NoSysAttrsTestCase, self).setUp()
+        super().setUp()
         self.root = self.h5file.root
 
         # Create a table object
@@ -1779,13 +1779,13 @@ class EmbeddedNullsTestCase(common.TempFileMixin, TestCase):
 
 class VlenStrAttrTestCase(TestCase):
     def setUp(self):
-        super(VlenStrAttrTestCase, self).setUp()
+        super().setUp()
         self.h5fname = test_filename('vlstr_attr.h5')
         self.h5file = tables.open_file(self.h5fname)
 
     def tearDown(self):
         self.h5file.close()
-        super(VlenStrAttrTestCase, self).tearDown()
+        super().tearDown()
 
     def test01_vlen_str_scalar(self):
         """Checking file with variable length string attributes."""

--- a/tables/tests/test_backcompat.py
+++ b/tables/tests/test_backcompat.py
@@ -78,7 +78,7 @@ class BackCompatAttrsTestCase(common.TestFileMixin, TestCase):
 
     def setUp(self):
         self.h5fname = test_filename(self.FILENAME % self.format)
-        super(BackCompatAttrsTestCase, self).setUp()
+        super().setUp()
 
     def test01_readAttr(self):
         """Checking backward compatibility of old formats for attributes."""

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -39,7 +39,7 @@ from tables.tests.common import PyTablesTestCase as TestCase
 
 class OpenFileFailureTestCase(TestCase):
     def setUp(self):
-        super(OpenFileFailureTestCase, self).setUp()
+        super().setUp()
 
         import tables.file
 
@@ -93,7 +93,7 @@ class OpenFileFailureTestCase(TestCase):
 class OpenFileTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(OpenFileTestCase, self).setUp()
+        super().setUp()
         self.populateFile()
 
     def populateFile(self):
@@ -1190,7 +1190,7 @@ class DictNodeCacheOpenFile(OpenFileTestCase):
 
 class CheckFileTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(CheckFileTestCase, self).setUp()
+        super().setUp()
 
         # Create a regular (text) file
         self.txtfile = tempfile.mktemp(".h5")
@@ -1201,7 +1201,7 @@ class CheckFileTestCase(common.TempFileMixin, TestCase):
     def tearDown(self):
         self.fileh.close()
         os.remove(self.txtfile)
-        super(CheckFileTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_isHDF5File(self):
         """Checking  tables.is_hdf5_file function (TRUE case)"""
@@ -1371,7 +1371,7 @@ class CheckFileTestCase(common.TempFileMixin, TestCase):
                  'FILE_OPEN_POLICY = "strict"')
 class ThreadingTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(ThreadingTestCase, self).setUp()
+        super().setUp()
         self.h5file.create_carray('/', 'test_array', tables.Int64Atom(),
                                   (200, 300))
         self.h5file.close()
@@ -1812,13 +1812,13 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
     scalar_data = numpy.int32(10)
 
     def _reopen(self, mode='r'):
-        super(FlavorTestCase, self)._reopen(mode)
+        super()._reopen(mode)
         self.array = self.h5file.get_node('/array')
         self.scalar = self.h5file.get_node('/scalar')
         return True
 
     def setUp(self):
-        super(FlavorTestCase, self).setUp()
+        super().setUp()
         self.array = self.h5file.create_array('/', 'array', self.array_data)
         self.scalar = self.h5file.create_array('/', 'scalar', self.scalar_data)
 
@@ -1929,7 +1929,7 @@ class UnicodeFilename(common.TempFileMixin, TestCase):
         return tempfile.mktemp(prefix=self.unicode_prefix, suffix='.h5')
 
     def setUp(self):
-        super(UnicodeFilename, self).setUp()
+        super().setUp()
 
         self.test = self.h5file.create_array('/', 'test', [1, 2])
 
@@ -1992,7 +1992,7 @@ class PathLikeFilename(common.TempFileMixin, TestCase):
         return Path(tempfile.mktemp(suffix='.h5'))
 
     def setUp(self):
-        super(PathLikeFilename, self).setUp()
+        super().setUp()
 
         self.test = self.h5file.create_array('/', 'test', [1, 2])
 
@@ -2033,7 +2033,7 @@ class PathLikeFilename(common.TempFileMixin, TestCase):
 
 class FilePropertyTestCase(TestCase):
     def setUp(self):
-        super(FilePropertyTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = None
 
@@ -2043,7 +2043,7 @@ class FilePropertyTestCase(TestCase):
 
         if os.path.exists(self.h5fname):
             os.remove(self.h5fname)
-        super(FilePropertyTestCase, self).tearDown()
+        super().tearDown()
 
     def test_get_filesize(self):
         data = numpy.zeros((2000, 2000))
@@ -2191,12 +2191,12 @@ class BloscSubprocess(TestCase):
 
 class HDF5ErrorHandling(TestCase):
     def setUp(self):
-        super(HDF5ErrorHandling, self).setUp()
+        super().setUp()
         self._old_policy = tables.HDF5ExtError.DEFAULT_H5_BACKTRACE_POLICY
 
     def tearDown(self):
         tables.HDF5ExtError.DEFAULT_H5_BACKTRACE_POLICY = self._old_policy
-        super(HDF5ErrorHandling, self).tearDown()
+        super().tearDown()
 
     def test_silence_messages(self):
         code = """

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -35,7 +35,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     reopen = 1  # Tells whether the file has to be reopened on each test or not
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
         self.populateFile()
@@ -1062,7 +1062,7 @@ class ComprTestCase(BasicTestCase):
 class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(ReadOutArgumentTests, self).setUp()
+        super().setUp()
         self.size = 1000
         self.filters = tables.Filters(complevel=1, complib='blosc')
 
@@ -1107,7 +1107,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(SizeOnDiskInMemoryPropertyTestCase, self).setUp()
+        super().setUp()
         self.array_size = (10000, 10)
         # set chunkshape so it divides evenly into array_size, to avoid
         # partially filled chunks
@@ -1170,7 +1170,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(OffsetStrideTestCase, self).setUp()
+        super().setUp()
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
 
@@ -2013,7 +2013,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
     nanumber = 1000 * 3    # That should account for more than 2**31-1
 
     def setUp(self):
-        super(Rows64bitsTestCase, self).setUp()
+        super().setUp()
 
         # Create an CArray
         shape = (self.narows * self.nanumber,)
@@ -2096,7 +2096,7 @@ class BigArrayTestCase(common.TempFileMixin, TestCase):
     shape = (3000000000,)  # more than 2**31-1
 
     def setUp(self):
-        super(BigArrayTestCase, self).setUp()
+        super().setUp()
         # This should be fast since disk space isn't actually allocated,
         # so this case is OK for non-heavy test runs.
         self.h5file.create_carray('/', 'array',
@@ -2465,7 +2465,7 @@ class MDLargeAtomReopen(MDLargeAtomTestCase):
 class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(AccessClosedTestCase, self).setUp()
+        super().setUp()
         self.array = self.h5file.create_carray(self.h5file.root, 'array',
                                                atom=Int32Atom(),
                                                shape=(10, 10))

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -50,7 +50,7 @@ class CreateTestCase(common.TempFileMixin, TestCase):
     compress = 0
 
     def setUp(self):
-        super(CreateTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of HDF5 Table
         self.root = self.h5file.root
@@ -266,7 +266,7 @@ class FiltersTreeTestCase(common.TempFileMixin, TestCase):
     nrows = 10
 
     def setUp(self):
-        super(FiltersTreeTestCase, self).setUp()
+        super().setUp()
         self.populateFile()
 
     def populateFile(self):
@@ -625,7 +625,7 @@ class FiltersCaseBloscLZ4(FiltersTreeTestCase):
         self.filters = Filters(shuffle=False, complevel=1, complib="blosc:lz4")
         self.gfilters = Filters(complevel=5, shuffle=True, complib="blosc:lz4")
         self.open_kwargs = dict(filters=self.filters)
-        super(FiltersCaseBloscLZ4, self).setUp()
+        super().setUp()
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -638,7 +638,7 @@ class FiltersCaseBloscLZ4HC(FiltersTreeTestCase):
         self.gfilters = Filters(
             complevel=5, shuffle=True, complib="blosc:lz4hc")
         self.open_kwargs = dict(filters=self.filters)
-        super(FiltersCaseBloscLZ4HC, self).setUp()
+        super().setUp()
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -652,7 +652,7 @@ class FiltersCaseBloscSnappy(FiltersTreeTestCase):
         self.gfilters = Filters(
             complevel=5, shuffle=True, complib="blosc:snappy")
         self.open_kwargs = dict(filters=self.filters)
-        super(FiltersCaseBloscSnappy, self).setUp()
+        super().setUp()
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -663,7 +663,7 @@ class FiltersCaseBloscZlib(FiltersTreeTestCase):
         self.filters = Filters(shuffle=False, complevel=1, complib="blosc:zlib")
         self.gfilters = Filters(complevel=5, shuffle=True, complib="blosc:zlib")
         self.open_kwargs = dict(filters=self.filters)
-        super(FiltersCaseBloscZlib, self).setUp()
+        super().setUp()
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -674,7 +674,7 @@ class FiltersCaseBloscZstd(FiltersTreeTestCase):
         self.filters = Filters(shuffle=False, complevel=1, complib="blosc:zstd")
         self.gfilters = Filters(complevel=5, shuffle=True, complib="blosc:zstd")
         self.open_kwargs = dict(filters=self.filters)
-        super(FiltersCaseBloscZstd, self).setUp()
+        super().setUp()
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -693,7 +693,7 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
     nrows = 10
 
     def setUp(self):
-        super(CopyGroupTestCase, self).setUp()
+        super().setUp()
 
         # Create a temporary file
         self.h5fname2 = tempfile.mktemp(".h5")
@@ -768,7 +768,7 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
             self.h5file2.close()
         os.remove(self.h5fname2)
 
-        super(CopyGroupTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_nonRecursive(self):
         """Checking non-recursive copy of a Group"""
@@ -1036,7 +1036,7 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
     nrows = 10
 
     def setUp(self):
-        super(CopyFileTestCase, self).setUp()
+        super().setUp()
 
         # Create a temporary file
         self.h5fname2 = tempfile.mktemp(".h5")
@@ -1113,7 +1113,7 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
         if hasattr(self, 'h5fname2') and os.path.exists(self.h5fname2):
             os.remove(self.h5fname2)
 
-        super(CopyFileTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_overwrite(self):
         """Checking copy of a File (overwriting file)"""
@@ -1399,7 +1399,7 @@ class GroupFiltersTestCase(common.TempFileMixin, TestCase):
     filters = tables.Filters(complevel=4)  # something non-default
 
     def setUp(self):
-        super(GroupFiltersTestCase, self).setUp()
+        super().setUp()
 
         atom, shape = tables.IntAtom(), (1, 1)
         create_group = self.h5file.create_group
@@ -1605,7 +1605,7 @@ class DefaultDriverTestCase(common.TempFileMixin, TestCase):
     open_kwargs = dict(driver=DRIVER, **DRIVER_PARAMS)
 
     def setUp(self):
-        super(DefaultDriverTestCase, self).setUp()
+        super().setUp()
 
         # Create an HDF5 file and contents
         root = self.h5file.root
@@ -1792,7 +1792,7 @@ class CoreDriverNoBackingStoreTestCase(TestCase):
     DRIVER = "H5FD_CORE"
 
     def setUp(self):
-        super(CoreDriverNoBackingStoreTestCase, self).setUp()
+        super().setUp()
 
         self.h5fname = tempfile.mktemp(suffix=".h5")
         self.h5file = None
@@ -1809,7 +1809,7 @@ class CoreDriverNoBackingStoreTestCase(TestCase):
         if os.path.isfile(self.h5fname):
             os.remove(self.h5fname)
 
-        super(CoreDriverNoBackingStoreTestCase, self).tearDown()
+        super().tearDown()
 
     def test_newFile(self):
         """Ensure that nothing is written to file."""
@@ -2041,7 +2041,7 @@ class SplitDriverTestCase(DefaultDriverTestCase):
         return tempfile.mktemp(prefix=self._getName())
 
     def setUp(self):
-        super(SplitDriverTestCase, self).setUp()
+        super().setUp()
 
         self.h5fnames = [self.h5fname + self.DRIVER_PARAMS[k] for k in
                          ("driver_split_meta_ext", "driver_split_raw_ext")]
@@ -2051,7 +2051,7 @@ class SplitDriverTestCase(DefaultDriverTestCase):
         for fname in self.h5fnames:
             if os.path.isfile(fname):
                 os.remove(fname)
-        #super(SplitDriverTestCase, self).tearDown()
+        #super().tearDown()
         TestCase.tearDown(self)
 
     def assertIsFile(self):
@@ -2065,7 +2065,7 @@ class NotSpportedDriverTestCase(TestCase):
     EXCEPTION = ValueError
 
     def setUp(self):
-        super(NotSpportedDriverTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(suffix=".h5")
 
     def tearDown(self):
@@ -2075,7 +2075,7 @@ class NotSpportedDriverTestCase(TestCase):
                 h5file.close()
         if os.path.exists(self.h5fname):
             os.remove(self.h5fname)
-        super(NotSpportedDriverTestCase, self).tearDown()
+        super().tearDown()
 
     def test_newFile(self):
         self.assertRaises(self.EXCEPTION, tables.open_file, self.h5fname,
@@ -2100,12 +2100,12 @@ class LogDriverTestCase(BaseLogDriverTestCase):
             "driver_log_file": tempfile.mktemp(suffix=".log")
         }
 
-        super(LogDriverTestCase, self).setUp()
+        super().setUp()
 
     def tearDown(self):
         if os.path.exists(self.DRIVER_PARAMS["driver_log_file"]):
             os.remove(self.DRIVER_PARAMS["driver_log_file"])
-        super(LogDriverTestCase, self).tearDown()
+        super().tearDown()
 
 
 if HAVE_DIRECT_DRIVER:
@@ -2159,7 +2159,7 @@ class InMemoryCoreDriverTestCase(TestCase):
     DRIVER = "H5FD_CORE"
 
     def setUp(self):
-        super(InMemoryCoreDriverTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = None
 
@@ -2170,7 +2170,7 @@ class InMemoryCoreDriverTestCase(TestCase):
 
         if os.path.isfile(self.h5fname):
             os.remove(self.h5fname)
-        super(InMemoryCoreDriverTestCase, self).tearDown()
+        super().tearDown()
 
     def _create_image(self, filename="in-memory", title="Title", mode='w'):
         h5file = tables.open_file(filename, mode=mode, title=title,
@@ -2431,7 +2431,7 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
     appendrows = 5
 
     def setUp(self):
-        super(QuantizeTestCase, self).setUp()
+        super().setUp()
 
         self.data = numpy.linspace(-5., 5., 41)
         self.randomdata = numpy.random.random_sample(1000000)

--- a/tables/tests/test_do_undo.py
+++ b/tables/tests/test_do_undo.py
@@ -23,7 +23,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             self._reopen('r+')
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -983,7 +983,7 @@ class CreateArrayTestCase(common.TempFileMixin, TestCase):
     """Test for create_array operations"""
 
     def setUp(self):
-        super(CreateArrayTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -1150,7 +1150,7 @@ class CreateGroupTestCase(common.TempFileMixin, TestCase):
     """Test for create_group operations"""
 
     def setUp(self):
-        super(CreateGroupTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -1354,7 +1354,7 @@ class RenameNodeTestCase(common.TempFileMixin, TestCase):
     """Test for rename_node operations"""
 
     def setUp(self):
-        super(RenameNodeTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -1568,7 +1568,7 @@ class MoveNodeTestCase(common.TempFileMixin, TestCase):
     """Tests for move_node operations"""
 
     def setUp(self):
-        super(MoveNodeTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -1786,7 +1786,7 @@ class RemoveNodeTestCase(common.TempFileMixin, TestCase):
     """Test for remove_node operations"""
 
     def setUp(self):
-        super(RemoveNodeTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -1980,7 +1980,7 @@ class CopyNodeTestCase(common.TempFileMixin, TestCase):
     """Tests for copy_node and copy_children operations"""
 
     def setUp(self):
-        super(CopyNodeTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -2188,7 +2188,7 @@ class ComplexTestCase(common.TempFileMixin, TestCase):
     """Tests for a mix of all operations"""
 
     def setUp(self):
-        super(ComplexTestCase, self).setUp()
+        super().setUp()
 
         h5file = self.h5file
         root = h5file.root
@@ -2438,7 +2438,7 @@ class AttributesTestCase(common.TempFileMixin, TestCase):
     """Tests for operation on attributes"""
 
     def setUp(self):
-        super(AttributesTestCase, self).setUp()
+        super().setUp()
 
         # Create an array.
         array = self.h5file.create_array('/', 'array', [1, 2])
@@ -2620,7 +2620,7 @@ class CreateParentsTestCase(common.TempFileMixin, TestCase):
     """Test the ``createparents`` flag."""
 
     def setUp(self):
-        super(CreateParentsTestCase, self).setUp()
+        super().setUp()
         g1 = self.h5file.create_group('/', 'g1')
         self.h5file.create_group(g1, 'g2')
 

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -34,7 +34,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     reopen = 1  # Tells whether the file has to be reopened on each test or not
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -1226,7 +1226,7 @@ class StringComprTestCase(BasicTestCase):
 class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(SizeOnDiskInMemoryPropertyTestCase, self).setUp()
+        super().setUp()
 
         self.array_size = (0, 10)
         # set chunkshape so it divides evenly into array_size, to avoid
@@ -1282,7 +1282,7 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(OffsetStrideTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
 
     def test01a_String(self):
@@ -2166,7 +2166,7 @@ class CopyIndex12TestCase(CopyIndexTestCase):
 class TruncateTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(TruncateTestCase, self).setUp()
+        super().setUp()
 
         # Create an EArray
         atom = Int16Atom(dflt=3)
@@ -2275,7 +2275,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
     nanumber = 1000 * 3    # That should account for more than 2**31-1
 
     def setUp(self):
-        super(Rows64bitsTestCase, self).setUp()
+        super().setUp()
 
         # Create an EArray
         array = self.h5file.create_earray(
@@ -2353,7 +2353,7 @@ class ZeroSizedTestCase(common.TempFileMixin, TestCase):
     open_mode = 'a'
 
     def setUp(self):
-        super(ZeroSizedTestCase, self).setUp()
+        super().setUp()
 
         # Create an EArray
         ea = self.h5file.create_earray('/', 'test',
@@ -2522,7 +2522,7 @@ class MDAtomReopen(MDAtomTestCase):
 class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(AccessClosedTestCase, self).setUp()
+        super().setUp()
         self.array = self.h5file.create_earray(self.h5file.root, 'array',
                                                atom=Int32Atom(), shape=(0, 10))
         self.array.append(numpy.zeros((10, 10)))

--- a/tables/tests/test_expression.py
+++ b/tables/tests/test_expression.py
@@ -58,7 +58,7 @@ class ExprTestCase(common.TempFileMixin, TestCase):
     shape = (10, 20)
 
     def setUp(self):
-        super(ExprTestCase, self).setUp()
+        super().setUp()
 
         # The expression
         self.expr = "2 * a*b + c"
@@ -189,7 +189,7 @@ class ExprColumn(ExprTestCase):
 class MixedContainersTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(MixedContainersTestCase, self).setUp()
+        super().setUp()
 
         # The expression
         self.expr = "2 * a*b + c**2+d**2+e-f+g"
@@ -528,7 +528,7 @@ class ExprError(common.TempFileMixin, TestCase):
     shape = (10,)
 
     def setUp(self):
-        super(ExprError, self).setUp()
+        super().setUp()
 
         # Define the NumPy variables to be used in expression
         N = np.prod(self.shape)
@@ -1162,7 +1162,7 @@ class AppendModeFalse(AppendModeTestCase):
 class iterTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(iterTestCase, self).setUp()
+        super().setUp()
         shape = list(self.shape)
         # Build input arrays
         a = np.arange(np.prod(shape), dtype="i4").reshape(shape)

--- a/tables/tests/test_index_backcompat.py
+++ b/tables/tests/test_index_backcompat.py
@@ -11,7 +11,7 @@ from tables.tests.common import PyTablesTestCase as TestCase
 class IndexesTestCase(common.TestFileMixin, TestCase):
 
     def setUp(self):
-        super(IndexesTestCase, self).setUp()
+        super().setUp()
         self.table1 = self.h5file.root.table1
         self.table2 = self.h5file.root.table2
         self.il = 0

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -41,7 +41,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     ss = small_blocksizes[2]
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         self.rootgroup = self.h5file.root
         self.populateFile()
@@ -973,7 +973,7 @@ class AutomaticIndexingTestCase(common.TempFileMixin, TestCase):
     small_blocksizes = (16, 8, 4, 2)
 
     def setUp(self):
-        super(AutomaticIndexingTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         title = "This is the IndexArray title"
@@ -1689,7 +1689,7 @@ class IndexPropsChangeTestCase(TempFileMixin, TestCase):
     newIndexProps = IndexProps(auto=False, filters=tables.Filters(complevel=9))
 
     def setUp(self):
-        super(IndexPropsChangeTestCase, self).setUp()
+        super().setUp()
 
         table = self.h5file.create_table('/', 'test', self.MyDescription)
         table.autoindex = self.oldIndexProps.auto
@@ -1717,7 +1717,7 @@ class IndexFiltersTestCase(TempFileMixin, TestCase):
     """Test case for setting index filters."""
 
     def setUp(self):
-        super(IndexFiltersTestCase, self).setUp()
+        super().setUp()
         description = {'icol': IntCol()}
         self.table = self.h5file.create_table('/', 'test', description)
 
@@ -1791,7 +1791,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         icol = IntCol(pos=2)
 
     def setUp(self):
-        super(CompletelySortedIndexTestCase, self).setUp()
+        super().setUp()
         table = self.h5file.create_table('/', 'table', self.MyDescription)
         row = table.row
         nrows = self.nrows
@@ -2357,7 +2357,7 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         icol = IntCol(pos=2)
 
     def setUp(self):
-        super(ReadSortedIndexTestCase, self).setUp()
+        super().setUp()
 
         table = self.h5file.create_table('/', 'table', self.MyDescription)
         row = table.row
@@ -2454,7 +2454,7 @@ class Issue156TestBase(common.TempFileMixin, TestCase):
     sort_field = None
 
     def setUp(self):
-        super(Issue156TestBase, self).setUp()
+        super().setUp()
 
         # create nested table
         class Foo(tables.IsDescription):
@@ -2529,7 +2529,7 @@ class Issue119Time32ColTestCase(common.TempFileMixin, TestCase):
     ]
 
     def setUp(self):
-        super(Issue119Time32ColTestCase, self).setUp()
+        super().setUp()
 
         class Descr(tables.IsDescription):
             when = self.col_typ(pos=1)

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -46,7 +46,7 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
     reopen = False
 
     def setUp(self):
-        super(SelectValuesTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         if verbose:
@@ -3168,7 +3168,7 @@ class LastRowReuseBuffers(TestCase):
         id1 = tables.Int16Col()
 
     def setUp(self):
-        super(LastRowReuseBuffers, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = None
 
@@ -3177,7 +3177,7 @@ class LastRowReuseBuffers(TestCase):
             self.h5file.close()
         if os.path.exists(self.h5fname):
             os.remove(self.h5fname)
-        super(LastRowReuseBuffers, self).tearDown()
+        super().tearDown()
 
     def test00_lrucache(self):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=64)

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -26,7 +26,7 @@ from tables.tests.common import PyTablesTestCase as TestCase
 class HardLinkTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(HardLinkTestCase, self).setUp()
+        super().setUp()
         self._createFile()
 
     def _createFile(self):
@@ -105,7 +105,7 @@ class HardLinkTestCase(common.TempFileMixin, TestCase):
 class SoftLinkTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(SoftLinkTestCase, self).setUp()
+        super().setUp()
         self._createFile()
 
     def _createFile(self):
@@ -369,7 +369,7 @@ class SoftLinkTestCase(common.TempFileMixin, TestCase):
 class ExternalLinkTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(ExternalLinkTestCase, self).setUp()
+        super().setUp()
 
         self.extfname = tempfile.mktemp(".h5")
         self.exth5file = tables.open_file(self.extfname, "w")
@@ -380,7 +380,7 @@ class ExternalLinkTestCase(common.TempFileMixin, TestCase):
 
         extfname = self.extfname
         self.exth5file.close()
-        super(ExternalLinkTestCase, self).tearDown()
+        super().tearDown()
 
         #open_files = tables.file._open_files
         #if self.extfname in open_files:

--- a/tables/tests/test_lists.py
+++ b/tables/tests/test_lists.py
@@ -47,7 +47,7 @@ def WriteRead(filename, testTuple):
 
 class BasicTestCase(TestCase):
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = None
 
@@ -56,7 +56,7 @@ class BasicTestCase(TestCase):
             self.h5file.close()
         if os.path.exists(self.h5fname):
             os.remove(self.h5fname)
-        super(BasicTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_char(self):
         """Data integrity during recovery (character types)"""
@@ -123,7 +123,7 @@ class Basic10DTestCase(BasicTestCase):
 
 class ExceptionTestCase(TestCase):
     def setUp(self):
-        super(ExceptionTestCase, self).setUp()
+        super().setUp()
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = None
 
@@ -132,7 +132,7 @@ class ExceptionTestCase(TestCase):
             self.h5file.close()
         if os.path.exists(self.h5fname):
             os.remove(self.h5fname)
-        super(ExceptionTestCase, self).tearDown()
+        super().tearDown()
 
     def test00_char(self):
         """Non suppported lists objects (character objects)"""

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -412,7 +412,7 @@ class TableReadTestCase(common.TempFileMixin, TestCase):
     nrows = 100
 
     def setUp(self):
-        super(TableReadTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         table = self.h5file.create_table(self.h5file.root, 'table', Record)
@@ -614,7 +614,7 @@ class TableNativeFlavorTestCase(common.TempFileMixin, TestCase):
     nrows = 100
 
     def setUp(self):
-        super(TableNativeFlavorTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         table = self.h5file.create_table(self.h5file.root, 'table', TestTDescr,
@@ -1228,7 +1228,7 @@ class TableNativeFlavorCloseTestCase(TableNativeFlavorTestCase):
 
 class AttributesTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(AttributesTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.h5file.create_group(self.h5file.root, 'group')
@@ -1297,7 +1297,7 @@ class AttributesCloseTestCase(AttributesTestCase):
 
 class StrlenTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(StrlenTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         group = self.h5file.create_group(self.h5file.root, 'group')

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -297,7 +297,7 @@ class BaseTableQueryTestCase(common.TempFileMixin, TestCase):
                 "Indexing columns of this type is not supported yet.")
 
     def setUp(self):
-        super(BaseTableQueryTestCase, self).setUp()
+        super().setUp()
         self.table = self.h5file.create_table(
             '/', 'test', self.tableDescription, expectedrows=self.nrows)
         fill_table(self.table, self.shape, self.nrows)
@@ -795,7 +795,7 @@ class IndexedTableUsage(ScalarTableMixin, BaseTableUsageTestCase):
     indexed = True
 
     def setUp(self):
-        super(IndexedTableUsage, self).setUp()
+        super().setUp()
         self.table.cols.c_bool.create_index(_blocksizes=small_blocksizes)
         self.table.cols.c_int32.create_index(_blocksizes=small_blocksizes)
         self.will_query_use_indexing = self.table.will_query_use_indexing

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -136,7 +136,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     maxshort = 1 << 15
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -1870,7 +1870,7 @@ class BigTablesTestCase(BasicTestCase):
 
 class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(SizeOnDiskInMemoryPropertyTestCase, self).setUp()
+        super().setUp()
 
         # set chunkshape so it divides evenly into array_size, to avoid
         # partially filled chunks
@@ -1921,7 +1921,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
 class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(NonNestedTableReadTestCase, self).setUp()
+        super().setUp()
 
         self.dtype = np.format_parser(['i4'] * 10, [], []).dtype
         self.table = self.h5file.create_table('/', 'table', self.dtype)
@@ -2050,7 +2050,7 @@ class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):
 
 class TableReadByteorderTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(TableReadByteorderTestCase, self).setUp()
+        super().setUp()
         self.system_byteorder = sys.byteorder
         self.other_byteorder = {
             'little': 'big', 'big': 'little'}[sys.byteorder]
@@ -2142,7 +2142,7 @@ class BasicRangeTestCase(common.TempFileMixin, TestCase):
     checkgetCol = 0
 
     def setUp(self):
-        super(BasicRangeTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -2614,7 +2614,7 @@ class GetItemTestCase(common.TempFileMixin, TestCase):
     checkgetCol = 0
 
     def setUp(self):
-        super(GetItemTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -5402,7 +5402,7 @@ class LengthTestCase(common.TempFileMixin, TestCase):
     nrows = 20
 
     def setUp(self):
-        super(LengthTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -5477,7 +5477,7 @@ class WhereAppendTestCase(common.TempFileMixin, TestCase):
         v2 = StringCol(itemsize=8)
 
     def setUp(self):
-        super(WhereAppendTestCase, self).setUp()
+        super().setUp()
 
         tbl = self.h5file.create_table('/', 'test', self.SrcTblDesc)
         row = tbl.row
@@ -5644,7 +5644,7 @@ class WhereAppendTestCase(common.TempFileMixin, TestCase):
 
 class DerivedTableTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(DerivedTableTestCase, self).setUp()
+        super().setUp()
         self.h5file.create_table('/', 'original', Record)
 
     def test00(self):
@@ -5658,7 +5658,7 @@ class DerivedTableTestCase(common.TempFileMixin, TestCase):
 
 class ChunkshapeTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(ChunkshapeTestCase, self).setUp()
+        super().setUp()
         self.h5file.create_table('/', 'table', Record, chunkshape=13)
 
     def test00(self):
@@ -5683,7 +5683,7 @@ class ChunkshapeTestCase(common.TempFileMixin, TestCase):
 # Test for appending zero-sized recarrays
 class ZeroSizedTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(ZeroSizedTestCase, self).setUp()
+        super().setUp()
 
         # Create a Table
         t = self.h5file.create_table('/', 'table',
@@ -5708,7 +5708,7 @@ class ZeroSizedTestCase(common.TempFileMixin, TestCase):
 # len(datatype) > boundary_alignment is fullfilled.
 class IrregularStrideTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(IrregularStrideTestCase, self).setUp()
+        super().setUp()
 
         class IRecord(tables.IsDescription):
             c1 = Int32Col(pos=1)
@@ -5736,7 +5736,7 @@ class IrregularStrideTestCase(common.TempFileMixin, TestCase):
 
 class Issue262TestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(Issue262TestCase, self).setUp()
+        super().setUp()
 
         class IRecord(tables.IsDescription):
             c1 = Int32Col(pos=1)
@@ -5823,7 +5823,7 @@ class Issue262TestCase(common.TempFileMixin, TestCase):
 
 class TruncateTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(TruncateTestCase, self).setUp()
+        super().setUp()
 
         table = self.h5file.create_table('/', 'table', self.IRecord)
         # Fill just a couple of rows
@@ -5951,7 +5951,7 @@ class TruncateClose2(TruncateTestCase):
 
 class PointSelectionTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(PointSelectionTestCase, self).setUp()
+        super().setUp()
 
         N = 100
 
@@ -6154,7 +6154,7 @@ class MDLargeColReopen(MDLargeColTestCase):
 # See ticket #264.
 class ExhaustedIter(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(ExhaustedIter, self).setUp()
+        super().setUp()
 
         class Observations(tables.IsDescription):
             market_id = IntCol(pos=0)
@@ -6237,7 +6237,7 @@ class RowContainsTestCase(common.TempFileMixin, TestCase):
 
 class AccessClosedTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(AccessClosedTestCase, self).setUp()
+        super().setUp()
         self.table = self.h5file.create_table(
             self.h5file.root, 'table', Record)
 
@@ -6300,7 +6300,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
 class ColumnIterationTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(ColumnIterationTestCase, self).setUp()
+        super().setUp()
         self.buffer_size = self.h5file.params['IO_BUFFER_SIZE']
 
     def create_non_nested_table(self, nrows, dtype):

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -77,7 +77,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     maxshort = 1 << 15
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -574,7 +574,7 @@ class BasicRangeTestCase(common.TempFileMixin, TestCase):
     checkgetCol = 0
 
     def setUp(self):
-        super(BasicRangeTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -1286,7 +1286,7 @@ class RecordT(tables.IsDescription):
 class ShapeTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(ShapeTestCase, self).setUp()
+        super().setUp()
         self.populateFile()
 
     def populateFile(self):
@@ -1368,7 +1368,7 @@ class ShapeTestCase2(ShapeTestCase):
 class SetItemTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(SetItemTestCase, self).setUp()
+        super().setUp()
 
         # Create a new table:
         self.table = self.h5file.create_table(self.h5file.root,
@@ -1757,7 +1757,7 @@ class SetItemTestCase4(SetItemTestCase):
 class UpdateRowTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(UpdateRowTestCase, self).setUp()
+        super().setUp()
 
         # Create a new table:
         self.table = self.h5file.create_table(self.h5file.root,

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -80,7 +80,7 @@ class TimestampTestCase(TrackTimesMixin, common.TempFileMixin, TestCase):
     nrows = 10
 
     def setUp(self):
-        super(TimestampTestCase, self).setUp()
+        super().setUp()
         self.populateFile()
 
     def populateFile(self):

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -82,7 +82,7 @@ class OpenTestCase(common.TempFileMixin, TestCase):
     myTime64Atom = tables.Time64Atom(shape=(2, 1))
 
     def setUp(self):
-        super(OpenTestCase, self).setUp()
+        super().setUp()
 
         # Create test Table.
         self.h5file.create_table('/', 'table', self.MyTimeRow)
@@ -406,13 +406,13 @@ class BigEndianTestCase(TestCase):
     """Tests for reading big-endian time values in arrays and nested tables."""
 
     def setUp(self):
-        super(BigEndianTestCase, self).setUp()
+        super().setUp()
         filename = test_filename('times-nested-be.h5')
         self.h5file = tables.open_file(filename, 'r')
 
     def tearDown(self):
         self.h5file.close()
-        super(BigEndianTestCase, self).tearDown()
+        super().tearDown()
 
     def test00a_Read32Array(self):
         """Checking Time32 type in arrays."""

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -31,7 +31,7 @@ class TreeTestCase(common.TempFileMixin, TestCase):
     appendrows = 5
 
     def setUp(self):
-        super(TreeTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of HDF5 Table
         self.populateFile()
@@ -587,7 +587,7 @@ class DeepTreeTestCase(common.TempFileMixin, TestCase):
     """Checks for deep hierarchy levels in PyTables trees."""
 
     def setUp(self):
-        super(DeepTreeTestCase, self).setUp()
+        super().setUp()
 
         # Here we put a more conservative limit to deal with more platforms
         # With maxdepth = 64 this test would take less than 40 MB
@@ -857,7 +857,7 @@ class HiddenTreeTestCase(common.TempFileMixin, TestCase):
     """Check for hidden groups, leaves and hierarchies."""
 
     def setUp(self):
-        super(HiddenTreeTestCase, self).setUp()
+        super().setUp()
 
         self.visible = []  # list of visible object paths
         self.hidden = []  # list of hidden object paths
@@ -1057,7 +1057,7 @@ class CreateParentsTestCase(common.TempFileMixin, TestCase):
     filters = tables.Filters(complevel=4)  # simply non-default
 
     def setUp(self):
-        super(CreateParentsTestCase, self).setUp()
+        super().setUp()
         self.h5file.create_array('/', 'array', [1])
         self.h5file.create_group('/', 'group', filters=self.filters)
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -43,7 +43,7 @@ class RangeTestCase(common.TempFileMixin, TestCase):
     compress = 0
 
     def setUp(self):
-        super(RangeTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
 
         # Create a table
@@ -156,7 +156,7 @@ class ReadFloatTestCase(common.TestFileMixin, TestCase):
     ncols = 6
 
     def setUp(self):
-        super(ReadFloatTestCase, self).setUp()
+        super().setUp()
         x = numpy.arange(self.ncols)
         y = numpy.arange(self.nrows)
         y.shape = (self.nrows, 1)

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -30,7 +30,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
     flavor = "numpy"
 
     def setUp(self):
-        super(BasicTestCase, self).setUp()
+        super().setUp()
 
         # Create an instance of an HDF5 Table
         self.rootgroup = self.h5file.root
@@ -1359,7 +1359,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         vlarray = self.h5file.create_vlarray(
             '/', "Object", atom=ObjectAtom())
-        vlarray.append([[1, 2, 3], "aaa", u"aaaççç"])
+        vlarray.append([[1, 2, 3], "aaa", u"aaaï¿½ï¿½ï¿½"])
         vlarray.append([3, 4, C()])
         vlarray.append(42)
 
@@ -1376,7 +1376,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertEqual(row[0], [[1, 2, 3], "aaa", u"aaaççç"])
+        self.assertEqual(row[0], [[1, 2, 3], "aaa", u"aaaï¿½ï¿½ï¿½"])
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [3, 4])
@@ -1396,14 +1396,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray('/', "Object", atom=ObjectAtom())
         # When updating an object, this seems to change the number
         # of bytes that pickle.dumps generates
-        # vlarray.append(([1,2,3], "aaa", u"aaaççç"))
-        vlarray.append(([1, 2, 3], "aaa", u"çç4"))
+        # vlarray.append(([1,2,3], "aaa", u"aaaï¿½ï¿½ï¿½"))
+        vlarray.append(([1, 2, 3], "aaa", u"ï¿½ï¿½4"))
         # vlarray.append([3,4, C()])
         vlarray.append([3, 4, [24]])
 
         # Modify the rows
-        # vlarray[0] = ([1,2,4], "aa4", u"aaaçç4")
-        vlarray[0] = ([1, 2, 4], "aa4", u"çç5")
+        # vlarray[0] = ([1,2,4], "aa4", u"aaaï¿½ï¿½4")
+        vlarray[0] = ([1, 2, 4], "aa4", u"ï¿½ï¿½5")
         # vlarray[1] = (3,4, C())
         vlarray[1] = [4, 4, [24]]
 
@@ -1420,7 +1420,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertEqual(row[0], ([1, 2, 4], "aa4", u"çç5"))
+        self.assertEqual(row[0], ([1, 2, 4], "aa4", u"ï¿½ï¿½5"))
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [4, 4])
@@ -1595,7 +1595,7 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(MDTypesTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
 
     def test01_StringAtom(self):
@@ -1930,7 +1930,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
     open_mode = "w"
 
     def setUp(self):
-        super(AppendShapeTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
 
     def test00_difinputs(self):
@@ -2111,7 +2111,7 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(FlavorTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
 
     def test01a_EmptyVLArray(self):
@@ -2417,7 +2417,7 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(ReadRangeTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
         self.populateFile()
         self._reopen()
@@ -2823,7 +2823,7 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(GetItemRangeTestCase, self).setUp()
+        super().setUp()
 
         self.rootgroup = self.h5file.root
         self.populateFile()
@@ -3150,7 +3150,7 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
     complib = "zlib"  # Default compression library
 
     def setUp(self):
-        super(SetRangeTestCase, self).setUp()
+        super().setUp()
         self.rootgroup = self.h5file.root
         self.populateFile()
         self._reopen(mode='a')
@@ -3879,7 +3879,7 @@ class CopyIndex12TestCase(CopyIndexTestCase):
 class ChunkshapeTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(ChunkshapeTestCase, self).setUp()
+        super().setUp()
         atom = Int32Atom(shape=(2,))
         self.h5file.create_vlarray('/', 'vlarray', atom=atom,
                                    title="t array1",
@@ -3906,13 +3906,13 @@ class ChunkshapeTestCase(common.TempFileMixin, TestCase):
 
 class VLUEndianTestCase(TestCase):
     def setUp(self):
-        super(VLUEndianTestCase, self).setUp()
+        super().setUp()
         self.h5fname = test_filename('vlunicode_endian.h5')
         self.h5file = tables.open_file(self.h5fname)
 
     def tearDown(self):
         self.h5file.close()
-        super(VLUEndianTestCase, self).tearDown()
+        super().tearDown()
 
     def test(self):
         """Accessing ``vlunicode`` data of a different endianness."""
@@ -3926,7 +3926,7 @@ class VLUEndianTestCase(TestCase):
 class TruncateTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(TruncateTestCase, self).setUp()
+        super().setUp()
 
         # Create an VLArray
         arr = Int16Atom(dflt=3)
@@ -4036,7 +4036,7 @@ class TruncateCloseTestCase(TruncateTestCase):
 class PointSelectionTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
-        super(PointSelectionTestCase, self).setUp()
+        super().setUp()
 
         # The next are valid selections for both NumPy and PyTables
         self.working_keyset = [
@@ -4169,7 +4169,7 @@ class SizeOnDiskPropertyTestCase(common.TempFileMixin, TestCase):
 
 class AccessClosedTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
-        super(AccessClosedTestCase, self).setUp()
+        super().setUp()
         self.array = self.h5file.create_vlarray(
             self.h5file.root, 'array', atom=StringAtom(8))
         self.array.append([str(i) for i in range(5, 5005, 100)])

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -64,7 +64,7 @@ class UnImplemented(hdf5extension.UnImplemented, Leaf):
         """The endianness of data in memory ('big', 'little' or
         'irrelevant')."""
 
-        super(UnImplemented, self).__init__(parentnode, name)
+        super().__init__(parentnode, name)
 
     def _g_open(self):
         (self.shape, self.byteorder, object_id) = self._open_unimplemented()
@@ -130,7 +130,7 @@ class Unknown(Node):
         """Create the `Unknown` instance."""
 
         self._v_new = False
-        super(Unknown, self).__init__(parentnode, name)
+        super().__init__(parentnode, name)
 
     def _g_new(self, parentnode, name, init=False):
         pass

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -366,7 +366,7 @@ class CacheDict(dict):
 
     def __init__(self, maxentries):
         self.maxentries = maxentries
-        super(CacheDict, self).__init__(self)
+        super().__init__(self)
 
     def __setitem__(self, key, value):
         # Protection against growing the cache too much
@@ -374,8 +374,8 @@ class CacheDict(dict):
             # Remove a 10% of (arbitrary) elements from the cache
             entries_to_remove = self.maxentries / 10
             for k in list(self.keys())[:entries_to_remove]:
-                super(CacheDict, self).__delitem__(k)
-        super(CacheDict, self).__setitem__(key, value)
+                super().__delitem__(k)
+        super().__setitem__(key, value)
 
 
 class NailedDict(object):

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -346,11 +346,11 @@ class VLArray(hdf5extension.VLArray, Leaf):
                                  % (chunkshape,))
             self._v_chunkshape = tuple(SizeType(s) for s in chunkshape)
 
-        super(VLArray, self).__init__(parentnode, name, new, filters,
+        super().__init__(parentnode, name, new, filters,
                                       byteorder, _log, track_times)
 
     def _g_post_init_hook(self):
-        super(VLArray, self)._g_post_init_hook()
+        super()._g_post_init_hook()
         self.nrowsinbuf = 100  # maybe enough for most applications
 
     # This is too specific for moving it into Leaf


### PR DESCRIPTION
On Python 3, `super` doesn't need to called with arguments where as on Python 2, `super` needs to be called with a class object and an instance as the two arguments e.g. `super(EArray, self)`.

Now that the pytables codebase is python 3 only, the `super` usage can be updated to remove the need to pass args.

Note that these changes were done using automated regex-based search and replace. `(super)+\(+(\w+)(,)+\s(self)+\)+`. The regex searches for the word `"super"`, followed by the character `(`, followed by another word, followed by the comma character `,`, followed by the word `"self"`, followed by the character `)`.

After the automated search and replace was done, each change was individually checked and added to the commit. Each change was checked to ensure that the `super` was being called with the current class and not a super class. For example, in `CArray`, the usage `super(Array, self)` has not been updated. A few other such uses have been observed. I am not sure if they are intentional or if they are hidden bugs.

Note to reviewer : These changes were not prompted by any specific issue in the repository but something I noticed while I was going through the codebase. This is a large changeset and I fully understand if the maintainer/maintainers decide to not merge this PR/close this PR/brake it up into smaller chunks.

Ref : https://docs.python.org/3/library/functions.html#super