### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - 3.8-dev
+  - 3.8
+  - 3.9
 
 jobs:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,14 @@ environment:
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Miniconda38-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda39-x64"
+      PYTHON_VERSION: "3.9"
+      PYTHON_ARCH: "64"
+
 install:
   - powershell .\\ci\\appveyor\\missing-headers.ps1
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -49,7 +49,7 @@ Prerequisites
 
 First, make sure that you have
 
-* Python_ >= 3.4 (PyTables-3.5 was the last release with Python 2.7 support)
+* Python_ >= 3.5 (PyTables-3.5 was the last release with Python 2.7 support)
 * HDF5_ >= 1.8.4 (>=1.8.15 is strongly recommended)
 * NumPy_ >= 1.9.3
 * Numexpr_ >= 2.6.2


### PR DESCRIPTION
Add Python 3.9 (and 3.8) to appveyor and travis CIs.

Did you consider dropping Python 3.5 support (since after EOL)?

And in https://github.com/PyTables/PyTables/blob/master/setup.py#L98-L103 the minimum required version is 3.4. Is this still valid as CIs are testing only against Py3.5+?