### PR TITLE
Make cimports explicitly relative

### DIFF
--- a/tables/hdf5extension.pxd
+++ b/tables/hdf5extension.pxd
@@ -9,7 +9,7 @@
 ########################################################################
 
 from numpy cimport ndarray
-from definitions cimport hid_t, hsize_t, hbool_t
+from .definitions cimport hid_t, hsize_t, hbool_t
 
 
 # Declaration of instance variables for shared classes

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -39,16 +39,16 @@ import pickle
 
 import numpy
 
-from tables.exceptions import HDF5ExtError, DataTypeWarning
+from .exceptions import HDF5ExtError, DataTypeWarning
 
-from tables.utils import (check_file_access, byteorders, correct_byteorder,
+from .utils import (check_file_access, byteorders, correct_byteorder,
   SizeType)
 
-from tables.atom import Atom
+from .atom import Atom
 
-from tables.description import descr_from_dtype
+from .description import descr_from_dtype
 
-from tables.utilsextension import (encode_filename, set_blosc_max_threads,
+from .utilsextension import (encode_filename, set_blosc_max_threads,
   atom_to_hdf5_type, atom_from_hdf5_type, hdf5_to_np_ext_type, create_nested_type,
   pttype_to_hdf5, pt_special_kinds, npext_prefixes_to_ptkinds, hdf5_class_to_string,
   platform_byteorder)
@@ -63,7 +63,7 @@ from cpython.bytes cimport (PyBytes_AsString, PyBytes_FromStringAndSize,
 from cpython.unicode cimport PyUnicode_DecodeUTF8
 
 
-from definitions cimport (uintptr_t, hid_t, herr_t, hsize_t, hvl_t,
+from .definitions cimport (uintptr_t, hid_t, herr_t, hsize_t, hvl_t,
   H5S_seloper_t, H5D_FILL_VALUE_UNDEFINED,
   H5O_TYPE_UNKNOWN, H5O_TYPE_GROUP, H5O_TYPE_DATASET, H5O_TYPE_NAMED_DATATYPE,
   H5L_TYPE_ERROR, H5L_TYPE_HARD, H5L_TYPE_SOFT, H5L_TYPE_EXTERNAL,
@@ -99,7 +99,7 @@ from definitions cimport (uintptr_t, hid_t, herr_t, hsize_t, hvl_t,
 
 cdef int H5T_CSET_DEFAULT = 16
 
-from utilsextension cimport malloc_dims, get_native_type, cstr_to_pystr, load_reference
+from .utilsextension cimport malloc_dims, get_native_type, cstr_to_pystr, load_reference
 
 
 #-------------------------------------------------------------------

--- a/tables/indexesextension.pyx
+++ b/tables/indexesextension.pyx
@@ -29,7 +29,7 @@ import numpy
 cimport numpy as cnp
 
 from .exceptions import HDF5ExtError
-from hdf5extension cimport Array
+from .hdf5extension cimport Array
 
 
 # Types, constants, functions, classes & other objects from everywhere
@@ -46,8 +46,8 @@ ctypedef npy_uint16 npy_float16
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, strncmp
 
-from definitions cimport hid_t, herr_t, hsize_t, H5Screate_simple, H5Sclose
-from lrucacheextension cimport NumCache
+from .definitions cimport hid_t, herr_t, hsize_t, H5Screate_simple, H5Sclose
+from .lrucacheextension cimport NumCache
 
 
 

--- a/tables/linkextension.pyx
+++ b/tables/linkextension.pyx
@@ -12,13 +12,13 @@
 
 from .exceptions import HDF5ExtError
 
-from hdf5extension cimport Node
-from utilsextension cimport cstr_to_pystr
+from .hdf5extension cimport Node
+from .utilsextension cimport cstr_to_pystr
 
 from libc.stdlib cimport malloc, free
 from libc.string cimport strlen
 from cpython.unicode cimport PyUnicode_DecodeUTF8
-from definitions cimport (H5P_DEFAULT,
+from .definitions cimport (H5P_DEFAULT,
     hid_t, herr_t, hbool_t, int64_t, H5T_cset_t, haddr_t)
 
 

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -34,7 +34,7 @@ from .utilsextension import (get_nested_field, atom_from_hdf5_type,
   H5T_STD_I64)
 from .utils import SizeType
 
-from utilsextension cimport get_native_type, cstr_to_pystr
+from .utilsextension cimport get_native_type, cstr_to_pystr
 
 # numpy functions & objects
 from hdf5extension cimport Leaf
@@ -44,7 +44,7 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, strdup, strcmp, strlen
 from numpy cimport (import_array, ndarray, PyArray_GETITEM, PyArray_SETITEM, \
   npy_intp)
-from definitions cimport (hid_t, herr_t, hsize_t, htri_t, hbool_t,
+from .definitions cimport (hid_t, herr_t, hsize_t, htri_t, hbool_t,
   H5F_ACC_RDONLY, H5P_DEFAULT, H5D_CHUNKED, H5T_DIR_DEFAULT,
   H5F_SCOPE_LOCAL, H5F_SCOPE_GLOBAL, H5T_COMPOUND, H5Tget_order,
   H5Fflush, H5Dget_create_plist, H5T_ORDER_LE,
@@ -60,7 +60,7 @@ from definitions cimport (hid_t, herr_t, hsize_t, htri_t, hbool_t,
   conv_float64_timeval32, truncate_dset,
   pt_H5free_memory)
 
-from lrucacheextension cimport ObjectCache, NumCache
+from .lrucacheextension cimport ObjectCache, NumCache
 
 
 

--- a/tables/utilsextension.pxd
+++ b/tables/utilsextension.pxd
@@ -13,7 +13,7 @@ These are declarations for functions in utilsextension.pyx that have to
 be shared with other extensions.
 """
 
-from definitions cimport hsize_t, hid_t, hobj_ref_t
+from .definitions cimport hsize_t, hid_t, hobj_ref_t
 from numpy cimport ndarray
 
 cdef hsize_t *malloc_dims(object)

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -22,12 +22,12 @@ except ImportError:
 
 import numpy
 
-from tables.description import Description, Col
-from tables.misc.enum import Enum
-from tables.exceptions import HDF5ExtError
-from tables.atom import Atom, EnumAtom, ReferenceAtom
+from .description import Description, Col
+from .misc.enum import Enum
+from .exceptions import HDF5ExtError
+from .atom import Atom, EnumAtom, ReferenceAtom
 
-from tables.utils import check_file_access
+from .utils import check_file_access
 
 from libc.stdio cimport stderr
 from libc.stdlib cimport malloc, free
@@ -41,7 +41,7 @@ from numpy cimport (import_array, ndarray, dtype,
   NPY_UINT8, NPY_UINT16, NPY_UINT32, NPY_UINT64, NPY_FLOAT16, NPY_FLOAT32,
   NPY_FLOAT64, NPY_COMPLEX64, NPY_COMPLEX128)
 
-from definitions cimport (H5ARRAYget_info, H5ARRAYget_ndims,
+from .definitions cimport (H5ARRAYget_info, H5ARRAYget_ndims,
   H5ATTRfind_attribute, H5ATTRget_attribute_string, H5D_CHUNKED,
   H5D_layout_t, H5Dclose, H5Dget_type, H5Dopen, H5E_DEFAULT,
   H5E_WALK_DOWNWARD, H5E_auto_t, H5E_error_t, H5E_walk_t, H5Eget_msg,


### PR DESCRIPTION
Unify some cimports ("tables.<X>", "<X>", ".<X>") into ".<X>"

I tested this by running "pip install ." then "python3 -m tables.tests.test_all" 