### PR TITLE
Apply `pyupgrade --py36-plus` to the Python code

### DIFF
--- a/bench/LRU-experiments.py
+++ b/bench/LRU-experiments.py
@@ -1,7 +1,6 @@
 # Testbed to perform experiments in order to determine best values for
 # the node numbers in LRU cache. Tables version.
 
-from __future__ import print_function
 from time import time
 from tables import *
 import tables

--- a/bench/LRU-experiments2.py
+++ b/bench/LRU-experiments2.py
@@ -1,7 +1,6 @@
 # Testbed to perform experiments in order to determine best values for
 # the node numbers in LRU cache. Arrays version.
 
-from __future__ import print_function
 from time import time
 import tables
 

--- a/bench/LRUcache-node-bench.py
+++ b/bench/LRUcache-node-bench.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import numpy
 import tables

--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 from time import time
@@ -162,4 +161,4 @@ if __name__ == '__main__':
             ts.append(time() - t0)
             t0 = time()
         ratio = size_orig / size
-        print("%5.2f, %5.2f" % (round(min(ts), 3), ratio))
+        print("{:5.2f}, {:5.2f}".format(round(min(ts), 3), ratio))

--- a/bench/bsddb-table-bench.py
+++ b/bench/bsddb-table-bench.py
@@ -4,7 +4,6 @@
 # If you get it working again, please drop me a line
 # F. Alted 2004-01-27
 
-from __future__ import print_function
 import sys
 import struct
 import cPickle

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -3,7 +3,6 @@
 # You need at least PyTables 2.1 to run this!
 # F. Alted
 
-from __future__ import print_function
 import numpy
 import tables
 from time import time
@@ -33,7 +32,7 @@ for i in rows_to_read:
     r1 = a[i, :]
 tr1 = round(time() - t1, 3)
 thr1 = round(dim2 * len(rows_to_read) * 8 / (tr1 * 1024 * 1024), 1)
-print("Time to read ten rows in original array: %s sec (%s MB/s)" % (tr1,
+print("Time to read ten rows in original array: {} sec ({} MB/s)".format(tr1,
                                                                      thr1))
 
 print("=" * 32)
@@ -45,7 +44,7 @@ b = a.copy(f.root, "b", chunkshape=newchunkshape)
 tcpy = round(time() - t1, 3)
 thcpy = round(dim1 * dim2 * 8 / (tcpy * 1024 * 1024), 1)
 print("Chunkshape for row-wise chunkshape array:", b.chunkshape)
-print("Time to copy the original array: %s sec (%s MB/s)" % (tcpy, thcpy))
+print(f"Time to copy the original array: {tcpy} sec ({thcpy} MB/s)")
 
 # Read the same ten rows from the new copied array
 t1 = time()
@@ -53,7 +52,7 @@ for i in rows_to_read:
     r2 = b[i, :]
 tr2 = round(time() - t1, 3)
 thr2 = round(dim2 * len(rows_to_read) * 8 / (tr2 * 1024 * 1024), 1)
-print("Time to read with a row-wise chunkshape: %s sec (%s MB/s)" % (tr2,
+print("Time to read with a row-wise chunkshape: {} sec ({} MB/s)".format(tr2,
                                                                      thr2))
 print("=" * 32)
 print("Speed-up with a row-wise chunkshape:", round(tr1 / tr2, 1))

--- a/bench/chunkshape-testing.py
+++ b/bench/chunkshape-testing.py
@@ -2,7 +2,6 @@
 
 """Simple benchmark for testing chunkshapes and nrowsinbuf."""
 
-from __future__ import print_function
 import numpy
 import tables
 from time import time

--- a/bench/collations.py
+++ b/bench/collations.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 from time import time

--- a/bench/copy-bench.py
+++ b/bench/copy-bench.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 import sys
 import time

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import subprocess
 from time import time
@@ -29,9 +28,9 @@ def show_stats(explain, tref):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-    print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-    print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -1,7 +1,6 @@
 # Small benchmark for compare creation times with parameter
 # PYTABLES_SYS_ATTRS active or not.
 
-from __future__ import print_function
 import os
 import subprocess
 from time import time
@@ -32,9 +31,9 @@ def show_stats(explain, tref):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-    print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-    print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 from time import time
 

--- a/bench/expression.py
+++ b/bench/expression.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from time import time
 import os.path
 
@@ -160,8 +159,8 @@ if __name__ == "__main__":
         elif option[0] == '-z':
             complib = option[1]
             if complib not in ('blosc', 'lzo', 'zlib'):
-                print(("complib must be 'lzo' or 'zlib' "
-                       "and you passed: '%s'" % complib))
+                print("complib must be 'lzo' or 'zlib' "
+                       "and you passed: '%s'" % complib)
                 sys.exit(1)
 
     # If not a backend selected, abort

--- a/bench/get-figures-ranges.py
+++ b/bench/get-figures-ranges.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from pylab import *
 
 linewidth = 2
@@ -208,7 +207,7 @@ if __name__ == '__main__':
         plegend = filename[filename.find('-'):filename.index('.out')]
         plegend = plegend.replace('-', ' ')
         xval, yval = get_values(filename)
-        print("Values for %s --> %s, %s" % (filename, xval, yval))
+        print(f"Values for {filename} --> {xval}, {yval}")
         if "PyTables" in filename or "pytables" in filename:
             plot = loglog(xval, yval, linewidth=2)
             #plot = semilogx(xval, yval, linewidth=2)

--- a/bench/get-figures.py
+++ b/bench/get-figures.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from pylab import *
 
 linewidth = 2
@@ -266,7 +265,7 @@ if __name__ == '__main__':
         #plegend = plegend.replace('zlib1', '')
         if filename.find('PyTables') != -1:
             xval, yval = get_values(filename)
-            print("Values for %s --> %s, %s" % (filename, xval, yval))
+            print(f"Values for {filename} --> {xval}, {yval}")
             if xval != []:
                 plot = loglog(xval, yval)
                 #plot = semilogx(xval, yval)
@@ -276,7 +275,7 @@ if __name__ == '__main__':
                 legends.append(plegend)
         else:
             xval, yval = get_values(filename)
-            print("Values for %s --> %s, %s" % (filename, xval, yval))
+            print(f"Values for {filename} --> {xval}, {yval}")
             plots.append(loglog(xval, yval, linewidth=3, color='m'))
             #plots.append(semilogx(xval, yval, linewidth=linewidth, color='m'))
             legends.append(plegend)

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from time import time
 import subprocess
 import random
@@ -40,7 +39,7 @@ def get_nrows(nrows_str):
             "value of nrows must end with either 'k', 'm' or 'g' suffixes.")
 
 
-class DB(object):
+class DB:
 
     def __init__(self, nrows, rng, userandom):
         global step, scale
@@ -96,11 +95,11 @@ class DB(object):
             # print "Times for warm cache:\n", wtimes
             print("Histogram for warm cache: %s\n%s" %
                   numpy.histogram(wtimes))
-        print("%s1st query time for %s:" % (r, colname),
+        print(f"{r}1st query time for {colname}:",
               round(qtime1, prec))
-        print("%sQuery time for %s (cold cache):" % (r, colname),
+        print(f"{r}Query time for {colname} (cold cache):",
               round(cmean, prec), "+-", round(cstd, prec))
-        print("%sQuery time for %s (warm cache):" % (r, colname),
+        print(f"{r}Query time for {colname} (warm cache):",
               round(wmean, prec), "+-", round(wstd, prec))
 
     def print_db_sizes(self, init, filled, indexed):

--- a/bench/keysort.py
+++ b/bench/keysort.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from tables.indexesextension import keysort
 import numpy
 from time import time
@@ -27,7 +26,7 @@ for dtype1 in ('S6', 'b1',
         t1 = time()
         keysort(a, b)
         tks = time() - t1
-        print("keysort time-->", tks, "    %.2fx" % (tref / tks,))
+        print("keysort time-->", tks, "    {:.2f}x".format(tref / tks))
         assert numpy.alltrue(a == e)
         #assert numpy.alltrue(b == d)
         assert numpy.alltrue(f == d)

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -1,7 +1,6 @@
 """Benchmark to help choosing the best chunksize so as to optimize the access
 time in random lookups."""
 
-from __future__ import print_function
 from time import time
 import os
 import subprocess
@@ -26,7 +25,7 @@ def get_nrows(nrows_str):
             "value of nrows must end with either 'k', 'm' or 'g' suffixes.")
 
 
-class DB(object):
+class DB:
 
     def __init__(self, nrows, dtype, chunksize, userandom, datadir,
                  docompress=0, complib='zlib'):

--- a/bench/open_close-bench.py
+++ b/bench/open_close-bench.py
@@ -4,7 +4,6 @@ This uses the HotShot profiler.
 
 """
 
-from __future__ import print_function
 import os
 import sys
 import getopt
@@ -39,9 +38,9 @@ def show_stats(explain, tref):
     sout.close()
     print("WallClock time:", time.time() - tref)
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-    print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-    print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
 
 
 def check_open_close():
@@ -213,7 +212,7 @@ if __name__ == '__main__':
     if all_system_checks:
         args.remove('-S')  # We don't want -S in the options list again
         for opt in options:
-            opts = "%s \-s %s %s" % (progname, opt, " ".join(args))
+            opts = r"{} \-s {} {}".format(progname, opt, " ".join(args))
             # print "opts-->", opts
             os.system("python2.4 %s" % opts)
     else:

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -5,7 +5,6 @@ Francesc Alted
 
 """
 
-from __future__ import print_function
 import os
 import math
 import subprocess

--- a/bench/plot-bar.py
+++ b/bench/plot-bar.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # a stacked bar plot with errorbars
 
-from __future__ import print_function
 from pylab import *
 
 checks = ['open_close', 'only_open',

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -6,7 +6,6 @@
 # Date: 2010-02-24
 #######################################################################
 
-from __future__ import print_function
 import os
 from time import time
 import numpy as np
@@ -49,7 +48,7 @@ def print_filesize(filename, clib=None, clevel=0):
     print("\t\tTotal file sizes: %d -- (%s MB)" % (
         filesize_bytes, filesize_MB), end=' ')
     if clevel > 0:
-        print("(using %s lvl%s)" % (clib, clevel))
+        print(f"(using {clib} lvl{clevel})")
     else:
         print()
 
@@ -170,7 +169,7 @@ if __name__ == '__main__':
             populate_x_memmap()
             compute = compute_memmap
         print("*** Time elapsed populating:", round(time() - t0, 3))
-        print("Computing: '%s' using %s" % (expr, what))
+        print(f"Computing: '{expr}' using {what}")
         t0 = time()
         compute()
         print("**************** Time elapsed computing:",
@@ -188,7 +187,7 @@ if __name__ == '__main__':
                 print("Populating x using %s with %d points..." % (what, N))
                 populate_x_tables(clib, clevel)
                 print("*** Time elapsed populating:", round(time() - t0, 3))
-                print("Computing: '%s' using %s" % (expr, what))
+                print(f"Computing: '{expr}' using {what}")
                 t0 = time()
                 compute_tables(clib, clevel)
                 print("**************** Time elapsed computing:",

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from time import time
 import numpy
 import random
@@ -48,7 +47,7 @@ def int_generator_slow(nrows):
             yield (i, float(i))
 
 
-class Stream32(object):
+class Stream32:
 
     "Object simulating a file for reading"
 

--- a/bench/postgres_backend.py
+++ b/bench/postgres_backend.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import subprocess  # Needs Python 2.4
 from indexed_search import DB
 import psycopg2 as db2
@@ -13,7 +12,7 @@ TABLE_NAME = "intsfloats"
 PORT = 5432
 
 
-class StreamChar(object):
+class StreamChar:
     "Object simulating a file for reading"
 
     def __init__(self, db):

--- a/bench/pytables-search-bench.py
+++ b/bench/pytables-search-bench.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 from time import time
 import random

--- a/bench/pytables_backend.py
+++ b/bench/pytables_backend.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import tables
 from indexed_search import DB
@@ -27,7 +26,7 @@ class PyTables_DB(DB):
                 dir_path = self.datadir
             os.makedirs(dir_path)
             self.datadir = dir_path
-            print("Created {}.".format(self.datadir))
+            print(f"Created {self.datadir}.")
         self.filename = self.datadir + '/' + self.filename + '.h5'
         # The chosen filters
         self.filters = tables.Filters(complevel=self.docompress,

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import time

--- a/bench/search-bench-plot.py
+++ b/bench/search-bench-plot.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 from pylab import *
 
@@ -132,7 +131,7 @@ if __name__ == '__main__':
         plegend = filename[filename.find('cl-') + 3:filename.index('.h5')]
         plegend = plegend.replace('-', ' ')
         xval, yval = get_values(filename, '')
-        print("Values for %s --> %s, %s" % (filename, xval, yval))
+        print(f"Values for {filename} --> {xval}, {yval}")
         #plots.append(loglog(xval, yval, linewidth=5))
         plots.append(semilogx(xval, yval, linewidth=4))
         legends.append(plegend)

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import sys
 import math
 import time

--- a/bench/searchsorted-bench.py
+++ b/bench/searchsorted-bench.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import time
 from tables import *
 

--- a/bench/searchsorted-bench2.py
+++ b/bench/searchsorted-bench2.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import time
 from tables import *
 

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 from tables import *
 import numpy as NA
 import struct

--- a/bench/split-file.py
+++ b/bench/split-file.py
@@ -29,11 +29,11 @@ for line in f:
                 complib = param
         if 'PyTables' in prefix:
             if complib:
-                sfilename = "%s-O%s-%s.out" % (prefix, optlevel, complib)
+                sfilename = f"{prefix}-O{optlevel}-{complib}.out"
             else:
-                sfilename = "%s-O%s.out" % (prefix, optlevel,)
+                sfilename = f"{prefix}-O{optlevel}.out"
         else:
-            sfilename = "%s.out" % (prefix,)
+            sfilename = f"{prefix}.out"
         sf = file(sfilename, 'a')
     if sf:
         sf.write(line)

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
 import sqlite
 import random
 import time
@@ -319,8 +318,8 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
             t2 = time2 / (riter - correction)
             tcpu2 = cpu2 / (riter - correction)
 
-        print(("*** Query results for atom = %s, nrows = %s, "
-              "indexmode = %s ***" % (atom, nrows, indexmode)))
+        print("*** Query results for atom = %s, nrows = %s, "
+              "indexmode = %s ***" % (atom, nrows, indexmode))
         print("Query time:", round(t1, 5), ", cached time:", round(t2, 5))
         print("MRows/s:", round((nrows / 10. ** 6) / t1, 3), end=' ')
         if t2 > 0:

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import os.path
 from time import time

--- a/bench/stress-test.py
+++ b/bench/stress-test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import gc
 import sys
 import time

--- a/bench/stress-test2.py
+++ b/bench/stress-test2.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import gc
 import sys
 import time

--- a/bench/stress-test3.py
+++ b/bench/stress-test3.py
@@ -7,7 +7,6 @@ Issue "python stress-test3.py" without parameters for a help on usage.
 
 """
 
-from __future__ import print_function
 import gc
 import sys
 import time

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import numpy as NP
 from tables import *
 

--- a/bench/table-copy.py
+++ b/bench/table-copy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 
 import numpy as np
@@ -32,7 +31,7 @@ def create_table(output_path):
 
 
 def copy1(input_path, output_path):
-    print("copying data from %s to %s..." % (input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 
@@ -43,14 +42,14 @@ def copy1(input_path, output_path):
 
 
 def copy2(input_path, output_path):
-    print("copying data from %s to %s..." % (input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     input_file.copy_file(output_path, overwrite=True)
     input_file.close()
 
 
 def copy3(input_path, output_path):
-    print("copying data from %s to %s..." % (input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
     table = input_file.root.test
@@ -60,7 +59,7 @@ def copy3(input_path, output_path):
 
 
 def copy4(input_path, output_path, complib='zlib', complevel=0):
-    print("copying data from %s to %s..." % (input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 
@@ -83,7 +82,7 @@ def copy4(input_path, output_path, complib='zlib', complevel=0):
 
 
 def copy5(input_path, output_path, complib='zlib', complevel=0):
-    print("copying data from %s to %s..." % (input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 

--- a/bench/undo_redo.py
+++ b/bench/undo_redo.py
@@ -6,7 +6,6 @@
 # 2005-03-09
 ###########################################################################
 
-from __future__ import print_function
 import numpy
 from time import time
 import tables
@@ -14,7 +13,7 @@ import tables
 verbose = 0
 
 
-class BasicBenchmark(object):
+class BasicBenchmark:
 
     def __init__(self, filename, testname, vecsize, nobjects, niter):
 

--- a/bench/widetree.py
+++ b/bench/widetree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import hotshot
 import hotshot.stats
 
@@ -54,8 +53,8 @@ class WideTreeTestCase(unittest.TestCase):
         t1 = time.time()
         # Open the previous HDF5 file in read-only mode
         fileh = open_file(file, mode="r")
-        print(("\nTime spent opening a file with %d groups + %d arrays: "
-              "%s s" % (maxchilds, maxchilds, time.time() - t1)))
+        print("\nTime spent opening a file with %d groups + %d arrays: "
+              "%s s" % (maxchilds, maxchilds, time.time() - t1))
         if verbose:
             print("\nChildren reading progress: ", end=' ')
         # Close the file

--- a/bench/widetree2.py
+++ b/bench/widetree2.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 from tables import *

--- a/c-blosc/bench/plot-speeds.py
+++ b/c-blosc/bench/plot-speeds.py
@@ -4,7 +4,6 @@ Invoke without parameters for usage hints.
 :Author: Francesc Alted
 :Date: 2010-06-01
 """
-from __future__ import print_function
 
 import matplotlib as mpl
 from pylab import *

--- a/c-blosc/conanfile.py
+++ b/c-blosc/conanfile.py
@@ -49,7 +49,7 @@ class CbloscConan(ConanFile):
             else:
                 return
             with tools.environment_append({'CTEST_OUTPUT_ON_FAILURE': '1'}):
-                self.run("%s ctest %s" % (prefix, test_args))
+                self.run(f"{prefix} ctest {test_args}")
 
     def package(self):
         self.copy("blosc.h", dst="include", src="blosc")

--- a/c-blosc/tests/check_symbols.py
+++ b/c-blosc/tests/check_symbols.py
@@ -1,6 +1,5 @@
 """Checks the exported symbols."""
 
-from __future__ import print_function, unicode_literals
 
 import argparse
 import re
@@ -61,7 +60,7 @@ def check_symbols(path):
       del symbol_type
       if re.match(allowed_symbols_pattern, name):
         continue
-      print('ERROR: Found unexpected symbol in %s: %s' % (filename, name))
+      print(f'ERROR: Found unexpected symbol in {filename}: {name}')
       failed = True
   return not failed
 

--- a/contrib/make_hdf.py
+++ b/contrib/make_hdf.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import generators
 
 import tables, cPickle, time
 #################################################################################

--- a/cpuinfo.py
+++ b/cpuinfo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 
 # Copyright (c) 2014-2018, Matthew Brennan Jones <matthew.brennan.jones@gmail.com>
 # Py-cpuinfo gets CPU info with pure Python 2 & 3
@@ -79,7 +78,7 @@ if platform.system().lower() == 'windows':
 
 	forking.Popen = _Popen
 
-class DataSource(object):
+class DataSource:
 	bits = platform.architecture()[0]
 	cpu_count = multiprocessing.cpu_count()
 	is_windows = platform.system().lower() == 'windows'
@@ -328,7 +327,7 @@ def _get_hz_string_from_brand(processor_brand):
 def to_friendly_hz(ticks, scale):
 	# Get the raw Hz as a string
 	left, right = to_raw_hz(ticks, scale)
-	ticks = '{0}.{1}'.format(left, right)
+	ticks = f'{left}.{right}'
 
 	# Get the location of the dot, and remove said dot
 	dot_index = ticks.index('.')
@@ -348,11 +347,11 @@ def to_friendly_hz(ticks, scale):
 		scale = 3
 
 	# Get the Hz with the dot at the new scaled point
-	ticks = '{0}.{1}'.format(ticks[:-scale-1], ticks[-scale-1:])
+	ticks = '{}.{}'.format(ticks[:-scale-1], ticks[-scale-1:])
 
 	# Format the ticks to have 4 numbers after the decimal
 	# and remove any superfluous zeroes.
-	ticks = '{0:.4f} {1}'.format(float(ticks), symbol)
+	ticks = '{:.4f} {}'.format(float(ticks), symbol)
 	ticks = ticks.rstrip('0')
 
 	return ticks
@@ -364,32 +363,32 @@ def to_raw_hz(ticks, scale):
 	ticks = ticks.replace('.', '')
 	ticks = ticks.ljust(scale + old_index+1, '0')
 	new_index = old_index + scale
-	ticks = '{0}.{1}'.format(ticks[:new_index], ticks[new_index:])
+	ticks = '{}.{}'.format(ticks[:new_index], ticks[new_index:])
 	left, right = ticks.split('.')
 	left, right = int(left), int(right)
 	return (left, right)
 
 def to_hz_string(ticks):
 	# Convert to string
-	ticks = '{0}'.format(ticks)
+	ticks = f'{ticks}'
 
 	# Add decimal if missing
 	if '.' not in ticks:
-		ticks = '{0}.0'.format(ticks)
+		ticks = f'{ticks}.0'
 
 	# Remove trailing zeros
 	ticks = ticks.rstrip('0')
 
 	# Add one trailing zero for empty right side
 	if ticks.endswith('.'):
-		ticks = '{0}0'.format(ticks)
+		ticks = f'{ticks}0'
 
 	return ticks
 
 def to_friendly_bytes(input):
 	if not input:
 		return input
-	input = "{0}".format(input)
+	input = f"{input}"
 
 	formats = {
 		r"^[0-9]+B$" : 'B',
@@ -400,7 +399,7 @@ def to_friendly_bytes(input):
 
 	for pattern, friendly_size in formats.items():
 		if re.match(pattern, input):
-			return "{0} {1}".format(input[ : -1].strip(), friendly_size)
+			return "{} {}".format(input[ : -1].strip(), friendly_size)
 
 	return input
 
@@ -546,7 +545,7 @@ def parse_arch(raw_arch_string):
 	raw_arch_string = raw_arch_string.lower()
 
 	# X86
-	if re.match('^i\d86$|^x86$|^x86_32$|^i86pc$|^ia32$|^ia-32$|^bepc$', raw_arch_string):
+	if re.match(r'^i\d86$|^x86$|^x86_32$|^i86pc$|^ia32$|^ia-32$|^bepc$', raw_arch_string):
 		arch = 'X86_32'
 		bits = 32
 	elif re.match('^x64$|^x86_64$|^x86_64t$|^i686-64$|^amd64$|^ia64$|^ia-64$', raw_arch_string):
@@ -585,7 +584,7 @@ def is_bit_set(reg, bit):
 	return is_set
 
 
-class CPUID(object):
+class CPUID:
 	def __init__(self):
 		self.prochandle = None
 
@@ -2100,8 +2099,8 @@ def get_cpu_info():
 	arch, bits = parse_arch(DataSource.raw_arch_string)
 
 	friendly_maxsize = { 2**31-1: '32 bit', 2**63-1: '64 bit' }.get(sys.maxsize) or 'unknown bits'
-	friendly_version = "{0}.{1}.{2}.{3}.{4}".format(*sys.version_info)
-	PYTHON_VERSION = "{0} ({1})".format(friendly_version, friendly_maxsize)
+	friendly_version = "{}.{}.{}.{}.{}".format(*sys.version_info)
+	PYTHON_VERSION = f"{friendly_version} ({friendly_maxsize})"
 
 	info = {
 		'python_version' : PYTHON_VERSION,
@@ -2165,34 +2164,34 @@ def main():
 
 	info = get_cpu_info()
 	if info:
-		print('Python Version: {0}'.format(info.get('python_version', '')))
-		print('Cpuinfo Version: {0}'.format(info.get('cpuinfo_version', '')))
-		print('Vendor ID: {0}'.format(info.get('vendor_id', '')))
-		print('Hardware Raw: {0}'.format(info.get('hardware', '')))
-		print('Brand: {0}'.format(info.get('brand', '')))
-		print('Hz Advertised: {0}'.format(info.get('hz_advertised', '')))
-		print('Hz Actual: {0}'.format(info.get('hz_actual', '')))
-		print('Hz Advertised Raw: {0}'.format(info.get('hz_advertised_raw', '')))
-		print('Hz Actual Raw: {0}'.format(info.get('hz_actual_raw', '')))
-		print('Arch: {0}'.format(info.get('arch', '')))
-		print('Bits: {0}'.format(info.get('bits', '')))
-		print('Count: {0}'.format(info.get('count', '')))
+		print('Python Version: {}'.format(info.get('python_version', '')))
+		print('Cpuinfo Version: {}'.format(info.get('cpuinfo_version', '')))
+		print('Vendor ID: {}'.format(info.get('vendor_id', '')))
+		print('Hardware Raw: {}'.format(info.get('hardware', '')))
+		print('Brand: {}'.format(info.get('brand', '')))
+		print('Hz Advertised: {}'.format(info.get('hz_advertised', '')))
+		print('Hz Actual: {}'.format(info.get('hz_actual', '')))
+		print('Hz Advertised Raw: {}'.format(info.get('hz_advertised_raw', '')))
+		print('Hz Actual Raw: {}'.format(info.get('hz_actual_raw', '')))
+		print('Arch: {}'.format(info.get('arch', '')))
+		print('Bits: {}'.format(info.get('bits', '')))
+		print('Count: {}'.format(info.get('count', '')))
 
-		print('Raw Arch String: {0}'.format(info.get('raw_arch_string', '')))
+		print('Raw Arch String: {}'.format(info.get('raw_arch_string', '')))
 
-		print('L1 Data Cache Size: {0}'.format(info.get('l1_data_cache_size', '')))
-		print('L1 Instruction Cache Size: {0}'.format(info.get('l1_instruction_cache_size', '')))
-		print('L2 Cache Size: {0}'.format(info.get('l2_cache_size', '')))
-		print('L2 Cache Line Size: {0}'.format(info.get('l2_cache_line_size', '')))
-		print('L2 Cache Associativity: {0}'.format(info.get('l2_cache_associativity', '')))
-		print('L3 Cache Size: {0}'.format(info.get('l3_cache_size', '')))
-		print('Stepping: {0}'.format(info.get('stepping', '')))
-		print('Model: {0}'.format(info.get('model', '')))
-		print('Family: {0}'.format(info.get('family', '')))
-		print('Processor Type: {0}'.format(info.get('processor_type', '')))
-		print('Extended Model: {0}'.format(info.get('extended_model', '')))
-		print('Extended Family: {0}'.format(info.get('extended_family', '')))
-		print('Flags: {0}'.format(', '.join(info.get('flags', ''))))
+		print('L1 Data Cache Size: {}'.format(info.get('l1_data_cache_size', '')))
+		print('L1 Instruction Cache Size: {}'.format(info.get('l1_instruction_cache_size', '')))
+		print('L2 Cache Size: {}'.format(info.get('l2_cache_size', '')))
+		print('L2 Cache Line Size: {}'.format(info.get('l2_cache_line_size', '')))
+		print('L2 Cache Associativity: {}'.format(info.get('l2_cache_associativity', '')))
+		print('L3 Cache Size: {}'.format(info.get('l3_cache_size', '')))
+		print('Stepping: {}'.format(info.get('stepping', '')))
+		print('Model: {}'.format(info.get('model', '')))
+		print('Family: {}'.format(info.get('family', '')))
+		print('Processor Type: {}'.format(info.get('processor_type', '')))
+		print('Extended Model: {}'.format(info.get('extended_model', '')))
+		print('Extended Family: {}'.format(info.get('extended_family', '')))
+		print('Flags: {}'.format(', '.join(info.get('flags', ''))))
 	else:
 		sys.stderr.write("Failed to find cpu info\n")
 		sys.exit(1)

--- a/doc/scripts/filenode.py
+++ b/doc/scripts/filenode.py
@@ -1,6 +1,5 @@
 # Copy this file into the clipboard and paste into 'script -c python'.
 
-from __future__ import print_function
 from tables.nodes import FileNode
 
 

--- a/doc/scripts/pickletrouble.py
+++ b/doc/scripts/pickletrouble.py
@@ -1,8 +1,7 @@
-from __future__ import print_function
 import tables
 
 
-class MyClass(object):
+class MyClass:
     foo = 'bar'
 
 # An object of my custom class.

--- a/doc/scripts/tutorial1.py
+++ b/doc/scripts/tutorial1.py
@@ -6,7 +6,6 @@ with any HDF5 generic utility.
 """
 
 
-from __future__ import print_function
 import os
 import traceback
 
@@ -239,7 +238,7 @@ tutsep()
 print("Table variable names with their type and shape:")
 tutsep()
 for name in table.colnames:
-    print(name, ':= %s, %s' % (table.coltypes[name], table.colshapes[name]))
+    print(name, ':= {}, {}'.format(table.coltypes[name], table.colshapes[name]))
 
 tutprint(table.__doc__)
 

--- a/doc/source/cookbook/py2exe_howto/pytables_test.py
+++ b/doc/source/cookbook/py2exe_howto/pytables_test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from tables import *
 import numarray
 

--- a/examples/add-column.py
+++ b/examples/add-column.py
@@ -1,6 +1,5 @@
 "Example showing how to add a column on a existing column"
 
-from __future__ import print_function
 import tables
 
 

--- a/examples/array1.py
+++ b/examples/array1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/array2.py
+++ b/examples/array2.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/array3.py
+++ b/examples/array3.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/array4.py
+++ b/examples/array4.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/attrs-with-padding.py
+++ b/examples/attrs-with-padding.py
@@ -1,5 +1,4 @@
 # This is an example on how to use complex columns
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/carray1.py
+++ b/examples/carray1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy
 import tables
 

--- a/examples/earray1.py
+++ b/examples/earray1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 import numpy
 
@@ -11,6 +10,6 @@ array_c.append(numpy.array(['a' * 6, 'b' * 8, 'c' * 10], dtype='S8'))
 
 # Read the string ``EArray`` we have created on disk.
 for s in array_c:
-    print('array_c[%s] => %r' % (array_c.nrow, s))
+    print(f'array_c[{array_c.nrow}] => {s!r}')
 # Close the file.
 fileh.close()

--- a/examples/earray2.py
+++ b/examples/earray2.py
@@ -3,7 +3,6 @@
 """Small example that shows how to work with extendeable arrays of different
 types, strings included."""
 
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/filenodes1.py
+++ b/examples/filenodes1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from tables.nodes import filenode
 
 import tables

--- a/examples/index.py
+++ b/examples/index.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import random
 import tables
 print('tables.__version__', tables.__version__)

--- a/examples/inmemory.py
+++ b/examples/inmemory.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 
 """inmemory.py.
 

--- a/examples/links.py
+++ b/examples/links.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables as tb
 
 # Create a new file with some structural groups
@@ -13,7 +12,7 @@ t1 = f1.create_table(g2, 't1', {'f1': tb.IntCol(), 'f2': tb.FloatCol()})
 # Create new group and a first hard link
 gl = f1.create_group('/', 'gl')
 ht = f1.create_hard_link(gl, 'ht', '/g1/g2/t1')  # ht points to t1
-print("``%s`` is a hard link to: ``%s``" % (ht, t1))
+print(f"``{ht}`` is a hard link to: ``{t1}``")
 
 # Remove the orginal link to the t1 table
 t1.remove()
@@ -21,13 +20,13 @@ print("table continues to be accessible in: ``%s``" % f1.get_node('/gl/ht'))
 
 # Let's continue with soft links
 la1 = f1.create_soft_link(gl, 'la1', '/g1/a1')  # la1 points to a1
-print("``%s`` is a soft link to: ``%s``" % (la1, la1.target))
+print(f"``{la1}`` is a soft link to: ``{la1.target}``")
 lt = f1.create_soft_link(gl, 'lt', '/g1/g2/t1')  # lt points to t1 (dangling)
-print("``%s`` is a soft link to: ``%s``" % (lt, lt.target))
+print(f"``{lt}`` is a soft link to: ``{lt.target}``")
 
 # Recreate the '/g1/g2/t1' path
 t1 = f1.create_hard_link('/g1/g2', 't1', '/gl/ht')
-print("``%s`` is not dangling anymore" % (lt,))
+print(f"``{lt}`` is not dangling anymore")
 
 # Dereferrencing
 plt = lt()
@@ -43,7 +42,7 @@ f2.close()  # close the other file
 # Remove the original soft link and create an external link
 la1.remove()
 la1 = f1.create_external_link(gl, 'la1', 'links2.h5:/a1')
-print("``%s`` is an external link to: ``%s``" % (la1, la1.target))
+print(f"``{la1}`` is an external link to: ``{la1.target}``")
 new_a1 = la1()  # dereferrencing la1 returns a1 in links2.h5
 print("dereferred la1 node:  ``%s``" % new_a1)
 print("new_a1 file:", new_a1._v_file.filename)

--- a/examples/multiprocess_access_benchmarks.py
+++ b/examples/multiprocess_access_benchmarks.py
@@ -12,9 +12,6 @@
 # another, and then modified by incrementing each array element.  This is meant
 # to simulate retrieving data and then modifying it.
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import multiprocessing
 import os
@@ -33,7 +30,7 @@ def create_file(array_size):
     array = np.ones(array_size, dtype='i8')
     with tables.open_file('test.h5', 'w') as fobj:
         array = fobj.create_array('/', 'test', array)
-        print('file created, size: {0} MB'.format(array.size_on_disk / 1e6))
+        print('file created, size: {} MB'.format(array.size_on_disk / 1e6))
 
 
 # process to receive an array using a multiprocessing.Pipe connection

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -1,7 +1,6 @@
 """Example showing how to access a PyTables file from multiple processes using
 queues."""
 
-from __future__ import print_function
 import sys
 
 if sys.version < '3':
@@ -63,7 +62,7 @@ class FileAccess(multiprocessing.Process):
                 # look up the appropriate result_queue for this data processor
                 # instance
                 result_queue = self.result_queues[proc_num]
-                print('processor {0} reading from row {1}'.format(proc_num,
+                print('processor {} reading from row {}'.format(proc_num,
                                                                   row_num))
                 result_queue.put(self.read_data(row_num))
                 another_loop = True
@@ -176,8 +175,8 @@ if __name__ == '__main__':
     print()
     for output_file in output_files:
         print()
-        print('contents of log file {0}'.format(output_file))
-        print(open(output_file, 'r').read())
+        print(f'contents of log file {output_file}')
+        print(open(output_file).read())
         os.remove(output_file)
 
     os.remove('test.h5')

--- a/examples/nested-tut.py
+++ b/examples/nested-tut.py
@@ -8,7 +8,6 @@ with ptdump or any HDF5 generic utility.
 
 """
 
-from __future__ import print_function
 import numpy
 
 import tables

--- a/examples/nested1.py
+++ b/examples/nested1.py
@@ -1,7 +1,6 @@
 # Example to show how nested types can be dealed with PyTables
 # F. Alted 2005/05/27
 
-from __future__ import print_function
 import random
 import tables
 

--- a/examples/objecttree.py
+++ b/examples/objecttree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 
 

--- a/examples/particles.py
+++ b/examples/particles.py
@@ -1,6 +1,5 @@
 """Beware! you need PyTables >= 2.3 to run this script!"""
 
-from __future__ import print_function
 from time import time  # use clock for Win
 import numpy as np
 import tables

--- a/examples/play-with-enums.py
+++ b/examples/play-with-enums.py
@@ -3,7 +3,6 @@
 # since it contains some statements that raise exceptions.
 # To run it, paste it as the input of ``python``.
 
-from __future__ import print_function
 
 
 def COMMENT(string):

--- a/examples/read_array_out_arg.py
+++ b/examples/read_array_out_arg.py
@@ -5,9 +5,6 @@
 # reused.
 
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import time
 
@@ -19,7 +16,7 @@ def create_file(array_size):
     array = np.ones(array_size, dtype='i8')
     with tables.open_file('test.h5', 'w') as fobj:
         array = fobj.create_array('/', 'test', array)
-        print('file created, size: {0} MB'.format(array.size_on_disk / 1e6))
+        print('file created, size: {} MB'.format(array.size_on_disk / 1e6))
 
 
 def standard_read(array_size):
@@ -31,7 +28,7 @@ def standard_read(array_size):
             output = array.read(0, array_size, 1)
         end = time.time()
         assert(np.all(output == 1))
-        print('standard read   \t {0:5.5f}'.format((end - start) / N))
+        print('standard read   \t {:5.5f}'.format((end - start) / N))
 
 
 def pre_allocated_read(array_size):
@@ -44,7 +41,7 @@ def pre_allocated_read(array_size):
             array.read(0, array_size, 1, out=output)
         end = time.time()
         assert(np.all(output == 1))
-        print('pre-allocated read\t {0:5.5f}'.format((end - start) / N))
+        print('pre-allocated read\t {:5.5f}'.format((end - start) / N))
 
 
 if __name__ == '__main__':

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -93,7 +93,7 @@ def main():
             thread.join()
 
     # print results
-    print('Mean: {}'.format(mean_))
+    print(f'Mean: {mean_}')
 
 
 if __name__ == '__main__':

--- a/examples/table-tree.py
+++ b/examples/table-tree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/table1.py
+++ b/examples/table1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 
 
@@ -56,7 +55,7 @@ print()
 
 table = fileh.root.newgroup.table
 print("Object:", table)
-print("Table name: %s. Table title: %s" % (table.name, table.title))
+print(f"Table name: {table.name}. Table title: {table.title}")
 print("Rows saved on table: %d" % (table.nrows))
 
 print("Variable names on table with their type:")

--- a/examples/table2.py
+++ b/examples/table2.py
@@ -1,5 +1,4 @@
 # This shows how to use the cols accessors for table columns
-from __future__ import print_function
 import tables
 
 

--- a/examples/table3.py
+++ b/examples/table3.py
@@ -1,5 +1,4 @@
 # This is an example on how to use complex columns
-from __future__ import print_function
 import tables
 
 

--- a/examples/tables-with-padding.py
+++ b/examples/tables-with-padding.py
@@ -1,5 +1,4 @@
 # This is an example on how to use complex columns
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -129,7 +129,7 @@ def main():
             thread.join()
 
     # print results
-    print('Mean: {}'.format(mean_))
+    print(f'Mean: {mean_}')
 
 
 if __name__ == '__main__':

--- a/examples/tutorial1-1.py
+++ b/examples/tutorial1-1.py
@@ -5,7 +5,6 @@ with any HDF5 generic utility.
 
 """
 
-from __future__ import print_function
 import numpy as np
 import tables
 

--- a/examples/tutorial1-2.py
+++ b/examples/tutorial1-2.py
@@ -5,7 +5,6 @@ that create the tutorial1.h5 file needed here.
 
 """
 
-from __future__ import print_function
 import tables
 
 print()
@@ -119,7 +118,7 @@ print("Table title:", table.title)
 print("Number of rows in table:", table.nrows)
 print("Table variable names with their type and shape:")
 for name in table.colnames:
-    print(name, ':= %s, %s' % (table.coldtypes[name],
+    print(name, ':= {}, {}'.format(table.coldtypes[name],
                                table.coldtypes[name].shape))
 print()
 

--- a/examples/tutorial2.py
+++ b/examples/tutorial2.py
@@ -5,7 +5,6 @@ Example to be used in the second tutorial in the User's Guide.
 
 """
 
-from __future__ import print_function
 import tables
 import numpy as np
 

--- a/examples/vlarray1.py
+++ b/examples/vlarray1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import tables
 import numpy as np
 

--- a/examples/vlarray2.py
+++ b/examples/vlarray2.py
@@ -3,7 +3,6 @@
 """Small example that shows how to work with variable length arrays of
 different types, UNICODE strings and general Python objects included."""
 
-from __future__ import print_function
 import numpy as np
 import tables
 import pickle

--- a/examples/vlarray3.py
+++ b/examples/vlarray3.py
@@ -3,7 +3,6 @@
 """Example that shows how to easily save a variable number of atoms with a
 VLArray."""
 
-from __future__ import print_function
 import numpy
 import tables
 

--- a/examples/vlarray4.py
+++ b/examples/vlarray4.py
@@ -3,7 +3,6 @@
 """Example that shows how to easily save a variable number of atoms with a
 VLArray."""
 
-from __future__ import print_function
 import numpy
 import tables
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     def _print_admonition(kind, head, body):
         tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
 
-        print(".. %s:: %s" % (kind.upper(), head))
+        print(f".. {kind.upper()}:: {head}")
         for line in tw.wrap(body):
             print(line)
 
@@ -191,7 +191,7 @@ if __name__ == '__main__':
         return None
 
 
-    class BasePackage(object):
+    class BasePackage:
         _library_prefixes = []
         _library_suffixes = []
         _runtime_prefixes = []
@@ -369,7 +369,7 @@ if __name__ == '__main__':
         if (major_version == -1 or minor_version == -1 or
                 release_version == -1):
             exit_with_error("Unable to detect HDF5 library version!")
-        return LooseVersion("%s.%s.%s" % (major_version, minor_version,
+        return LooseVersion("{}.{}.{}".format(major_version, minor_version,
                                         release_version))
 
 
@@ -391,7 +391,7 @@ if __name__ == '__main__':
         if (major_version == -1 or minor_version == -1 or
                 release_version == -1):
             exit_with_error("Unable to detect Blosc library version!")
-        return "%s.%s.%s" % (major_version, minor_version, release_version)
+        return f"{major_version}.{minor_version}.{release_version}"
 
 
     _cp = convert_path

--- a/tables/array.py
+++ b/tables/array.py
@@ -843,8 +843,8 @@ class Array(hdf5extension.Array, Leaf):
             bytes_required = self.rowsize * nrowstoread
             # if buffer is too small, it will segfault
             if bytes_required != out.nbytes:
-                raise ValueError(('output array size invalid, got {0} bytes, '
-                                  'need {1} bytes').format(out.nbytes,
+                raise ValueError(('output array size invalid, got {} bytes, '
+                                  'need {} bytes').format(out.nbytes,
                                                            bytes_required))
             if not out.flags['C_CONTIGUOUS']:
                 raise ValueError('output array not C contiguous')
@@ -892,7 +892,7 @@ class Array(hdf5extension.Array, Leaf):
         self._g_check_open()
         if out is not None and self.flavor != 'numpy':
             msg = ("Optional 'out' argument may only be supplied if array "
-                   "flavor is 'numpy', currently is {0}").format(self.flavor)
+                   "flavor is 'numpy', currently is {}").format(self.flavor)
             raise TypeError(msg)
         (start, stop, step) = self._process_range_read(start, stop, step)
         arr = self._read(start, stop, step, out)
@@ -923,12 +923,12 @@ class Array(hdf5extension.Array, Leaf):
     def __repr__(self):
         """This provides more metainfo in addition to standard __str__"""
 
-        return """%s
-  atom := %r
-  maindim := %r
-  flavor := %r
-  byteorder := %r
-  chunkshape := %r""" % (self, self.atom, self.maindim,
+        return """{}
+  atom := {!r}
+  maindim := {!r}
+  flavor := {!r}
+  byteorder := {!r}
+  chunkshape := {!r}""".format(self, self.atom, self.maindim,
                          self.flavor, self.byteorder,
                          self.chunkshape)
 

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -130,7 +130,7 @@ def _normalize_shape(shape):
     # HDF5 does not support ranks greater than 32
     if len(shape) > 32:
         raise ValueError(
-            "shapes with rank > 32 are not supported: %r" % (shape,))
+            f"shapes with rank > 32 are not supported: {shape!r}")
 
     return tuple(SizeType(s) for s in shape)
 
@@ -188,7 +188,7 @@ class MetaAtom(type):
     """
 
     def __init__(class_, name, bases, dict_):
-        super(MetaAtom, class_).__init__(name, bases, dict_)
+        super().__init__(name, bases, dict_)
 
         kind = dict_.get('kind')
         itemsize = dict_.get('itemsize')
@@ -343,7 +343,7 @@ class Atom(metaclass=MetaAtom):
         if (not isinstance(sctype, type)
            or not issubclass(sctype, numpy.generic)):
             if sctype not in numpy.sctypeDict:
-                raise ValueError("unknown NumPy scalar type: %r" % (sctype,))
+                raise ValueError(f"unknown NumPy scalar type: {sctype!r}")
             sctype = numpy.sctypeDict[sctype]
         return class_.from_dtype(numpy.dtype((sctype, shape)), dflt)
 
@@ -415,7 +415,7 @@ class Atom(metaclass=MetaAtom):
         """
 
         if type not in all_types:
-            raise ValueError("unknown type: %r" % (type,))
+            raise ValueError(f"unknown type: {type!r}")
         kind, itemsize = split_type(type)
         return class_.from_kind(kind, itemsize, shape, dflt)
 
@@ -456,7 +456,7 @@ class Atom(metaclass=MetaAtom):
 
         kwargs = {'shape': shape}
         if kind not in atom_map:
-            raise ValueError("unknown kind: %r" % (kind,))
+            raise ValueError(f"unknown kind: {kind!r}")
         # This incompatibility detection may get out-of-date and is
         # too hard-wired, but I couldn't come up with something
         # smarter.  -- Ivan (2007-02-08)
@@ -534,10 +534,10 @@ class Atom(metaclass=MetaAtom):
         as NumPy objects."""
 
     def __repr__(self):
-        args = 'shape=%s, dflt=%r' % (self.shape, self.dflt)
+        args = f'shape={self.shape}, dflt={self.dflt!r}'
         if not hasattr(self.__class__.itemsize, '__int__'):  # non-fixed
-            args = 'itemsize=%s, %s' % (self.itemsize, args)
-        return '%s(%s)' % (self.__class__.__name__, args)
+            args = f'itemsize={self.itemsize}, {args}'
+        return f'{self.__class__.__name__}({args})'
 
     __eq__ = _cmp_dispatcher('_is_equal_to_atom')
 
@@ -601,7 +601,7 @@ class Atom(metaclass=MetaAtom):
             args = [arg for arg, p in parameters.items()
                 if p.kind is p.POSITIONAL_OR_KEYWORD]
 
-        return dict((arg, getattr(self, arg)) for arg in args if arg != 'self')
+        return {arg: getattr(self, arg) for arg in args if arg != 'self'}
 
     def _is_equal_to_atom(self, atom):
         """Is this object equal to the given `atom`?"""
@@ -1028,7 +1028,7 @@ class ReferenceAtom(Atom):
         Atom.__init__(self, self.type, shape, self._defvalue)
 
     def __repr__(self):
-        return 'ReferenceAtom(shape=%s)' % (self.shape,)
+        return f'ReferenceAtom(shape={self.shape})'
 
 # Pseudo-atom classes
 # ===================
@@ -1049,7 +1049,7 @@ class ReferenceAtom(Atom):
 # serialization and string management.
 
 
-class PseudoAtom(object):
+class PseudoAtom:
     """Pseudo-atoms can only be used in ``VLArray`` nodes.
 
     They can be recognised because they also have `kind`, `type` and
@@ -1124,7 +1124,7 @@ class VLStringAtom(_BufferedAtom):
             warnings.warn("Storing non bytestrings in VLStringAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, bytes):
-            raise TypeError("object is not a string: %r" % (object_,))
+            raise TypeError(f"object is not a string: {object_!r}")
         return numpy.string_(object_)
 
     def fromarray(self, array):
@@ -1166,7 +1166,7 @@ class VLUnicodeAtom(_BufferedAtom):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, str):
-            raise TypeError("object is not a string: %r" % (object_,))
+            raise TypeError(f"object is not a string: {object_!r}")
         ustr = str(object_)
         uarr = numpy.array(ustr, dtype='U')
         return numpy.ndarray(
@@ -1180,7 +1180,7 @@ class VLUnicodeAtom(_BufferedAtom):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, str):
-            raise TypeError("object is not a string: %r" % (object_,))
+            raise TypeError(f"object is not a string: {object_!r}")
         return numpy.unicode_(object_)
 
     def fromarray(self, array):

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -67,7 +67,7 @@ def issysattrname(name):
         return False
 
 
-class AttributeSet(hdf5extension.AttributeSet, object):
+class AttributeSet(hdf5extension.AttributeSet):
     """Container for the HDF5 attributes of a Node.
 
     This class provides methods to create new HDF5 node attributes,
@@ -286,9 +286,9 @@ class AttributeSet(hdf5extension.AttributeSet, object):
 
         Only PY3 supports this special method.
         """
-        return list(set(c for c in
+        return list({c for c in
                     super().__dir__() + self._v_attrnames
-                    if c.isidentifier()))
+                    if c.isidentifier()})
 
     def __getattr__(self, name):
         """Get the attribute named "name"."""
@@ -659,7 +659,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # However, we need to know Node here.
         # Using class_name_dict avoids a circular import.
         if not isinstance(where, class_name_dict['Node']):
-            raise TypeError("destination object is not a node: %r" % (where,))
+            raise TypeError(f"destination object is not a node: {where!r}")
         self._g_copy(where._v_attrs, where._v_attrs.__setattr__)
 
     def _g_close(self):
@@ -685,11 +685,11 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # print additional info only if there are attributes to show
         attrnames = [n for n in self._v_attrnames]
         if len(attrnames):
-            rep = ['%s := %r' % (attr, getattr(self, attr))
+            rep = ['{} := {!r}'.format(attr, getattr(self, attr))
                    for attr in attrnames]
             attrlist = '[%s]' % (',\n    '.join(rep))
 
-            return "%s:\n   %s" % (str(self), attrlist)
+            return "{}:\n   {}".format(str(self), attrlist)
         else:
             return str(self)
 

--- a/tables/conditions.py
+++ b/tables/conditions.py
@@ -312,7 +312,7 @@ def _get_idx_expr(expr, indexedcols):
     return _get_idx_expr_recurse(expr, indexedcols, [], [''])
 
 
-class CompiledCondition(object):
+class CompiledCondition:
     """Container for a compiled condition."""
 
     # Lazy attributes

--- a/tables/description.py
+++ b/tables/description.py
@@ -227,14 +227,14 @@ class Col(atom.Atom, metaclass=type):
         rpar = atomrepr.rindex(')')
         atomargs = atomrepr[lpar + 1:rpar]
         classname = self.__class__.__name__
-        return '%s(%s, pos=%s)' % (classname, atomargs, self._v_pos)
+        return f'{classname}({atomargs}, pos={self._v_pos})'
 
     # Private methods
     # ~~~~~~~~~~~~~~~
     def _get_init_args(self):
         """Get a dictionary of instance constructor arguments."""
 
-        kwargs = dict((arg, getattr(self, arg)) for arg in ('shape', 'dflt'))
+        kwargs = {arg: getattr(self, arg) for arg in ('shape', 'dflt')}
         kwargs['pos'] = getattr(self, '_v_pos', None)
         return kwargs
 
@@ -309,7 +309,7 @@ Time64Col = Col._subclass_from_prefix('Time64')
 
 # Table description classes
 # =========================
-class Description(object):
+class Description:
     """This class represents descriptions of the structure of tables.
 
     An instance of this class is automatically bound to Table (see
@@ -660,7 +660,7 @@ class Description(object):
         def join_paths(path1, path2):
             if not path1:
                 return path2
-            return '%s/%s' % (path1, path2)
+            return f'{path1}/{path2}'
 
         # The top of the stack always has a nested description
         # and a list of its child columns

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -161,9 +161,9 @@ class HDF5ExtError(RuntimeError):
 
             if len(self.args) == 1 and isinstance(self.args[0], str):
                 msg = super().__str__()
-                msg = "%s\n\n%s" % (bt, msg)
+                msg = f"{bt}\n\n{msg}"
             elif self.h5backtrace[-1][-1]:
-                msg = "%s\n\n%s" % (bt, self.h5backtrace[-1][-1])
+                msg = "{}\n\n{}".format(bt, self.h5backtrace[-1][-1])
             else:
                 msg = bt
         else:

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -21,7 +21,7 @@ from .exceptions import PerformanceWarning
 from .parameters import IO_BUFFER_SIZE, BUFFER_TIMES
 
 
-class Expr(object):
+class Expr:
     """A class for evaluating expressions with arbitrary array-like objects.
 
     Expr is a class for evaluating expressions containing array-like objects.
@@ -679,8 +679,7 @@ value of dimensions that are orthogonal (and preferably close) to the
             # Do the actual computation
             rout = self._compiled_expr(*vals)
             # Return one row per call
-            for row in rout:
-                yield row
+            yield from rout
 
         # Activate the conversion again (default)
         for val in values:

--- a/tables/file.py
+++ b/tables/file.py
@@ -81,7 +81,7 @@ compatible_formats = []  # Old format versions we can read
                          # Empty means that we support all the old formats
 
 
-class _FileRegistry(object):
+class _FileRegistry:
     def __init__(self):
         self._name_mapping = collections.defaultdict(set)
         self._handlers = set()
@@ -315,7 +315,7 @@ def open_file(filename, mode="r", title="", root_uep="/", filters=None,
 
 
 # A dumb class that doesn't keep nothing at all
-class _NoCache(object):
+class _NoCache:
     def __len__(self):
         return 0
 
@@ -354,7 +354,7 @@ class _DictCache(dict):
         super().__setitem__(key, value)
 
 
-class NodeManager(object):
+class NodeManager:
     def __init__(self, nslots=64, node_factory=None):
         super().__init__()
 
@@ -569,7 +569,7 @@ class NodeManager(object):
                 node._f_close()
 
 
-class File(hdf5extension.File, object):
+class File(hdf5extension.File):
     """The in-memory representation of a PyTables file.
 
     An instance of this class is returned when a PyTables file is
@@ -751,14 +751,14 @@ class File(hdf5extension.File, object):
                              "'r', 'r+', 'a' and 'w'" % mode)
 
         # Get all the parameters in parameter file(s)
-        params = dict([(k, v) for k, v in parameters.__dict__.items()
-                       if k.isupper() and not k.startswith('_')])
+        params = {k: v for k, v in parameters.__dict__.items()
+                       if k.isupper() and not k.startswith('_')}
         # Update them with possible keyword arguments
         if [k for k in kwargs if k.isupper()]:
             warnings.warn("The use of uppercase keyword parameters is "
                           "deprecated", DeprecationWarning)
 
-        kwargs = dict([(k.upper(), v) for k, v in kwargs.items()])
+        kwargs = {k.upper(): v for k, v in kwargs.items()}
         params.update(kwargs)
 
         # If MAX_ * _THREADS is not set yet, set it to the number of cores
@@ -1640,7 +1640,7 @@ class File(hdf5extension.File, object):
             node = self._get_node(nodepath)
         else:
             raise TypeError(
-                "``where`` must be a string or a node: %r" % (where,))
+                f"``where`` must be a string or a node: {where!r}")
 
         # Finally, check whether the desired node is an instance
         # of the expected class.
@@ -1777,7 +1777,7 @@ class File(hdf5extension.File, object):
                                            recursive=recursive, **kwargs)
                 return npobj
             else:
-                raise IOError(
+                raise OSError(
                     "You cannot copy a root group over the same file")
         return obj._f_copy(newparent, newname,
                            overwrite, recursive, createparents, **kwargs)
@@ -1962,7 +1962,7 @@ class File(hdf5extension.File, object):
 
         # Check that we are not treading our own shoes
         if os.path.abspath(self.filename) == os.path.abspath(dstfilename):
-            raise IOError("You cannot copy a file over itself")
+            raise OSError("You cannot copy a file over itself")
 
         # Compute default arguments.
         # These are *not* passed on.
@@ -1977,7 +1977,7 @@ class File(hdf5extension.File, object):
         title = kwargs.pop('title', self.title)
 
         if os.path.isfile(dstfilename) and not overwrite:
-            raise IOError(("file ``%s`` already exists; "
+            raise OSError(("file ``%s`` already exists; "
                            "you may want to use the ``overwrite`` "
                            "argument") % dstfilename)
 
@@ -2111,12 +2111,10 @@ class File(hdf5extension.File, object):
         elif class_ is Node:  # all nodes
             yield self.get_node(where)
             for group in self.walk_groups(where):
-                for leaf in self.iter_nodes(group):
-                    yield leaf
+                yield from self.iter_nodes(group)
         else:  # only nodes of the named type
             for group in self.walk_groups(where):
-                for leaf in self.iter_nodes(group, classname):
-                    yield leaf
+                yield from self.iter_nodes(group, classname)
 
 
     def walk_groups(self, where="/"):
@@ -2168,7 +2166,7 @@ class File(hdf5extension.File, object):
     def _check_group(self, node):
         # `node` must already be a node.
         if not isinstance(node, Group):
-            raise TypeError("node ``%s`` is not a group" % (node._v_pathname,))
+            raise TypeError(f"node ``{node._v_pathname}`` is not a group")
 
 
     # <Undo/Redo support>

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -53,7 +53,7 @@ _bitshuffle_flag = 0x8
 
 # Classes
 # =======
-class Filters(object):
+class Filters:
     """Container for filter properties.
 
     This class is meant to serve as a container that keeps information about
@@ -389,7 +389,7 @@ class Filters(object):
         args.append('fletcher32=%s' % self.fletcher32)
         args.append(
             'least_significant_digit=%s' % self.least_significant_digit)
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(args))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(args))
 
     def __str__(self):
         return repr(self)

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -271,7 +271,7 @@ def _register_converters():
             # contiguous).  Otherwise, an identity function is used.
             convfunc = None
             try:
-                convfunc = eval('_conv_%s_to_%s' % (src_flavor, dst_flavor))
+                convfunc = eval(f'_conv_{src_flavor}_to_{dst_flavor}')
             except NameError:
                 if src_flavor == dst_flavor:
                     convfunc = identity

--- a/tables/group.py
+++ b/tables/group.py
@@ -182,7 +182,7 @@ class Group(hdf5extension.Group, Node):
     def _g_setfilters(self, value):
         if not isinstance(value, Filters):
             raise TypeError(
-                "value is not an instance of `Filters`: %r" % (value,))
+                f"value is not an instance of `Filters`: {value!r}")
         self._v_attrs.FILTERS = value
 
     def _g_delfilters(self):
@@ -474,8 +474,7 @@ class Group(hdf5extension.Group, Node):
                 yield group
         else:
             for group in self._f_walk_groups():
-                for leaf in group._f_iter_nodes(classname):
-                    yield leaf
+                yield from group._f_iter_nodes(classname)
 
 
     def _g_join(self, name):
@@ -1089,7 +1088,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         pathname = self._v_pathname
         classname = self.__class__.__name__
         title = self._v_title
-        return "%s (%s) %r" % (pathname, classname, title)
+        return f"{pathname} ({classname}) {title!r}"
 
     def __repr__(self):
         """Return a detailed string representation of the group.
@@ -1107,12 +1106,12 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         """
 
         rep = [
-            '%r (%s)' % (childname, child.__class__.__name__)
+            f'{childname!r} ({child.__class__.__name__})'
             for (childname, child) in self._v_children.items()
         ]
         childlist = '[%s]' % (', '.join(rep))
 
-        return "%s\n  children := %s" % (str(self), childlist)
+        return "{}\n  children := {}".format(str(self), childlist)
 
 
 # Special definition for group root

--- a/tables/index.py
+++ b/tables/index.py
@@ -947,7 +947,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if self.verbose:
             t = round(time() - t1, 4)
             c = round(perf_counter() - c1, 4)
-            print("time: %s. clock: %s" % (t, c))
+            print(f"time: {t}. clock: {c}")
 
     def swap(self, what, mode=None):
         """Swap chunks or slices using a certain bounds reference."""
@@ -967,16 +967,16 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         elif what == "slices":
             self.swap_slices(mode)
         if mode:
-            message = "swap_%s(%s)" % (what, mode)
+            message = f"swap_{what}({mode})"
         else:
-            message = "swap_%s" % (what,)
+            message = f"swap_{what}"
         (nover, mult, tover) = self.compute_overlaps(
             self.tmp, message, self.verbose)
         rmult = len(mult.nonzero()[0]) / float(len(mult))
         if self.verbose:
             t = round(time() - t1, 4)
             c = round(perf_counter() - c1, 4)
-            print("time: %s. clock: %s" % (t, c))
+            print(f"time: {t}. clock: {c}")
         # Check that entropy is actually decreasing
         if what == "chunks" and self.last_tover > 0. and self.last_nover > 0:
             tover_var = (self.last_tover - tover) / self.last_tover
@@ -2125,7 +2125,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 filters += ", shuffle"
             if self.filters.bitshuffle:
                 filters += ", bitshuffle"
-            filters += ", %s(%s)" % (self.filters.complib,
+            filters += ", {}({})".format(self.filters.complib,
                                      self.filters.complevel)
         return "Index(%s, %s%s).is_csi=%s" % \
                (self.optlevel, self.kind, filters, self.is_csi)
@@ -2134,18 +2134,18 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """This provides more metainfo than standard __repr__"""
 
         cpathname = self.table._v_pathname + ".cols." + self.column.pathname
-        retstr = """%s (Index for column %s)
-  optlevel := %s
-  kind := %s
-  filters := %s
-  is_csi := %s
-  nelements := %s
-  chunksize := %s
-  slicesize := %s
-  blocksize := %s
-  superblocksize := %s
-  dirty := %s
-  byteorder := %r""" % (self._v_pathname, cpathname,
+        retstr = """{} (Index for column {})
+  optlevel := {}
+  kind := {}
+  filters := {}
+  is_csi := {}
+  nelements := {}
+  chunksize := {}
+  slicesize := {}
+  blocksize := {}
+  superblocksize := {}
+  dirty := {}
+  byteorder := {!r}""".format(self._v_pathname, cpathname,
                         self.optlevel, self.kind,
                         self.filters, self.is_csi,
                         self.nelements,

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -175,13 +175,13 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
     def __repr__(self):
         """A verbose representation of this class."""
 
-        return """%s
-  atom = %r
-  shape = %s
-  nrows = %s
-  chunksize = %s
-  slicesize = %s
-  byteorder = %r""" % (self, self.atom, self.shape, self.nrows,
+        return """{}
+  atom = {!r}
+  shape = {}
+  nrows = {}
+  chunksize = {}
+  slicesize = {}
+  byteorder = {!r}""".format(self, self.atom, self.shape, self.nrows,
                        self.chunksize, self.slicesize, self.byteorder)
 
 

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -311,7 +311,7 @@ class Leaf(Node):
                 filters += ", shuffle"
             if self.filters.bitshuffle:
                 filters += ", bitshuffle"
-            filters += ", %s(%s)" % (self.filters.complib,
+            filters += ", {}({})".format(self.filters.complib,
                                      self.filters.complevel)
         return "%s (%s%s%s) %r" % \
                (self._v_pathname, classname, self.shape, filters, title)
@@ -535,15 +535,15 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         if type(key) in (list, tuple):
             if isinstance(key, tuple) and len(key) > len(self.shape):
-                raise IndexError("Invalid index or slice: %r" % (key,))
+                raise IndexError(f"Invalid index or slice: {key!r}")
             # Try to convert key to a numpy array.  If not possible,
             # a TypeError will be issued (to be catched later on).
             try:
                 key = toarray(key)
             except ValueError:
-                raise TypeError("Invalid index or slice: %r" % (key,))
+                raise TypeError(f"Invalid index or slice: {key!r}")
         elif not isinstance(key, numpy.ndarray):
-            raise TypeError("Invalid index or slice: %r" % (key,))
+            raise TypeError(f"Invalid index or slice: {key!r}")
 
         # Protection against empty keys
         if len(key) == 0:

--- a/tables/link.py
+++ b/tables/link.py
@@ -316,7 +316,7 @@ class SoftLink(linkextension.SoftLink, Link):
             dangling = " (dangling)"
         else:
             dangling = ""
-        return "%s%s (%s) -> %s%s" % (closed, self._v_pathname, classname,
+        return "{}{} ({}) -> {}{}".format(closed, self._v_pathname, classname,
                                       self.target, dangling)
 
 
@@ -426,7 +426,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
         """
 
         classname = self.__class__.__name__
-        return "%s (%s) -> %s" % (self._v_pathname, classname, self.target)
+        return f"{self._v_pathname} ({classname}) -> {self.target}"
 
 
 ## Local Variables:

--- a/tables/misc/enum.py
+++ b/tables/misc/enum.py
@@ -31,7 +31,7 @@ __docformat__ = 'reStructuredText'
 """The format of documentation strings in this module."""
 
 
-class Enum(object):
+class Enum:
     """Enumerated type.
 
     Each instance of this class represents an enumerated type. The
@@ -139,7 +139,7 @@ sequences, mappings and other enumerations""")
 
         if not isinstance(name, str):
             raise TypeError(
-                "name of enumerated value is not a string: %r" % (name,))
+                f"name of enumerated value is not a string: {name!r}")
         if name.startswith('_'):
             raise ValueError(
                 "name of enumerated value can not start with ``_``: %r"
@@ -185,7 +185,7 @@ sequences, mappings and other enumerations""")
         try:
             return self._names[name]
         except KeyError:
-            raise KeyError("no enumerated value with that name: %r" % (name,))
+            raise KeyError(f"no enumerated value with that name: {name!r}")
 
     def __setitem__(self, name, value):
         """This operation is forbidden."""
@@ -265,7 +265,7 @@ sequences, mappings and other enumerations""")
 
         if not isinstance(name, str):
             raise TypeError(
-                "name of enumerated value is not a string: %r" % (name,))
+                f"name of enumerated value is not a string: {name!r}")
         return name in self._names
 
     def __call__(self, value, *default):
@@ -303,7 +303,7 @@ sequences, mappings and other enumerations""")
             if len(default) > 0:
                 return default[0]
             raise ValueError(
-                "no enumerated value with that concrete value: %r" % (value,))
+                f"no enumerated value with that concrete value: {value!r}")
 
     def __len__(self):
         """Return the number of enumerated values in the enumerated type.
@@ -333,8 +333,7 @@ sequences, mappings and other enumerations""")
 
         """
 
-        for name_value in self._names.items():
-            yield name_value
+        yield from self._names.items()
 
     def __eq__(self, other):
         """Is the other enumerated type equivalent to this one?

--- a/tables/node.py
+++ b/tables/node.py
@@ -43,7 +43,7 @@ def _closedrepr(oldmethod):
             cmod = self.__class__.__module__
             cname = self.__class__.__name__
             addr = hex(id(self))
-            return '<closed %s.%s at %s>' % (cmod, cname, addr)
+            return f'<closed {cmod}.{cname} at {addr}>'
         return oldmethod(self)
 
     return newmethod
@@ -73,7 +73,7 @@ class MetaNode(type):
         return type.__new__(class_, name, bases, dict_)
 
     def __init__(class_, name, bases, dict_):
-        super(MetaNode, class_).__init__(name, bases, dict_)
+        super().__init__(name, bases, dict_)
 
         # Always register into class name dictionary.
         class_name_dict[class_.__name__] = class_
@@ -852,8 +852,8 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         if name in parent:
             if not overwrite:
                 raise NodeError("""\
-destination group ``%s`` already has a node named ``%s``; \
-you may want to use the ``overwrite`` argument""" % (parent._v_pathname, name))
+destination group ``{}`` already has a node named ``{}``; \
+you may want to use the ``overwrite`` argument""".format(parent._v_pathname, name))
             parent._f_get_child(name)._f_remove(True)
 
 

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -27,7 +27,6 @@ See :ref:`filenode_usersguide` for instructions on use.
    compliant with the interfaces defined in the :mod:`io` module.
 
 """
-from __future__ import absolute_import
 
 import io
 import os
@@ -114,7 +113,7 @@ class RawPyTablesIO(io.RawIOBase):
             raise TypeError("an integer is required")
         if whence == 0:
             if pos < 0:
-                raise ValueError("negative seek position %r" % (pos,))
+                raise ValueError(f"negative seek position {pos!r}")
             self._pos = pos
         elif whence == 1:
             self._pos = max(0, self._pos + pos)
@@ -193,10 +192,10 @@ class RawPyTablesIO(io.RawIOBase):
         if pos is None:
             pos = self._pos
         elif pos < 0:
-            raise ValueError("negative truncate position %r" % (pos,))
+            raise ValueError(f"negative truncate position {pos!r}")
 
         if pos < self._node.nrows:
-            raise IOError("truncating is only allowed for growing a file")
+            raise OSError("truncating is only allowed for growing a file")
         self._append_zeros(pos - self._node.nrows)
 
         return self.seek(pos)
@@ -455,10 +454,10 @@ class RawPyTablesIO(io.RawIOBase):
         ltypever = getattr(attrs, 'NODE_TYPE_VERSION', None)
 
         if ltype != NodeType:
-            raise ValueError("invalid type of node object: %s" % (ltype,))
+            raise ValueError(f"invalid type of node object: {ltype}")
         if ltypever not in NodeTypeVersions:
             raise ValueError(
-                "unsupported type version of node object: %s" % (ltypever,))
+                f"unsupported type version of node object: {ltypever}")
 
 
     def _append_zeros(self, size):
@@ -478,7 +477,7 @@ class RawPyTablesIO(io.RawIOBase):
             np.zeros(dtype=self._vtype, shape=self._vshape(size)))
 
 
-class FileNodeMixin(object):
+class FileNodeMixin:
     """Mixin class for FileNode objects.
 
     It provides access to the attribute set of the node that becomes
@@ -687,7 +686,7 @@ def open_node(node, mode='r'):
     elif mode == 'a+':
         return RAFileNode(node, None)
     else:
-        raise IOError("invalid mode: %s" % (mode,))
+        raise OSError(f"invalid mode: {mode}")
 
 
 
@@ -734,9 +733,9 @@ def save_to_filenode(h5file, filename, where, name=None, overwrite=False,
     """
     # sanity checks
     if not os.access(filename, os.R_OK):
-        raise IOError("The file '%s' could not be read" % filename)
+        raise OSError("The file '%s' could not be read" % filename)
     if isinstance(h5file, tables.file.File) and h5file.mode == "r":
-        raise IOError("The file '%s' is opened read-only" % h5file.filename)
+        raise OSError("The file '%s' is opened read-only" % h5file.filename)
 
     # guess filenode's name if necessary
     if name is None:
@@ -764,7 +763,7 @@ def save_to_filenode(h5file, filename, where, name=None, overwrite=False,
         if not overwrite:
             if new_h5file:
                 f.close()
-            raise IOError("Specified node already exists in file '%s'" %
+            raise OSError("Specified node already exists in file '%s'" %
                           f.filename)
     except tables.NoSuchNodeError:
         pass
@@ -848,7 +847,7 @@ def read_from_filenode(h5file, filename, where, name=None, overwrite=False,
     if os.access(filename, os.R_OK) and not overwrite:
         if new_h5file:
             f.close()
-        raise IOError("The file '%s' already exists" % filename)
+        raise OSError("The file '%s' already exists" % filename)
 
     # create folder hierarchy if necessary
     if create_target and not os.path.isdir(os.path.split(filename)[0]):
@@ -857,7 +856,7 @@ def read_from_filenode(h5file, filename, where, name=None, overwrite=False,
     if not os.access(os.path.split(filename)[0], os.W_OK):
         if new_h5file:
             f.close()
-        raise IOError("The file '%s' cannot be written to" % filename)
+        raise OSError("The file '%s' cannot be written to" % filename)
 
     # read data from filenode
     data = fnode.read()

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -9,7 +9,6 @@
 ########################################################################
 
 """Unit test for the filenode module."""
-from __future__ import absolute_import
 
 import os
 import shutil
@@ -404,7 +403,7 @@ class ReadFileTestCase(TempFileMixin, TestCase):
         except ImportError:
             # PIL not available, nothing to do.
             pass
-        except IOError:
+        except OSError:
             self.fail(
                 "PIL was not able to create an image from the file node.")
 

--- a/tables/path.py
+++ b/tables/path.py
@@ -95,7 +95,7 @@ def check_attribute_name(name):
     ValueError: the empty string is not allowed as an object name
     """
     if not isinstance(name, str):  # Python >= 2.3
-        raise TypeError("object name is not a string: %r" % (name,))
+        raise TypeError(f"object name is not a string: {name!r}")
 
     if name == '':
         raise ValueError("the empty string is not allowed as an object name")
@@ -187,9 +187,9 @@ def join_path(parentpath, name):
     if parentpath == '/' and name.startswith('/'):
         pstr = '%s' % name
     elif parentpath == '/' or name.startswith('/'):
-        pstr = '%s%s' % (parentpath, name)
+        pstr = f'{parentpath}{name}'
     else:
-        pstr = '%s/%s' % (parentpath, name)
+        pstr = f'{parentpath}/{name}'
     if pstr.endswith('/'):
         pstr = pstr[:-1]
     return pstr

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -12,7 +12,6 @@
 are PEP 8 compliant.
 
 """
-from __future__ import absolute_import
 import os
 import re
 import sys
@@ -464,7 +463,7 @@ old2newnames = dict([
     #('_v_expectedsizeinMB', '_v_expected_mb'),          # --> expectedrows
 ])
 
-new2oldnames = dict([(v, k) for k, v in old2newnames.items()])
+new2oldnames = {v: k for k, v in old2newnames.items()}
 
 # Note that it is tempting to use the ast module here, but then this
 # breaks transforming cython files.  So instead we are going to do the
@@ -473,12 +472,12 @@ new2oldnames = dict([(v, k) for k, v in old2newnames.items()])
 
 def make_subs(ns):
     names = new2oldnames if ns.reverse else old2newnames
-    s = '(?<=\W)({0})(?=\W)'.format('|'.join(list(names.keys())))
+    s = r'(?<=\W)({})(?=\W)'.format('|'.join(list(names.keys())))
     if ns.ignore_previous:
-        s += '(?!\s*?=\s*?previous_api(_property)?\()'
-        s += '(?!\* to \*\w+\*)'
-        s += '(?!\* parameter has been renamed into \*\w+\*\.)'
-        s += '(?! is pending deprecation, import \w+ instead\.)'
+        s += r'(?!\s*?=\s*?previous_api(_property)?\()'
+        s += r'(?!\* to \*\w+\*)'
+        s += r'(?!\* parameter has been renamed into \*\w+\*\.)'
+        s += r'(?! is pending deprecation, import \w+ instead\.)'
     subs = re.compile(s, flags=re.MULTILINE)
 
     def repl(m):
@@ -506,8 +505,8 @@ def main():
     ns = parser.parse_args()
 
     if not os.path.isfile(ns.filename):
-        sys.exit('file {0!r} not found'.format(ns.filename))
-    with open(ns.filename, 'r') as f:
+        sys.exit(f'file {ns.filename!r} not found')
+    with open(ns.filename) as f:
         src = f.read()
 
     subs, repl = make_subs(ns)

--- a/tables/scripts/ptdump.py
+++ b/tables/scripts/ptdump.py
@@ -14,8 +14,6 @@ Pass the flag -h to this for help on usage.
 
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
 
 import argparse
 import operator
@@ -66,7 +64,7 @@ def dump_leaf(leaf):
             print("[SCALAR] %s" % (leaf[()]))
         else:
             for i in range(start, stop, step):
-                print("[%s] %s" % (i, leaf[i]))
+                print("[{}] {}".format(i, leaf[i]))
 
     if isinstance(leaf, Table) and options.colinfo:
         # Show info of columns

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -14,8 +14,6 @@ Pass the flag -h to this for help on usage.
 
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
 import sys
 import time
 import os.path
@@ -149,7 +147,7 @@ def copy_leaf(srcfile, dstfile, srcnode, dstnode, title,
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcnode, dstfile, dstnode))
-        print("The error was --> %s: %s" % (type_, value))
+        print(f"The error was --> {type_}: {value}")
         print("The destination file looks like:\n", dstfileh)
         # Close all the open files:
         srcfileh.close()
@@ -238,7 +236,7 @@ def copy_children(srcfile, dstfile, srcgroup, dstgroup, title,
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcgroup, dstfile, dstgroup))
-        print("The error was --> %s: %s" % (type_, value))
+        print(f"The error was --> {type_}: {value}")
         print("The destination file looks like:\n", dstfileh)
         # Close all the open files:
         srcfileh.close()
@@ -510,7 +508,7 @@ def main():
             print("Forcing a CSI creation:", args.checkCSI)
         if args.propindexes:
             print("Recreating indexes in copied table(s)")
-        print("Start copying %s:%s to %s:%s" % (srcfile, srcnode,
+        print("Start copying {}:{} to {}:{}".format(srcfile, srcnode,
                                                 dstfile, dstnode))
         print("+=+" * 20)
 
@@ -579,7 +577,7 @@ def main():
         else:
             print("User attrs not copied")
         print("KBytes copied:", round(nbytescopied / 1024., 3))
-        print("Time copying: %s s (real) %s s (cpu)  %s%%" % (
+        print("Time copying: {} s (real) {} s (cpu)  {}%".format(
             tcopy, cpucopy, tpercent))
         print("Copied nodes/sec: ", round((nnodes) / float(tcopy), 1))
         print("Copied KB/s :", int(nbytescopied / (tcopy * 1024)))

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -13,8 +13,6 @@
 Pass the flag -h to this for help on usage.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 import tables
 import numpy as np
@@ -273,7 +271,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
             elif isinstance(node, (tables.Array, tables.Table)):
 
                 if print_size:
-                    sizestr = 'mem=%s, disk=%s' % (
+                    sizestr = 'mem={}, disk={}'.format(
                         b2h(in_mem[path]), b2h(on_disk[path]))
                     if print_percent:
                         sizestr += ' [%4.1f%%]' % pct
@@ -296,7 +294,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
             elif depth == max_depth:
                 itemstr = '... %i leaves' % leaf_count[path]
                 if print_size:
-                    itemstr += ', mem=%s, disk=%s' % (
+                    itemstr += ', mem={}, disk={}'.format(
                         b2h(in_mem[path]), b2h(on_disk[path]))
                 if print_percent:
                     itemstr += ' [%4.1f%%]' % pct
@@ -347,7 +345,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
 
         out_str += '-' * 60 + '\n'
         out_str += 'Total branch leaves:    %i\n' % total_items
-        out_str += 'Total branch size:      %s in memory, %s on disk\n' % (
+        out_str += 'Total branch size:      {} in memory, {} on disk\n'.format(
             b2h(total_in_mem), b2h(total_on_disk))
         out_str += 'Mean compression ratio: %.2f\n' % avg_ratio
         out_str += 'HDF5 file size:         %s\n' % b2h(fsize)
@@ -356,7 +354,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
     return out_str
 
 
-class PrettyTree(object):
+class PrettyTree:
 
     """
 
@@ -417,7 +415,7 @@ class PrettyTree(object):
         return "\n".join(self.tree_lines())
 
     def __repr__(self):
-        return '<%s at %s>' % (self.__class__.__name__, hex(id(self)))
+        return '<{} at {}>'.format(self.__class__.__name__, hex(id(self)))
 
 
 def bytes2human(use_si_units=False):
@@ -436,7 +434,7 @@ def bytes2human(use_si_units=False):
             if scaled >= 1:
                 break
 
-        return "%.1f%s" % (scaled, prefix)
+        return f"{scaled:.1f}{prefix}"
 
     return b2h
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -285,7 +285,7 @@ def _column__create_index(self, optlevel, kind, filters, tmp_dir,
             else:
                 dname += '/' + iname
             try:
-                idgroup = get_node('%s/%s' % (itgroup._v_pathname, dname))
+                idgroup = get_node(f'{itgroup._v_pathname}/{dname}')
             except NoSuchNodeError:
                 idgroup = create_indexes_descr(idgroup, dname, iname, filters)
 
@@ -342,7 +342,7 @@ class _ColIndexes(dict):
     def __repr__(self):
         """Gives a detailed Description column representation."""
 
-        rep = ['  \"%s\": %s' % (k, self[k]) for k in self.keys()]
+        rep = ['  \"{}\": {}'.format(k, self[k]) for k in self.keys()]
         return '{\n  %s}' % (',\n  '.join(rep))
 
 
@@ -652,9 +652,9 @@ class Table(tableextension.Table, Leaf):
     def colindexes(self):
         """A dictionary with the indexes of the indexed columns."""
         return _ColIndexes(
-            ((_colpname, self.cols._f_col(_colpname).index)
+            (_colpname, self.cols._f_col(_colpname).index)
                 for _colpname in self.colpathnames
-                if self.colindexed[_colpname]))
+                if self.colindexed[_colpname])
 
     @property
     def _dirtyindexes(self):
@@ -853,7 +853,7 @@ class Table(tableextension.Table, Leaf):
 
         if self._v_new:
             # Columns are never indexed on creation.
-            self.colindexed = dict((cpn, False) for cpn in self.colpathnames)
+            self.colindexed = {cpn: False for cpn in self.colpathnames}
             return
 
         # The following code is only for opened tables.
@@ -1388,7 +1388,7 @@ very small/large chunksize, you may want to increase/decrease it."""
 
     def where(self, condition, condvars=None,
               start=None, stop=None, step=None):
-        """Iterate over values fulfilling a condition.
+        r"""Iterate over values fulfilling a condition.
 
         This method returns a Row iterator (see :ref:`RowClassDescr`) which
         only selects rows in the table that satisfy the given condition (an
@@ -1616,8 +1616,8 @@ very small/large chunksize, you may want to increase/decrease it."""
         """Iterate over a sequence of row coordinates."""
 
         if not hasattr(sequence, '__getitem__'):
-            raise TypeError(("Wrong 'sequence' parameter type. Only sequences "
-                             "are suported."))
+            raise TypeError("Wrong 'sequence' parameter type. Only sequences "
+                             "are suported.")
         # start, stop and step are necessary for the new iterator for
         # coordinates, and perhaps it would be useful to add them as
         # parameters in the future (not now, because I've just removed
@@ -1793,8 +1793,8 @@ very small/large chunksize, you may want to increase/decrease it."""
                     select_field = field
                     field = None
                 else:
-                    raise KeyError(("Field {0} not found in table "
-                                    "{1}").format(field, self))
+                    raise KeyError(("Field {} not found in table "
+                                    "{}").format(field, self))
             else:
                 # The column hangs directly from the top
                 dtype_field = self.coldtypes[field]
@@ -1820,15 +1820,15 @@ very small/large chunksize, you may want to increase/decrease it."""
             # there is no fast way to byteswap, since different columns may
             # have different byteorders
             if not out.dtype.isnative:
-                raise ValueError(("output array must be in system's byteorder "
-                                  "or results will be incorrect"))
+                raise ValueError("output array must be in system's byteorder "
+                                  "or results will be incorrect")
             if field:
                 bytes_required = dtype_field.itemsize * nrows
             else:
                 bytes_required = self.rowsize * nrows
             if bytes_required != out.nbytes:
-                raise ValueError(('output array size invalid, got {0} bytes, '
-                                  'need {1} bytes').format(out.nbytes,
+                raise ValueError(('output array size invalid, got {} bytes, '
+                                  'need {} bytes').format(out.nbytes,
                                                            bytes_required))
             if not out.flags['C_CONTIGUOUS']:
                 raise ValueError('output array not C contiguous')
@@ -1918,7 +1918,7 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         if out is not None and self.flavor != 'numpy':
             msg = ("Optional 'out' argument may only be supplied if array "
-                   "flavor is 'numpy', currently is {0}").format(self.flavor)
+                   "flavor is 'numpy', currently is {}").format(self.flavor)
             raise TypeError(msg)
 
         start, stop, step = self._process_range(start, stop, step,
@@ -2078,7 +2078,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             return self._read_coordinates(key, None)
         else:
-            raise IndexError("Invalid index or slice: %r" % (key,))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def __setitem__(self, key, value):
         """Set a row or a range of rows in the table.
@@ -2148,7 +2148,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             return self.modify_coordinates(key, value)
         else:
-            raise IndexError("Invalid index or slice: %r" % (key,))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def _save_buffered_rows(self, wbufRA, lenrows):
         """Update the indexes after a flushing of rows."""
@@ -2451,8 +2451,8 @@ very small/large chunksize, you may want to increase/decrease it."""
         if start < 0:
             raise ValueError("'start' must have a positive value.")
         if step < 1:
-            raise ValueError(("'step' must have a value greater or "
-                              "equal than 1."))
+            raise ValueError("'step' must have a value greater or "
+                              "equal than 1.")
         descr = []
         for colname in names:
             objcol = self._get_column_instance(colname)
@@ -2993,7 +2993,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 (str(self), self.description, self.byteorder, self.chunkshape)
 
 
-class Cols(object):
+class Cols:
     """Container for columns in a table or nested column.
 
     This class is used as an *accessor* to the columns in a table or nested
@@ -3164,7 +3164,7 @@ class Cols(object):
                 else:
                     return get_nested_field(crecarray, colgroup)  # numpy case
         else:
-            raise TypeError("invalid index or slice: %r" % (key,))
+            raise TypeError(f"invalid index or slice: {key!r}")
 
     def __setitem__(self, key, value):
         """Set a row or a range of rows in a table or nested column.
@@ -3208,7 +3208,7 @@ class Cols(object):
             (start, stop, step) = table._process_range(
                 key.start, key.stop, key.step)
         else:
-            raise TypeError("invalid index or slice: %r" % (key,))
+            raise TypeError(f"invalid index or slice: {key!r}")
 
         # Actually modify the correct columns
         colgroup = self._v_desc._v_pathname
@@ -3263,11 +3263,11 @@ class Cols(object):
                 tcol = "Description"
                 # Description doesn't have a shape currently
                 shape = ()
-            out += "  %s (%s%s, %s)" % (name, classname, shape, tcol) + "\n"
+            out += f"  {name} ({classname}{shape}, {tcol})" + "\n"
         return out
 
 
-class Column(object):
+class Column:
     """Accessor for a non-nested column in a table.
 
     Each instance of this class is associated with one *non-nested* column of a
@@ -3469,8 +3469,7 @@ class Column(object):
             buf_slice = buf[0:end_row - start_row]
             table.read(start_row, end_row, 1, field=self.pathname,
                        out=buf_slice)
-            for row in buf_slice:
-                yield row
+            yield from buf_slice
 
     def __setitem__(self, key, value):
         """Set a row or a range of rows in a column.

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -27,9 +27,9 @@ def show_mem(explain):
                 vmlib = int(line.split()[1])
 
     print("\nMemory usage: ******* %s *******" % explain)
-    print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-    print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-    print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     print("WallClock time:", time.time() - tref, end=' ')
     print("  Delta time:", time.time() - trel)
     trel = time.time()

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -95,23 +95,23 @@ def print_versions():
         vml_avail = "using VML/MKL %s" % vml_version
     else:
         vml_avail = "not using Intel's VML/MKL"
-    print("Numexpr version:     %s (%s)" % (numexpr.__version__, vml_avail))
+    print(f"Numexpr version:     {numexpr.__version__} ({vml_avail})")
     if tinfo is not None:
-        print("Zlib version:        %s (%s)" % (tinfo[1],
+        print("Zlib version:        {} ({})".format(tinfo[1],
                                                 "in Python interpreter"))
     tinfo = tables.which_lib_version("lzo")
     if tinfo is not None:
-        print("LZO version:         %s (%s)" % (tinfo[1], tinfo[2]))
+        print("LZO version:         {} ({})".format(tinfo[1], tinfo[2]))
     tinfo = tables.which_lib_version("bzip2")
     if tinfo is not None:
-        print("BZIP2 version:       %s (%s)" % (tinfo[1], tinfo[2]))
+        print("BZIP2 version:       {} ({})".format(tinfo[1], tinfo[2]))
     tinfo = tables.which_lib_version("blosc")
     if tinfo is not None:
         blosc_date = tinfo[2].split()[1]
-        print("Blosc version:       %s (%s)" % (tinfo[1], blosc_date))
+        print("Blosc version:       {} ({})".format(tinfo[1], blosc_date))
         blosc_cinfo = tables.blosc_get_complib_info()
         blosc_cinfo = [
-            "%s (%s)" % (k, v[1]) for k, v in sorted(blosc_cinfo.items())
+            "{} ({})".format(k, v[1]) for k, v in sorted(blosc_cinfo.items())
         ]
         print("Blosc compressors:   %s" % ', '.join(blosc_cinfo))
         blosc_finfo = ['shuffle']
@@ -248,8 +248,8 @@ class PyTablesTestCase(unittest.TestCase):
             name = self._getName()
             methodName = self._getMethodName()
 
-            title = "Running %s.%s" % (name, methodName)
-            print('%s\n%s' % (title, '-' * len(title)))
+            title = f"Running {name}.{methodName}"
+            print('{}\n{}'.format(title, '-' * len(title)))
 
     # COMPATIBILITY: assertWarns is new in Python 3.2
     if not hasattr(unittest.TestCase, 'assertWarns'):
@@ -291,7 +291,7 @@ class PyTablesTestCase(unittest.TestCase):
             "node1 and node2 does not have the same values.")
 
 
-class TestFileMixin(object):
+class TestFileMixin:
     h5fname = None
     open_kwargs = {}
 
@@ -307,7 +307,7 @@ class TestFileMixin(object):
         super().tearDown()
 
 
-class TempFileMixin(object):
+class TempFileMixin:
     open_mode = 'w'
     open_kwargs = {}
 
@@ -372,9 +372,9 @@ class ShowMemTime(PyTablesTestCase):
                 vmlib = int(line.split()[1])
         print("\nWallClock time:", time.time() - self.tref)
         print("Memory usage: ******* %s *******" % self._getName())
-        print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-        print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-        print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+        print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+        print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+        print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
 
 
 ## Local Variables:

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -513,7 +513,7 @@ class Basic2DOneTestCase(BasicTestCase):
 class Basic2DTwoTestCase(BasicTestCase):
     # 2D case, with a multidimensional dtype
     title = "Rank-2 case 2"
-    tupleInt = numpy.array(numpy.arange((4)), dtype=(numpy.int_, (4,)))
+    tupleInt = numpy.array(numpy.arange(4), dtype=(numpy.int_, (4,)))
     tupleChar = numpy.array(["abc"]*3, dtype=("S3", (3,)))
     endiancheck = True
 

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -806,8 +806,8 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
 
         if common.verbose:
             print('\n', '-=' * 30)
-            print(("Running %s.test01_nonRecursiveAttrs..." %
-                   self.__class__.__name__))
+            print("Running %s.test01_nonRecursiveAttrs..." %
+                   self.__class__.__name__)
 
         # Copy a group non-recursively with attrs
         srcgroup = self.h5file.root.group0.group1
@@ -842,9 +842,9 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
 
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node %s: %s" % (srcnode._v_name,
+                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
                                                         srcattrskeys))
-                print("dstattrskeys for node %s: %s" % (dstnode._v_name,
+                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
                                                         dstattrskeys))
             self.assertEqual(srcattrskeys, dstattrskeys)
             if common.verbose:
@@ -922,8 +922,8 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
 
         if common.verbose:
             print('\n', '-=' * 30)
-            print(("Running %s.test03_RecursiveFilters..." %
-                   self.__class__.__name__))
+            print("Running %s.test03_RecursiveFilters..." %
+                   self.__class__.__name__)
 
         # Create the destination node
         group = self.h5file2.root
@@ -1248,9 +1248,9 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
 
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node %s: %s" % (srcnode._v_name,
+                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
                                                         srcattrskeys))
-                print("dstattrskeys for node %s: %s" % (dstnode._v_name,
+                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
                                                         dstattrskeys))
             self.assertEqual(srcattrskeys, dstattrskeys)
             if common.verbose:
@@ -1297,9 +1297,9 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
             dstattrskeys = dstattrs._f_list("all")
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node %s: %s" % (srcnode._v_name,
+                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
                                                         srcattrskeys))
-                print("dstattrskeys for node %s: %s" % (dstnode._v_name,
+                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
                                                         dstattrskeys))
 
             # Filters may differ, do not take into account

--- a/tables/tests/test_hdf5compat.py
+++ b/tables/tests/test_hdf5compat.py
@@ -258,7 +258,7 @@ class ContiguousCompoundAppendTestCase(common.TestFileMixin, TestCase):
         # Reopen in 'a'ppend mode
         try:
             self.h5file = tables.open_file(h5fname_copy, 'a')
-        except IOError:
+        except OSError:
             # Problems for opening (probably not permisions to write the file)
             return
         tbl = self.h5file.get_node('/test_var/structure variable')

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -952,7 +952,7 @@ class DeepTableIndexTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(idxcol.nelements, self.nrows)
 
 
-class IndexProps(object):
+class IndexProps:
     def __init__(self, auto=default_auto_index, filters=default_index_filters):
         self.auto = auto
         self.filters = filters
@@ -1757,8 +1757,8 @@ class IndexFiltersTestCase(TempFileMixin, TestCase):
         icol.reindex()
         ni = icol.index
         if verbose:
-            print("Old parameters: %s, %s, %s" % (kind, optlevel, filters))
-            print("New parameters: %s, %s, %s" % (
+            print(f"Old parameters: {kind}, {optlevel}, {filters}")
+            print("New parameters: {}, {}, {}".format(
                 ni.kind, ni.optlevel, ni.filters))
         self.assertEqual(ni.kind, kind)
         self.assertEqual(ni.optlevel, optlevel)

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3191,10 +3191,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> %s %s %s %s" % (idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: %s != %s, %s" % (idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
     def test01_nocache(self):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=0)
@@ -3210,10 +3210,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> %s %s %s %s" % (idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: %s != %s, %s" % (idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
     def test02_dictcache(self):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=-64)
@@ -3229,10 +3229,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> %s %s %s %s" % (idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: %s != %s, %s" % (idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
 
 normal_tests = (
@@ -3283,7 +3283,7 @@ testlevels = ['Normal', 'Heavy']
 def iclassdata():
     for ckind in ckinds:
         for ctest in normal_tests + heavy_tests:
-            classname = '%sI%s%s' % (ckind[0], testlevels[heavy][0], ctest)
+            classname = '{}I{}{}'.format(ckind[0], testlevels[heavy][0], ctest)
             # Uncomment the next one and comment the past one if one
             # don't want to include the methods (testing purposes only)
             # cbasenames = ( '%sITableMixin' % ckind, "object")
@@ -3328,7 +3328,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
         v1 = numpy.unique(arr['o'])[0]
         v2 = numpy.unique(arr['o'])[1]
         res = numpy.array([v1, v2])
-        selector = '((o == %s) | (o == %s))' % (v1, v2)
+        selector = f'((o == {v1}) | (o == {v2}))'
         if verbose:
             print("selecting values: %s" % selector)
 
@@ -3338,7 +3338,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
         numpy.testing.assert_almost_equal(result, res)
         if verbose:
             print("select entire table:")
-            print("result: %s\texpected: %s" % (result, res))
+            print(f"result: {result}\texpected: {res}")
 
         if verbose:
             print("index the column o")
@@ -3351,7 +3351,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
             result = numpy.unique(result['o'])
             numpy.testing.assert_almost_equal(numpy.unique(result), res)
             if verbose:
-                print("result: %s\texpected: %s" % (result, res))
+                print(f"result: {result}\texpected: {res}")
 
 
 # Test case for issue #441
@@ -3369,7 +3369,7 @@ class SideEffectNumPyQuicksort(TestCase):
         # Setting the chunkshape is critical for reproducing the bug
         t = o.copy(newname="table2", chunkshape=2730)
         t.cols.path.create_index()
-        indexed = set(r.nrow for r in t.where('path == 6'))
+        indexed = {r.nrow for r in t.where('path == 6')}
 
         if verbose:
             diffs = sorted(npvals - indexed)

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -866,13 +866,13 @@ class ColsTestCase(common.TempFileMixin, TestCase):
         except AssertionError:
             self.assertEqual(repr(tbl.cols),
                              """/test.cols (Cols), 6 columns
-  x (Column(0, 2), ('%s', (2,)))
+  x (Column(0, 2), ('{}', (2,)))
   Info (Cols(), Description)
   color (Column(0,), |S2)
   info (Cols(), Description)
-  y (Column(0, 2, 2), ('%s', (2, 2)))
+  y (Column(0, 2, 2), ('{}', (2, 2)))
   z (Column(0,), uint8)
-""" % (numpy.int32(0).dtype.str, numpy.float64(0).dtype.str))
+""".format(numpy.int32(0).dtype.str, numpy.float64(0).dtype.str))
 
     def test00b_repr(self):
         """Checking string representation of nested Cols."""

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -90,17 +90,17 @@ if hasattr(numpy, 'float16'):
 # if hasattr(numpy, 'complex256'):
 #    type_info['complex256'] = (numpy.complex256, complex)
 
-sctype_from_type = dict((type_, info[0])
-                        for (type_, info) in type_info.items())
+sctype_from_type = {type_: info[0]
+                        for (type_, info) in type_info.items()}
 """Maps PyTables types to NumPy scalar types."""
-nxtype_from_type = dict((type_, info[1])
-                        for (type_, info) in type_info.items())
+nxtype_from_type = {type_: info[1]
+                        for (type_, info) in type_info.items()}
 """Maps PyTables types to Numexpr types."""
 
 heavy_types = frozenset(['uint8', 'int16', 'uint16', 'float32', 'complex64'])
 """PyTables types to be tested only in heavy mode."""
 
-enum = tables.Enum(dict(('n%d' % i, i) for i in range(_maxnvalue)))
+enum = tables.Enum({'n%d' % i: i for i in range(_maxnvalue)})
 """Enumerated type to be used in tests."""
 
 
@@ -278,7 +278,7 @@ class BaseTableQueryTestCase(common.TempFileMixin, TestCase):
             return
         try:
             kind = self.kind
-            vprint("* Indexing ``%s`` columns. Type: %s." % (colname, kind))
+            vprint(f"* Indexing ``{colname}`` columns. Type: {kind}.")
             for acolname in [colname, ncolname, extracolname]:
                 acolumn = self.table.colinstances[acolname]
                 acolumn.create_index(
@@ -372,16 +372,16 @@ def create_test_method(type_, op, extracond, func=None):
     elif op == '~':  # unary
         cond = '~(%s)' % colname
     elif op == '<' and func is None:  # binary variable-constant
-        cond = '%s %s %s' % (colname, op, repr(condvars['bound']))
+        cond = '{} {} {}'.format(colname, op, repr(condvars['bound']))
     elif isinstance(op, tuple):  # double binary variable-constant
         cond = ('(lbound %s %s) & (%s %s rbound)'
                 % (op[0], colname, colname, op[1]))
     elif func is not None:
-        cond = '%s(%s) %s func_bound' % (func, colname, op)
+        cond = f'{func}({colname}) {op} func_bound'
     else:  # function or binary variable-variable
-        cond = '%s %s bound' % (colname, op)
+        cond = f'{colname} {op} bound'
     if extracond:
-        cond = '(%s) %s' % (cond, extracond)
+        cond = f'({cond}) {extracond}'
 
     def ignore_skipped(oldmethod):
         @functools.wraps(oldmethod)
@@ -551,7 +551,7 @@ def niclassdata():
     for size in table_sizes:
         heavy = size in heavy_table_sizes
         for ndim in table_ndims:
-            classname = '%s%sTDTestCase' % (size[0], ndim[0])
+            classname = '{}{}TDTestCase'.format(size[0], ndim[0])
             cbasenames = ('%sNITableMixin' % size, '%sTableMixin' % ndim,
                           'TableDataTestCase')
             classdict = dict(heavy=heavy)

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -23,10 +23,10 @@ class Record(tables.IsDescription):
     var3 = Int16Col()             # short integer
 
 
-class TrackTimesMixin(object):
+class TrackTimesMixin:
     def _add_datasets(self, group, j, track_times):
         # Create a table
-        table = self.h5file.create_table(group, 'table{}'.format(j),
+        table = self.h5file.create_table(group, f'table{j}',
                                          Record,
                                          title=self.title,
                                          filters=None,
@@ -46,18 +46,18 @@ class TrackTimesMixin(object):
         var1List = [x['var1'] for x in table.iterrows()]
         var3List = [x['var3'] for x in table.iterrows()]
 
-        self.h5file.create_array(group, 'array{}'.format(j),
-                                 var1List, "col {}".format(j),
+        self.h5file.create_array(group, f'array{j}',
+                                 var1List, f"col {j}",
                                  track_times=track_times)
 
         # Create CArrays as well
-        self.h5file.create_carray(group, name='carray{}'.format(j),
+        self.h5file.create_carray(group, name=f'carray{j}',
                                   obj=var3List,
                                   title="col {}".format(j + 2),
                                   track_times=track_times)
 
         # Create EArrays as well
-        ea = self.h5file.create_earray(group, 'earray{}'.format(j),
+        ea = self.h5file.create_earray(group, f'earray{j}',
                                        StringAtom(itemsize=4), (0,),
                                        "col {}".format(j + 4),
                                        track_times=track_times)
@@ -65,7 +65,7 @@ class TrackTimesMixin(object):
         ea.append(var1List)
 
         # Finally VLArrays too
-        vla = self.h5file.create_vlarray(group, 'vlarray{}'.format(j),
+        vla = self.h5file.create_vlarray(group, f'vlarray{j}',
                                          Int16Atom(),
                                          "col {}".format(j + 6),
                                          track_times=track_times)

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -568,7 +568,7 @@ class TreeTestCase(common.TempFileMixin, TestCase):
         """
         self.assertIsInstance(self.h5file.root._v_groups, dict)
         group_names = {'group0'}
-        names = set(k for k, v in self.h5file.root._v_groups.iteritems())
+        names = {k for k, v in self.h5file.root._v_groups.iteritems()}
         self.assertEqual(group_names, names)
         groups = list(self.h5file.root._v_groups.itervalues())
         self.assertEqual(len(groups), len(group_names))

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -1,4 +1,3 @@
-
 import sys
 
 import numpy

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -4,7 +4,7 @@ from io import StringIO
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 from tables.tests import common
 from tables.tests.common import unittest

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -1,5 +1,3 @@
-# -*- coding: latin-1 -*-
-
 import sys
 
 import numpy

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -102,12 +102,12 @@ class UnImplemented(hdf5extension.UnImplemented, Leaf):
         return None  # Can you see it?
 
     def __repr__(self):
-        return """%s
+        return """{}
   NOTE: <The UnImplemented object represents a PyTables unimplemented
-         dataset present in the '%s' HDF5 file.  If you want to see this
+         dataset present in the '{}' HDF5 file.  If you want to see this
          kind of HDF5 dataset implemented in PyTables, please contact the
          developers.>
-""" % (str(self), self._v_file.filename)
+""".format(str(self), self._v_file.filename)
 
 
 # Classes reported as H5G_UNKNOWN by HDF5
@@ -146,7 +146,7 @@ class Unknown(Node):
     def __str__(self):
         pathname = self._v_pathname
         classname = self.__class__.__name__
-        return "%s (%s)" % (pathname, classname)
+        return f"{pathname} ({classname})"
 
     def __repr__(self):
         return """%s

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -148,11 +148,11 @@ def check_file_access(filename, mode='r'):
     if mode == 'r':
         # The file should be readable.
         if not os.access(filename, os.F_OK):
-            raise IOError("``%s`` does not exist" % (filename,))
+            raise OSError(f"``{filename}`` does not exist")
         if not os.path.isfile(filename):
-            raise IOError("``%s`` is not a regular file" % (filename,))
+            raise OSError(f"``{filename}`` is not a regular file")
         if not os.access(filename, os.R_OK):
-            raise IOError("file ``%s`` exists but it can not be read"
+            raise OSError("file ``%s`` exists but it can not be read"
                           % (filename,))
     elif mode == 'w':
         if os.access(filename, os.F_OK):
@@ -166,11 +166,11 @@ def check_file_access(filename, mode='r'):
             if not parentname:
                 parentname = '.'
             if not os.access(parentname, os.F_OK):
-                raise IOError("``%s`` does not exist" % (parentname,))
+                raise OSError(f"``{parentname}`` does not exist")
             if not os.path.isdir(parentname):
-                raise IOError("``%s`` is not a directory" % (parentname,))
+                raise OSError(f"``{parentname}`` is not a directory")
             if not os.access(parentname, os.W_OK):
-                raise IOError("directory ``%s`` exists but it can not be "
+                raise OSError("directory ``%s`` exists but it can not be "
                               "written" % (parentname,))
     elif mode == 'a':
         if os.access(filename, os.F_OK):
@@ -180,10 +180,10 @@ def check_file_access(filename, mode='r'):
     elif mode == 'r+':
         check_file_access(filename, 'r')
         if not os.access(filename, os.W_OK):
-            raise IOError("file ``%s`` exists but it can not be written"
+            raise OSError("file ``%s`` exists but it can not be written"
                           % (filename,))
     else:
-        raise ValueError("invalid mode: %r" % (mode,))
+        raise ValueError(f"invalid mode: {mode!r}")
 
 
 
@@ -265,9 +265,9 @@ def show_stats(explain, tref, encoding=None):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: %7s kB\tVmRSS: %7s kB" % (vmsize, vmrss))
-    print("VmData: %7s kB\tVmStk: %7s kB" % (vmdata, vmstk))
-    print("VmExe:  %7s kB\tVmLib: %7s kB" % (vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow
@@ -351,7 +351,7 @@ def dump_logged_instances(classes, file=sys.stdout):
             if obj is not None:
                 file.write('    %s:\n' % obj)
                 for key, value in obj.__dict__.items():
-                    file.write('        %20s : %s\n' % (key, value))
+                    file.write(f'        {key:>20} : {value}\n')
 
 
 
@@ -375,7 +375,7 @@ class CacheDict(dict):
         super().__setitem__(key, value)
 
 
-class NailedDict(object):
+class NailedDict:
     """A dictionary which ignores its items when it has nails on it."""
 
     def __init__(self, maxentries):

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -682,7 +682,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
             coords = self._point_selection(key)
             return self._read_coordinates(coords)
         else:
-            raise IndexError("Invalid index or slice: %r" % (key,))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def _assign_values(self, coords, values):
         """Assign the `values` to the positions stated in `coords`."""
@@ -784,7 +784,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             coords = self._point_selection(key)
         else:
-            raise IndexError("Invalid index or slice: %r" % (key,))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
         # Do the assignment row by row
         self._assign_values(coords, value)
@@ -870,9 +870,9 @@ class VLArray(hdf5extension.VLArray, Leaf):
     def __repr__(self):
         """This provides more metainfo in addition to standard __str__"""
 
-        return """%s
-  atom = %r
-  byteorder = %r
-  nrows = %s
-  flavor = %r""" % (self, self.atom, self.byteorder, self.nrows,
+        return """{}
+  atom = {!r}
+  byteorder = {!r}
+  nrows = {}
+  flavor = {!r}""".format(self, self.atom, self.byteorder, self.nrows,
                     self.flavor)


### PR DESCRIPTION
This commit is done only automatically using  the following command:

```bash
pyupgrade --py36-plus {bench,c-blosc,contrib,doc,examples,tables}/**/*.py cpuinfo.py setup.py
```

Since we're at Python 3.6+, the code can be modernized using the automatic tool https://github.com/asottile/pyupgrade using the `--py36-plus` switch, which does the following:

- remove the old `from __future__` imports
- convert string formattings from `%` to `.format` to f-string depending on what is shorter
- declare classes without the unnecessary `(object)` inheritance
- remove the unnecessary `# -*- coding: UTF-8 -*-` for source files
- `yield from`
- literal dicts
- shorted `super()`
- etc.
