### PR TITLE
Remove u string prefixes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -151,7 +151,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   ('usersguide/usersguide', 'usersguide-%s.tex' % version,
-   u'PyTables User Guide', u'PyTables maintainers', 'manual'),
+   'PyTables User Guide', 'PyTables maintainers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1186,7 +1186,7 @@ class VLUnicodeAtom(_BufferedAtom):
     def fromarray(self, array):
         length = len(array)
         if length == 0:
-            return u''  # ``array.view('U0')`` raises a `TypeError`
+            return ''  # ``array.view('U0')`` raises a `TypeError`
         return array.view('U%d' % length).item()
 
 

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -365,7 +365,7 @@ class AttributeSet(hdf5extension.AttributeSet, object):
                 # explaining how the user can tell where the problem was.
                 retval = value
             # Additional check for allowing a workaround for #307
-            if isinstance(retval, str) and retval == u'':
+            if isinstance(retval, str) and retval == '':
                 retval = numpy.array(retval)[()]
         elif name == 'FILTERS' and format_version is not None and format_version >= (2, 0):
             retval = Filters._unpack(value)
@@ -415,7 +415,7 @@ class AttributeSet(hdf5extension.AttributeSet, object):
                                 numpy.unicode_)):
             # Additional check for allowing a workaround for #307
             if isinstance(value, str) and len(value) == 0:
-                stvalue = numpy.array(u'')
+                stvalue = numpy.array('')
             else:
                 stvalue = numpy.array(value)
             value = stvalue[()]

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -228,13 +228,13 @@ cdef object get_attribute_string_or_none(hid_t node_id, char* attr_name):
     size = H5ATTRget_attribute_string(node_id, attr_name, &attr_value, &cset)
     if size == 0:
       if cset == H5T_CSET_UTF8:
-        retvalue = numpy.unicode_(u'')
+        retvalue = numpy.unicode_('')
       else:
         retvalue = numpy.bytes_(b'')
     elif cset == H5T_CSET_UTF8:
       if size == 1 and attr_value[0] == 0:
         # compatibility with PyTables <= 3.1.1
-        retvalue = numpy.unicode_(u'')
+        retvalue = numpy.unicode_('')
       retvalue = PyUnicode_DecodeUTF8(attr_value, size, NULL)
       retvalue = numpy.unicode_(retvalue)
     else:
@@ -760,14 +760,14 @@ cdef class AttributeSet:
                                              &cset)
       if type_size == 0:
         if cset == H5T_CSET_UTF8:
-          retvalue = numpy.unicode_(u'')
+          retvalue = numpy.unicode_('')
         else:
           retvalue = numpy.bytes_(b'')
 
       elif cset == H5T_CSET_UTF8:
         if type_size == 1 and str_value[0] == 0:
           # compatibility with PyTables <= 3.1.1
-          retvalue = numpy.unicode_(u'')
+          retvalue = numpy.unicode_('')
         retvalue = PyUnicode_DecodeUTF8(str_value, type_size, NULL)
         retvalue = numpy.unicode_(retvalue)
       else:

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -645,7 +645,7 @@ class MonoReadlineTestCase(ReadlineTestCase):
 #        self.assertRaises(
 #            ValueError, setattr, self.fnode, 'line_separator', b'x' * 1024)
 #        self.assertRaises(
-#            TypeError, setattr, self.fnode, 'line_separator', u'x')
+#            TypeError, setattr, self.fnode, 'line_separator', 'x')
 
 
 class AttrsTestCase(TempFileMixin, TestCase):

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -1325,9 +1325,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test06a_setUnicodeAttributes(self):
         """Checking setting unicode attributes (scalar case)"""
 
-        self.array.attrs.pq = u'para\u0140lel'
-        self.array.attrs.qr = u''                 # check #213 or gh-64
-        self.array.attrs.rs = u'baz'
+        self.array.attrs.pq = 'para\u0140lel'
+        self.array.attrs.qr = ''                 # check #213 or gh-64
+        self.array.attrs.rs = 'baz'
 
         # Check the results
         if common.verbose:
@@ -1349,14 +1349,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         self.assertIsInstance(self.array.attrs.pq, numpy.unicode_)
         self.assertIsInstance(self.array.attrs.qr, numpy.unicode_)
         self.assertIsInstance(self.array.attrs.rs, numpy.unicode_)
-        self.assertEqual(self.array.attrs.pq, u'para\u0140lel')
-        self.assertEqual(self.array.attrs.qr, u'')
-        self.assertEqual(self.array.attrs.rs, u'baz')
+        self.assertEqual(self.array.attrs.pq, 'para\u0140lel')
+        self.assertEqual(self.array.attrs.qr, '')
+        self.assertEqual(self.array.attrs.rs, 'baz')
 
     def test06b_setUnicodeAttributes(self):
         """Checking setting unicode attributes (unidimensional 1-elem case)"""
 
-        self.array.attrs.pq = numpy.array([u'para\u0140lel'])
+        self.array.attrs.pq = numpy.array(['para\u0140lel'])
 
         # Check the results
         if common.verbose:
@@ -1370,7 +1370,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         assert_array_equal(self.array.attrs.pq,
-                           numpy.array([u'para\u0140lel']))
+                           numpy.array(['para\u0140lel']))
 
     def test06c_setUnicodeAttributes(self):
         """Checking setting unicode attributes (empty unidimensional
@@ -1378,8 +1378,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         # The next raises a `TypeError` when unpickled. See:
         # http://projects.scipy.org/numpy/ticket/1037
-        # self.array.attrs.pq = numpy.array([u''])
-        self.array.attrs.pq = numpy.array([u''], dtype="U1")
+        # self.array.attrs.pq = numpy.array([''])
+        self.array.attrs.pq = numpy.array([''], dtype="U1")
 
         # Check the results
         if common.verbose:
@@ -1395,12 +1395,12 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("pq -->", repr(self.array.attrs.pq))
 
         assert_array_equal(self.array.attrs.pq,
-                           numpy.array([u''], dtype="U1"))
+                           numpy.array([''], dtype="U1"))
 
     def test06d_setUnicodeAttributes(self):
         """Checking setting unicode attributes (unidimensional 2-elem case)"""
 
-        self.array.attrs.pq = numpy.array([u'para\u0140lel', u'bar3'])
+        self.array.attrs.pq = numpy.array(['para\u0140lel', 'bar3'])
 
         # Check the results
         if common.verbose:
@@ -1414,7 +1414,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         assert_array_equal(self.array.attrs.pq,
-                           numpy.array([u'para\u0140lel', u'bar3']))
+                           numpy.array(['para\u0140lel', 'bar3']))
 
     def test06e_setUnicodeAttributes(self):
         """Checking setting unicode attributes (empty unidimensional
@@ -1439,8 +1439,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test06f_setUnicodeAttributes(self):
         """Checking setting unicode attributes (bidimensional 4-elem case)"""
 
-        self.array.attrs.pq = numpy.array([[u'para\u0140lel', 'foo2'],
-                                           ['foo3', u'para\u0140lel4']])
+        self.array.attrs.pq = numpy.array([['para\u0140lel', 'foo2'],
+                                           ['foo3', 'para\u0140lel4']])
 
         # Check the results
         if common.verbose:
@@ -1454,8 +1454,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         assert_array_equal(self.array.attrs.pq,
-                           numpy.array([[u'para\u0140lel', 'foo2'],
-                                        ['foo3', u'para\u0140lel4']]))
+                           numpy.array([['para\u0140lel', 'foo2'],
+                                        ['foo3', 'para\u0140lel4']]))
 
     def test07a_setRecArrayAttributes(self):
         """Checking setting RecArray (NumPy) attributes."""
@@ -1705,7 +1705,7 @@ class CompatibilityTestCase(common.TestFileMixin, TestCase):
         # behaviour of PyTables.
 
         self.assertEqual(
-            self.h5file.get_node_attr('/', 'py2_pickled_unicode'), u'abc')
+            self.h5file.get_node_attr('/', 'py2_pickled_unicode'), 'abc')
 
 
 class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, TestCase):
@@ -1732,7 +1732,7 @@ class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, TestCase):
         # dict will be unpickled with encoding='latin1'
         d = self.h5file.get_node_attr('/', 'py2_pickled_dict')
         self.assertIsInstance(d, dict)
-        self.assertEqual(d['s'], u'just a string')
+        self.assertEqual(d['s'], 'just a string')
 
 class SegFaultPythonTestCase(common.TempFileMixin, TestCase):
 
@@ -1755,7 +1755,7 @@ class EmbeddedNullsTestCase(common.TempFileMixin, TestCase):
     # See laso gh-371 (https://github.com/PyTables/PyTables/issues/371)
 
     def test_unicode(self):
-        value = u"string with a null byte \x00 in it"
+        value = "string with a null byte \x00 in it"
 
         self.h5file.root._v_attrs.name = value
         self.assertEqual(self.h5file.root._v_attrs.name, value)

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1921,7 +1921,7 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
 @unittest.skipIf(sys.getfilesystemencoding() != 'utf-8',
                  'need utf-8 file-system encoding')
 class UnicodeFilename(common.TempFileMixin, TestCase):
-    unicode_prefix = u'para\u0140lel'
+    unicode_prefix = 'para\u0140lel'
 
     def _getTempFileName(self):
         return tempfile.mktemp(prefix=self.unicode_prefix, suffix='.h5')
@@ -1973,7 +1973,7 @@ class UnicodeFilename(common.TempFileMixin, TestCase):
         self.h5file = tables.open_file(self.h5fname, "a")
         root = self.h5file.root
         group = self.h5file.create_group(root, 'face_data')
-        array_name = u'data at 40\N{DEGREE SIGN}C'
+        array_name = 'data at 40\N{DEGREE SIGN}C'
         data = numpy.sinh(numpy.linspace(-1.4, 1.4, 500))
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', NaturalNameWarning)

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -1288,7 +1288,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         # Check for ticket #62.
         self.assertRaises(TypeError, vlarray.append, [b"foo", b"bar"])
         # `VLStringAtom` makes no encoding assumptions.  See ticket #51.
-        self.assertRaises(UnicodeEncodeError, vlarray.append, u"asd\xe4")
+        self.assertRaises(UnicodeEncodeError, vlarray.append, "asd\xe4")
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -1359,7 +1359,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         vlarray = self.h5file.create_vlarray(
             '/', "Object", atom=ObjectAtom())
-        vlarray.append([[1, 2, 3], "aaa", u"aaa���"])
+        vlarray.append([[1, 2, 3], "aaa", "aaa���"])
         vlarray.append([3, 4, C()])
         vlarray.append(42)
 
@@ -1376,7 +1376,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertEqual(row[0], [[1, 2, 3], "aaa", u"aaa���"])
+        self.assertEqual(row[0], [[1, 2, 3], "aaa", "aaa���"])
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [3, 4])
@@ -1396,14 +1396,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray('/', "Object", atom=ObjectAtom())
         # When updating an object, this seems to change the number
         # of bytes that pickle.dumps generates
-        # vlarray.append(([1,2,3], "aaa", u"aaa���"))
-        vlarray.append(([1, 2, 3], "aaa", u"��4"))
+        # vlarray.append(([1,2,3], "aaa", "aaa���"))
+        vlarray.append(([1, 2, 3], "aaa", "��4"))
         # vlarray.append([3,4, C()])
         vlarray.append([3, 4, [24]])
 
         # Modify the rows
-        # vlarray[0] = ([1,2,4], "aa4", u"aaa��4")
-        vlarray[0] = ([1, 2, 4], "aa4", u"��5")
+        # vlarray[0] = ([1,2,4], "aa4", "aaa��4")
+        vlarray[0] = ([1, 2, 4], "aa4", "��5")
         # vlarray[1] = (3,4, C())
         vlarray[1] = [4, 4, [24]]
 
@@ -1420,7 +1420,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertEqual(row[0], ([1, 2, 4], "aa4", u"��5"))
+        self.assertEqual(row[0], ([1, 2, 4], "aa4", "��5"))
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [4, 4])
@@ -1510,9 +1510,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray(
             '/', "VLUnicodeAtom", atom=VLUnicodeAtom())
         vlarray.append("asd")
-        vlarray.append(u"asd\u0140")
-        vlarray.append(u"aaana")
-        vlarray.append(u"")
+        vlarray.append("asd\u0140")
+        vlarray.append("aaana")
+        vlarray.append("")
         # Check for ticket #62.
         self.assertRaises(TypeError, vlarray.append, ["foo", "bar"])
         # `VLUnicodeAtom` makes no encoding assumptions.
@@ -1531,10 +1531,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 4)
-        self.assertEqual(row[0], u"asd")
-        self.assertEqual(row[1], u"asd\u0140")
-        self.assertEqual(row[2], u"aaana")
-        self.assertEqual(row[3], u"")
+        self.assertEqual(row[0], "asd")
+        self.assertEqual(row[1], "asd\u0140")
+        self.assertEqual(row[2], "aaana")
+        self.assertEqual(row[3], "")
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
@@ -1551,11 +1551,11 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray(
             '/', "VLUnicodeAtom", atom=VLUnicodeAtom())
         vlarray.append("asd")
-        vlarray.append(u"aaan\xe4")
+        vlarray.append("aaan\xe4")
 
         # Modify values
-        vlarray[0] = u"as\xe4"
-        vlarray[1] = u"aaan\u0140"
+        vlarray[0] = "as\xe4"
+        vlarray[1] = "aaan\u0140"
         self.assertRaises(ValueError, vlarray.__setitem__, 1, "shrt")
         self.assertRaises(ValueError, vlarray.__setitem__, 1, "toolong")
 
@@ -1573,8 +1573,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("Second row in vlarray ==>", repr(row[1]))
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertEqual(row[0], u"as\xe4")
-        self.assertEqual(row[1], u"aaan\u0140")
+        self.assertEqual(row[0], "as\xe4")
+        self.assertEqual(row[1], "aaan\u0140")
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 5)
 
@@ -3919,8 +3919,8 @@ class VLUEndianTestCase(TestCase):
 
         bedata = self.h5file.root.vlunicode_big[0]
         ledata = self.h5file.root.vlunicode_little[0]
-        self.assertEqual(bedata, u'para\u0140lel')
-        self.assertEqual(ledata, u'para\u0140lel')
+        self.assertEqual(bedata, 'para\u0140lel')
+        self.assertEqual(ledata, 'para\u0140lel')
 
 
 class TruncateTestCase(common.TempFileMixin, TestCase):

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -903,7 +903,7 @@ def read_f_attr(hid_t file_id, str attr_name):
     size = H5ATTRget_attribute_string(file_id, c_attr_name, &attr_value, &cset)
     if size == 0:
       if cset == H5T_CSET_UTF8:
-        retvalue = numpy.unicode_(u'')
+        retvalue = numpy.unicode_('')
       else:
         retvalue = numpy.bytes_(b'')
     else:


### PR DESCRIPTION
On Python 2, `u"..."` string prefix is used to denote a unicode string where as on Python 3, all strings are unicode strings so the `u"..."` string prefix isnt needed. The changes were made by manually searching and replacing the occurances in the codebase.