### PR TITLE
Use integer division

### DIFF
--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1184,7 +1184,7 @@ cdef class Leaf(Node):
     else:
       nrecords = len(nparr)
       bytestride = nparr.strides[0]  # supports multi-dimensional recarray
-    nelements = <size_t>nparr.size / nrecords
+    nelements = <size_t>nparr.size // nrecords
     t64buf = nparr.data
 
     conv_float64_timeval32(

--- a/tables/indexesextension.pyx
+++ b/tables/indexesextension.pyx
@@ -240,7 +240,7 @@ cdef void _keysort(number_type* start1, char* start2, size_t elsize2, size_t n) 
     while True:
         while pr - pl > SMALL_QUICKSORT:
             pm  = pl + ((pr - pl) >> 1)
-            ipm  = ipl + ((ipr - ipl)/elsize2 >> 1)*elsize2
+            ipm  = ipl + ((ipr - ipl)//elsize2 >> 1)*elsize2
 
             if less_than(pm, pl):
                 pm[0], pl[0] =  pl[0], pm[0]
@@ -383,8 +383,8 @@ cdef void _keysort_string(char* start1, size_t ss, char* start2, size_t ts, size
 
     while True:
         while pr - pl > SMALL_QUICKSORT * ss:
-            pm  = pl + ((pr - pl)/ss >> 1)*ss
-            ipm  = ipl + ((ipr - ipl)/ts >> 1)*ts
+            pm  = pl + ((pr - pl)//ss >> 1)*ss
+            ipm  = ipl + ((ipr - ipl)//ts >> 1)*ts
 
             if strncmp(pm, pl, ss) < 0:
                 swap_bytes(pm, pl, ss)
@@ -520,7 +520,7 @@ def _bisect_left(a, x, int hi):
   if x <= a[0]: return 0
   if a[-1] < x: return hi
   while lo < hi:
-      mid = (lo+hi)/2
+      mid = (lo+hi)//2
       if a[mid] < x: lo = mid+1
       else: hi = mid
   return lo
@@ -541,7 +541,7 @@ def _bisect_right(a, x, int hi):
   if x < a[0]: return 0
   if a[-1] <= x: return hi
   while lo < hi:
-    mid = (lo+hi)/2
+    mid = (lo+hi)//2
     if x < a[mid]: hi = mid
     else: lo = mid+1
   return lo
@@ -660,7 +660,7 @@ cdef class IndexArray(Array):
       # not be duplicated (I know, this smells badly, but anyway).
       params = self._v_file.params
       rowsize = (self.bounds_ext._v_chunkshape[1] * dtype.itemsize)
-      maxslots = params['BOUNDS_MAX_SIZE'] / rowsize
+      maxslots = params['BOUNDS_MAX_SIZE'] // rowsize
       self.boundscache = <NumCache>NumCache(
         (maxslots, self.nbounds), dtype, 'non-opt types bounds')
       self.bufferbc = numpy.empty(dtype=dtype, shape=self.nbounds)
@@ -668,7 +668,7 @@ cdef class IndexArray(Array):
       self.rbufbc = self.bufferbc.data
       # Another NumCache for the sorted values
       rowsize = (self.chunksize*dtype.itemsize)
-      maxslots = params['SORTED_MAX_SIZE'] / (self.chunksize*dtype.itemsize)
+      maxslots = params['SORTED_MAX_SIZE'] // (self.chunksize*dtype.itemsize)
       self.sortedcache = <NumCache>NumCache(
         (maxslots, self.chunksize), dtype, 'sorted')
 
@@ -754,7 +754,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -816,7 +816,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -878,7 +878,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -939,7 +939,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -1000,7 +1000,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -1061,7 +1061,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -1122,7 +1122,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -1183,7 +1183,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     rbufst = <int *>self.rbufst
@@ -1244,7 +1244,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     tlength = 0
@@ -1306,7 +1306,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     tlength = 0
@@ -1369,7 +1369,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     tlength = 0
@@ -1433,7 +1433,7 @@ cdef class IndexArray(Array):
 
     cs = self.l_chunksize
     ss = self.l_slicesize
-    ncs = ss / cs
+    ncs = ss // cs
     nbounds = self.nbounds
     nrows = self.nrows
     tlength = 0

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -780,7 +780,7 @@ cdef class Row:
     self.exist_enum_cols = len(self.colenums)
     self.nrowsinbuf = table.nrowsinbuf
     self.chunksize = table.chunkshape[0]
-    self.nchunksinbuf = self.nrowsinbuf / self.chunksize
+    self.nchunksinbuf = self.nrowsinbuf // self.chunksize
     self.dtype = table._v_dtype
     self._new_buffer(table)
     self.mod_elements = None
@@ -877,7 +877,7 @@ cdef class Row:
       self.indexed = 1
       # Compute totalchunks here because self.nrows can change during the
       # life of a Row instance.
-      self.totalchunks = self.nrows / self.chunksize
+      self.totalchunks = self.nrows // self.chunksize
       if self.nrows % self.chunksize:
         self.totalchunks = self.totalchunks + 1
       self.nrowsread = 0
@@ -938,7 +938,7 @@ cdef class Row:
         table = self.table
         iobuf = self.iobuf
         j = 0;  recout = 0;  cs = self.chunksize
-        nchunksread = self.nrowsread / cs
+        nchunksread = self.nrowsread // cs
         tmp_range = numpy.arange(0, cs, dtype='int64')
         self.bufcoords = numpy.empty(self.nrowsinbuf, dtype='int64')
         # Fetch valid chunks until the I/O buffer is full
@@ -1225,7 +1225,7 @@ cdef class Row:
         istopb = istop - inrowsread
         if istopb > inrowsinbuf:
           istopb = inrowsinbuf
-        stopr = startr + ((istopb - istartb - 1) / istep) + 1
+        stopr = startr + ((istopb - istartb - 1) // istep) + 1
         # Read a chunk
         inrowsread = inrowsread + self.table._read_records(i, inrowsinbuf,
                                                            self.iobuf)
@@ -1237,7 +1237,7 @@ cdef class Row:
 
         # Compute some indexes for the next iteration
         startr = stopr
-        j = istartb + ((istopb - istartb - 1) / istep) * istep
+        j = istartb + ((istopb - istartb - 1) // istep) * istep
         istartb = (j+istep) % inrowsinbuf
         inextelement = inextelement + istep
         i = i + inrowsinbuf
@@ -1259,7 +1259,7 @@ cdef class Row:
           continue
         # Compute the end for this iteration
         # (we know we are going backward so try to keep indices positive)
-        stopr = startr + (1 - istopb + istartb) / (-istep)
+        stopr = startr + (1 - istopb + istartb) // (-istep)
         # Read a chunk
         inrowsread = inrowsread + self.table._read_records(i - inrowsinbuf + 1,
                                                            inrowsinbuf, self.iobuf)

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -232,7 +232,7 @@ def bisect_left(a, x, int lo=0):
 
   lo = 0
   while lo < hi:
-    mid = (lo+hi)/2
+    mid = (lo+hi)//2
     if nan_aware_lt(a[mid], x): lo = mid+1
     else: hi = mid
   return lo
@@ -250,7 +250,7 @@ def bisect_right(a, x, int lo=0):
 
   lo = 0
   while lo < hi:
-    mid = (lo+hi)/2
+    mid = (lo+hi)//2
     if nan_aware_lt(x, a[mid]): hi = mid
     else: lo = mid+1
   return lo


### PR DESCRIPTION
`cython -3` complaining about not being able to cast double to int in these locations.

```
Error compiling Cython file:
------------------------------------------------------------
...

--
  while lo < hi:
    mid = (lo+hi)/2
                ^
------------------------------------------------------------

tables/utilsextension.pyx:253:17: Cannot assign type 'double' to 'int'
```