### PR TITLE
doctest: adjust __init__ TypeError formatting

### DIFF
--- a/tables/atom.py
+++ b/tables/atom.py
@@ -569,10 +569,10 @@ class Atom(metaclass=MetaAtom):
             >>> atom3 = atom1.copy(shape=(2, 2))
             >>> print(atom3)
             Int32Atom(shape=(2, 2), dflt=0)
-            >>> atom1.copy(foobar=42)
+            >>> atom1.copy(foobar=42) #doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
-            TypeError: __init__() got an unexpected keyword argument 'foobar'
+            TypeError: ...__init__() got an unexpected keyword argument 'foobar'
 
         """
         newargs = self._get_init_args()

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -432,10 +432,10 @@ class Filters:
             Filters(complevel=0, shuffle=False, bitshuffle=False, fletcher32=False, least_significant_digit=None)
             >>> print(filters3)
             Filters(complevel=1, complib='zlib', shuffle=False, bitshuffle=False, fletcher32=False, least_significant_digit=None)
-            >>> filters1.copy(foobar=42)
+            >>> filters1.copy(foobar=42) #doctest: +ELLIPSIS
             Traceback (most recent call last):
             ...
-            TypeError: __init__() got an unexpected keyword argument 'foobar'
+            TypeError: ...__init__() got an unexpected keyword argument 'foobar'
 
         """
 


### PR DESCRIPTION
Python3.10 includes the class name in the TypeError string
for __init__(). This change allows the tests to pass in the new version,
but obviously breaks with older Pythons.

This patch is enough for the tests to pass in Fedora rawhide with the new python version, but obviously you need something that also works with python <= 3.9. So I'm opening this to get the discussion started ;)