### PR TITLE
A bunch of minor code quality refactorings

### DIFF
--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -28,13 +28,10 @@ prec = 6  # precision for printing floats purposes
 
 
 def get_nrows(nrows_str):
-    if nrows_str.endswith("k"):
-        return int(float(nrows_str[:-1]) * 1000)
-    elif nrows_str.endswith("m"):
-        return int(float(nrows_str[:-1]) * 1000 * 1000)
-    elif nrows_str.endswith("g"):
-        return int(float(nrows_str[:-1]) * 1000 * 1000 * 1000)
-    else:
+    powers = {'k': 3, 'm': 6, 'g': 9}
+    try:
+        return int(float(nrows_str[:-1]) * 10 ** powers[nrows_str[-1]])
+    except KeyError:
         raise ValueError(
             "value of nrows must end with either 'k', 'm' or 'g' suffixes.")
 

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -14,13 +14,10 @@ rdm_cod = ['lin', 'rnd']
 
 
 def get_nrows(nrows_str):
-    if nrows_str.endswith("k"):
-        return int(float(nrows_str[:-1]) * 1000)
-    elif nrows_str.endswith("m"):
-        return int(float(nrows_str[:-1]) * 1000 * 1000)
-    elif nrows_str.endswith("g"):
-        return int(float(nrows_str[:-1]) * 1000 * 1000 * 1000)
-    else:
+    powers = {'k': 3, 'm': 6, 'g': 9}
+    try:
+        return int(float(nrows_str[:-1]) * 10 ** powers[nrows_str[-1]])
+    except KeyError:
         raise ValueError(
             "value of nrows must end with either 'k', 'm' or 'g' suffixes.")
 

--- a/examples/array4.py
+++ b/examples/array4.py
@@ -31,9 +31,9 @@ fileh = tables.open_file(file, mode="r")
 # Get the root group
 group = fileh.root
 # Get the metadata on the previosly saved arrays
-for i in range(len(dtypes)):
+for i, dtype in enumerate(dtypes, 1):
     # Create an array for later comparison
-    a = np.ones((basedim,) * (i + 1), dtypes[i])
+    a = np.ones((basedim,) * i, dtype)
     # Get the dset object hangin from group
     dset = getattr(group, 'array_' + a.dtype.char)
     print("Info from dataset:", repr(dset))

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -65,7 +65,7 @@ def main():
     outqueue = queue.Queue()
 
     # start all threads
-    for i in range(NTHREADS):
+    for _ in range(NTHREADS):
         thread = threading.Thread(target=run,
                                   args=(FILENAME, H5PATH, inqueue, outqueue))
         thread.start()
@@ -79,7 +79,7 @@ def main():
     try:
         mean_ = 0.
 
-        for i in range(len(threads)):
+        for _ in range(len(threads)):
             out = outqueue.get()
             if isinstance(out, Exception):
                 raise out

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -115,7 +115,7 @@ def main():
     try:
         mean_ = 0.
 
-        for i in range(len(threads)):
+        for _ in range(len(threads)):
             out = outqueue.get()
             if isinstance(out, Exception):
                 raise out

--- a/tables/array.py
+++ b/tables/array.py
@@ -106,7 +106,7 @@ class Array(hdf5extension.Array, Leaf):
 
     @property
     def nrows(self):
-        "The number of rows in the array."
+        """The number of rows in the array."""
         if self.shape == ():
             return SizeType(1)  # scalar case
         else:
@@ -114,7 +114,7 @@ class Array(hdf5extension.Array, Leaf):
 
     @property
     def rowsize(self):
-        "The size of the rows in bytes in dimensions orthogonal to *maindim*."
+        """The size of the rows in bytes in dimensions orthogonal to *maindim*."""
         maindim = self.maindim
         rowsize = self.atom.size
         for i, dim in enumerate(self.shape):

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -624,7 +624,7 @@ class StringAtom(Atom):
 
     @property
     def itemsize(self):
-        "Size in bytes of a sigle item in the atom."
+        """Size in bytes of a sigle item in the atom."""
         return self.dtype.base.itemsize
 
     def __init__(self, itemsize, shape=(), dflt=_defvalue):
@@ -733,8 +733,8 @@ class ComplexAtom(Atom):
 
     @property
     def itemsize(self):
-         "Size in bytes of a sigle item in the atom."
-         return self.dtype.base.itemsize
+        """Size in bytes of a sigle item in the atom."""
+        return self.dtype.base.itemsize
 
     # Only instances have a `type` attribute, so complex types must be
     # registered by hand.

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -588,18 +588,10 @@ class Atom(metaclass=MetaAtom):
         for both constructor arguments and instance attributes.
 
         """
-
-        # @COMPATIBILITY: inspect.getargspec has been deprecated since
-        #                 Python 3.5
-        try:
-            # inspect.signature is new in Python 3.5
-            signature = inspect.signature(self.__init__)
-        except AttributeError:
-            args = inspect.getargspec(self.__init__)[0]
-        else:
-            parameters = signature.parameters
-            args = [arg for arg, p in parameters.items()
-                if p.kind is p.POSITIONAL_OR_KEYWORD]
+        signature = inspect.signature(self.__init__)
+        parameters = signature.parameters
+        args = [arg for arg, p in parameters.items()
+            if p.kind is p.POSITIONAL_OR_KEYWORD]
 
         return {arg: getattr(self, arg) for arg in args if arg != 'self'}
 

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -187,7 +187,7 @@ class MetaAtom(type):
 
     """
 
-    def __init__(class_, name, bases, dict_):
+    def __init__(cls, name, bases, dict_):
         super().__init__(name, bases, dict_)
 
         kind = dict_.get('kind')
@@ -204,15 +204,15 @@ class MetaAtom(type):
         if kind and itemsize and not hasattr(itemsize, '__int__'):
             # Atom classes with a non-fixed item size do have an
             # ``itemsize``, but it's not a number (e.g. property).
-            atom_map[kind] = class_
+            atom_map[kind] = cls
             return
 
         if kind:  # first definition of kind, make new entry
             atom_map[kind] = {}
 
         if itemsize and hasattr(itemsize, '__int__'):  # fixed
-            kind = class_.kind  # maybe from superclasses
-            atom_map[kind][int(itemsize)] = class_
+            kind = cls.kind  # maybe from superclasses
+            atom_map[kind][int(itemsize)] = cls
 
 
 # Atom classes
@@ -315,13 +315,13 @@ class Atom(metaclass=MetaAtom):
     # Class methods
     # ~~~~~~~~~~~~~
     @classmethod
-    def prefix(class_):
+    def prefix(cls):
         """Return the atom class prefix."""
-        cname = class_.__name__
+        cname = cls.__name__
         return cname[:cname.rfind('Atom')]
 
     @classmethod
-    def from_sctype(class_, sctype, shape=(), dflt=None):
+    def from_sctype(cls, sctype, shape=(), dflt=None):
         """Create an Atom from a NumPy scalar type sctype.
 
         Optional shape and default value may be specified as the
@@ -345,10 +345,10 @@ class Atom(metaclass=MetaAtom):
             if sctype not in numpy.sctypeDict:
                 raise ValueError("unknown NumPy scalar type: {!r}".format(sctype))
             sctype = numpy.sctypeDict[sctype]
-        return class_.from_dtype(numpy.dtype((sctype, shape)), dflt)
+        return cls.from_dtype(numpy.dtype((sctype, shape)), dflt)
 
     @classmethod
-    def from_dtype(class_, dtype, dflt=None):
+    def from_dtype(cls, dtype, dflt=None):
         """Create an Atom from a NumPy dtype.
 
         An optional default value may be specified as the dflt
@@ -381,19 +381,19 @@ class Atom(metaclass=MetaAtom):
                              % dtype)
         if basedtype.kind == 'S':  # can not reuse something like 'string80'
             itemsize = basedtype.itemsize
-            return class_.from_kind('string', itemsize, dtype.shape, dflt)
+            return cls.from_kind('string', itemsize, dtype.shape, dflt)
         elif basedtype.kind == 'U':
             # workaround for unicode type (standard string type in Python 3)
             warnings.warn("support for unicode type is very limited, "
                           "and only works for strings that can be cast as ascii", FlavorWarning)
             itemsize = basedtype.itemsize // 4
             assert str(itemsize) in basedtype.str, "something went wrong in handling unicode."
-            return class_.from_kind('string', itemsize, dtype.shape, dflt)
+            return cls.from_kind('string', itemsize, dtype.shape, dflt)
         # Most NumPy types have direct correspondence with PyTables types.
-        return class_.from_type(basedtype.name, dtype.shape, dflt)
+        return cls.from_type(basedtype.name, dtype.shape, dflt)
 
     @classmethod
-    def from_type(class_, type, shape=(), dflt=None):
+    def from_type(cls, type, shape=(), dflt=None):
         """Create an Atom from a PyTables type.
 
         Optional shape and default value may be specified as the
@@ -417,10 +417,10 @@ class Atom(metaclass=MetaAtom):
         if type not in all_types:
             raise ValueError("unknown type: {!r}".format(type))
         kind, itemsize = split_type(type)
-        return class_.from_kind(kind, itemsize, shape, dflt)
+        return cls.from_kind(kind, itemsize, shape, dflt)
 
     @classmethod
-    def from_kind(class_, kind, itemsize=None, shape=(), dflt=None):
+    def from_kind(cls, kind, itemsize=None, shape=(), dflt=None):
         """Create an Atom from a PyTables kind.
 
         Optional item size, shape and default value may be

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -57,7 +57,7 @@ _new_filters_sub = br'(\1tables.filters\n'
 
 
 def issysattrname(name):
-    "Check if a name is a system attribute or not"
+    """Check if a name is a system attribute or not"""
 
     if (name in SYS_ATTRS or
             numpy.prod([name.startswith(prefix)

--- a/tables/description.py
+++ b/tables/description.py
@@ -535,8 +535,7 @@ class Description:
             # Class variables
             object = classdict[k]
             newdict[k] = object    # To allow natural naming
-            if not (isinstance(object, Col) or
-                    isinstance(object, Description)):
+            if not isinstance(object, (Col, Description)):
                 raise TypeError('Passing an incorrect value to a table column.'
                                 ' Expected a Col (or subclass) instance and '
                                 'got: "%s". Please make use of the Col(), or '

--- a/tables/description.py
+++ b/tables/description.py
@@ -93,14 +93,14 @@ class Col(atom.Atom, metaclass=type):
     # Class methods
     # ~~~~~~~~~~~~~
     @classmethod
-    def prefix(class_):
+    def prefix(cls):
         """Return the column class prefix."""
 
-        cname = class_.__name__
+        cname = cls.__name__
         return cname[:cname.rfind('Col')]
 
     @classmethod
-    def from_atom(class_, atom, pos=None, _offset=None):
+    def from_atom(cls, atom, pos=None, _offset=None):
         """Create a Col definition from a PyTables atom.
 
         An optional position may be specified as the pos argument.
@@ -109,11 +109,11 @@ class Col(atom.Atom, metaclass=type):
 
         prefix = atom.prefix()
         kwargs = atom._get_init_args()
-        colclass = class_._class_from_prefix[prefix]
+        colclass = cls._class_from_prefix[prefix]
         return colclass(pos=pos, _offset=_offset, **kwargs)
 
     @classmethod
-    def from_sctype(class_, sctype, shape=(), dflt=None, pos=None):
+    def from_sctype(cls, sctype, shape=(), dflt=None, pos=None):
         """Create a `Col` definition from a NumPy scalar type `sctype`.
 
         Optional shape, default value and position may be specified as
@@ -124,10 +124,10 @@ class Col(atom.Atom, metaclass=type):
         """
 
         newatom = atom.Atom.from_sctype(sctype, shape, dflt)
-        return class_.from_atom(newatom, pos=pos)
+        return cls.from_atom(newatom, pos=pos)
 
     @classmethod
-    def from_dtype(class_, dtype, dflt=None, pos=None, _offset=None):
+    def from_dtype(cls, dtype, dflt=None, pos=None, _offset=None):
         """Create a `Col` definition from a NumPy `dtype`.
 
         Optional default value and position may be specified as the
@@ -139,10 +139,10 @@ class Col(atom.Atom, metaclass=type):
         """
 
         newatom = atom.Atom.from_dtype(dtype, dflt)
-        return class_.from_atom(newatom, pos=pos, _offset=_offset)
+        return cls.from_atom(newatom, pos=pos, _offset=_offset)
 
     @classmethod
-    def from_type(class_, type, shape=(), dflt=None, pos=None):
+    def from_type(cls, type, shape=(), dflt=None, pos=None):
         """Create a `Col` definition from a PyTables `type`.
 
         Optional shape, default value and position may be specified as
@@ -151,10 +151,10 @@ class Col(atom.Atom, metaclass=type):
         """
 
         newatom = atom.Atom.from_type(type, shape, dflt)
-        return class_.from_atom(newatom, pos=pos)
+        return cls.from_atom(newatom, pos=pos)
 
     @classmethod
-    def from_kind(class_, kind, itemsize=None, shape=(), dflt=None, pos=None):
+    def from_kind(cls, kind, itemsize=None, shape=(), dflt=None, pos=None):
         """Create a `Col` definition from a PyTables `kind`.
 
         Optional item size, shape, default value and position may be
@@ -165,19 +165,19 @@ class Col(atom.Atom, metaclass=type):
         """
 
         newatom = atom.Atom.from_kind(kind, itemsize, shape, dflt)
-        return class_.from_atom(newatom, pos=pos)
+        return cls.from_atom(newatom, pos=pos)
 
     @classmethod
-    def _subclass_from_prefix(class_, prefix):
+    def _subclass_from_prefix(cls, prefix):
         """Get a column subclass for the given `prefix`."""
 
         cname = '%sCol' % prefix
-        class_from_prefix = class_._class_from_prefix
+        class_from_prefix = cls._class_from_prefix
         if cname in class_from_prefix:
             return class_from_prefix[cname]
         atombase = getattr(atom, '%sAtom' % prefix)
 
-        class NewCol(class_, atombase):
+        class NewCol(cls, atombase):
             """Defines a non-nested column of a particular type.
 
             The constructor accepts the same arguments as the equivalent
@@ -766,7 +766,7 @@ type can only take the parameters 'All', 'Col' or 'Description'.""")
 class MetaIsDescription(type):
     """Helper metaclass to return the class variables as a dictionary."""
 
-    def __new__(cls, classname, bases, classdict):
+    def __new__(mcs, classname, bases, classdict):
         """Return a new class with a "columns" attribute filled."""
 
         newdict = {"columns": {}, }
@@ -782,7 +782,7 @@ class MetaIsDescription(type):
                 newdict["columns"][k] = classdict[k]
 
         # Return a new class with the "columns" attribute filled
-        return type.__new__(cls, classname, bases, newdict)
+        return type.__new__(mcs, classname, bases, newdict)
 
 
 

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -179,7 +179,7 @@ class EArray(CArray):
         return self._g_create_common(self._v_expectedrows)
 
     def _check_shape_append(self, nparr):
-        "Test that nparr shape is consistent with underlying EArray."
+        """Test that nparr shape is consistent with underlying EArray."""
 
         # The arrays conforms self expandibility?
         myrank = len(self.shape)

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -261,7 +261,7 @@ class Expr:
             # Protection against growing the cache too much
             if len(exprvars_cache) > 256:
                 # Remove 10 (arbitrary) elements from the cache
-                for k in list(exprvars_cache.keys())[:10]:
+                for k in list(exprvars_cache)[:10]:
                     del exprvars_cache[k]
             cexpr = compile(expression, '<string>', 'eval')
             exprvars = [var for var in cexpr.co_names

--- a/tables/file.py
+++ b/tables/file.py
@@ -88,7 +88,7 @@ class _FileRegistry:
 
     @property
     def filenames(self):
-        return list(self._name_mapping.keys())
+        return list(self._name_mapping)
 
     @property
     def handlers(self):
@@ -2449,7 +2449,7 @@ class File(hdf5extension.File):
             markid = mark
         elif isinstance(mark, str):
             if mark not in self._markers:
-                lmarkers = sorted(self._markers.keys())
+                lmarkers = sorted(self._markers)
                 raise UndoRedoError("The mark that you have specified has not "
                                     "been found in the internal marker list: "
                                     "%r" % lmarkers)

--- a/tables/file.py
+++ b/tables/file.py
@@ -439,7 +439,7 @@ class NodeManager:
                 cache[newkey] = node
 
     def drop_from_cache(self, nodepath):
-        '''Remove the node from cache'''
+        """Remove the node from cache"""
 
         # Remove the node from the cache.
         self.cache.pop(nodepath, None)
@@ -699,7 +699,7 @@ class File(hdf5extension.File):
 
     @property
     def title(self):
-        "The title of the root group in the file."
+        """The title of the root group in the file."""
         return self.root._v_title
 
     @title.setter
@@ -712,7 +712,7 @@ class File(hdf5extension.File):
 
     @property
     def filters(self):
-        "Default filter properties for the root group (see :ref:`FiltersClassDescr`)."
+        """Default filter properties for the root group (see :ref:`FiltersClassDescr`)."""
         return self.root._v_filters
 
     @filters.setter

--- a/tables/file.py
+++ b/tables/file.py
@@ -2106,8 +2106,7 @@ class File(hdf5extension.File):
         class_ = get_class_by_name(classname)
 
         if class_ is Group:  # only groups
-            for group in self.walk_groups(where):
-                yield group
+            yield from self.walk_groups(where)
         elif class_ is Node:  # all nodes
             yield self.get_node(where)
             for group in self.walk_groups(where):

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -185,7 +185,7 @@ class Filters:
             return 2
 
     @classmethod
-    def _from_leaf(class_, leaf):
+    def _from_leaf(cls, leaf):
         # Get a dictionary with all the filters
         parent = leaf._v_parent
         filters_dict = utilsextension.get_filters(parent._v_objectid,
@@ -221,10 +221,10 @@ class Filters:
                 kwargs['complevel'] = 1  # any nonzero value will do
             elif name in ['shuffle', 'fletcher32']:
                 kwargs[name] = True
-        return class_(**kwargs)
+        return cls(**kwargs)
 
     @classmethod
-    def _unpack(class_, packed):
+    def _unpack(cls, packed):
         """Create a new `Filters` object from a packed version.
 
         >>> Filters._unpack(0)
@@ -272,7 +272,7 @@ class Filters:
         else:
             kwargs['least_significant_digit'] = None
 
-        return class_(**kwargs)
+        return cls(**kwargs)
 
     def _pack(self):
         """Pack the `Filters` object into a 64-bit NumPy integer."""

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -207,7 +207,7 @@ def array_of_flavor(array, dst_flavor):
     return array_of_flavor2(array, flavor_of(array), dst_flavor)
 
 
-def restrict_flavors(keep=['python']):
+def restrict_flavors(keep=('python',)):
     """Disable all flavors except those in keep.
 
     Providing an empty keep sequence implies disabling all flavors (but the
@@ -218,8 +218,7 @@ def restrict_flavors(keep=['python']):
 
     """
 
-    keep = set(keep).union([internal_flavor])
-    remove = set(all_flavors).difference(keep)
+    remove = set(all_flavors) - set(keep) - {internal_flavor}
     for flavor in remove:
         _disable_flavor(flavor)
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -470,8 +470,7 @@ class Group(hdf5extension.Group, Node):
 
         if classname == "Group":
             # Recursive algorithm
-            for group in self._f_walk_groups():
-                yield group
+            yield from self._f_walk_groups()
         else:
             for group in self._f_walk_groups():
                 yield from group._f_iter_nodes(classname)
@@ -734,35 +733,26 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         if not classname:
             # Returns all the children alphanumerically sorted
-            names = sorted(self._v_children)
-            for name in names:
+            for name in sorted(self._v_children):
                 yield self._v_children[name]
         elif classname == 'Group':
             # Returns all the groups alphanumerically sorted
-            names = sorted(self._v_groups)
-            for name in names:
+            for name in sorted(self._v_groups):
                 yield self._v_groups[name]
         elif classname == 'Leaf':
             # Returns all the leaves alphanumerically sorted
-            names = sorted(self._v_leaves)
-            for name in names:
+            for name in sorted(self._v_leaves):
                 yield self._v_leaves[name]
         elif classname == 'Link':
             # Returns all the links alphanumerically sorted
-            names = sorted(self._v_links)
-            for name in names:
+            for name in sorted(self._v_links):
                 yield self._v_links[name]
         elif classname == 'IndexArray':
             raise TypeError(
                 "listing ``IndexArray`` nodes is not allowed")
         else:
             class_ = get_class_by_name(classname)
-
-            children = self._v_children
-            childnames = sorted(children)
-
-            for childname in childnames:
-                childnode = children[childname]
+            for childname, childnode in sorted(self._v_children.items()):
                 if isinstance(childnode, class_):
                     yield childnode
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -166,7 +166,7 @@ class Group(hdf5extension.Group, Node):
     # `_v_nchildren` is a direct read-only shorthand
     # for the number of *visible* children in a group.
     def _g_getnchildren(self):
-        "The number of children hanging from this group."
+        """The number of children hanging from this group."""
         return len(self._v_children)
 
     _v_nchildren = property(_g_getnchildren)

--- a/tables/group.py
+++ b/tables/group.py
@@ -734,22 +734,22 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         if not classname:
             # Returns all the children alphanumerically sorted
-            names = sorted(self._v_children.keys())
+            names = sorted(self._v_children)
             for name in names:
                 yield self._v_children[name]
         elif classname == 'Group':
             # Returns all the groups alphanumerically sorted
-            names = sorted(self._v_groups.keys())
+            names = sorted(self._v_groups)
             for name in names:
                 yield self._v_groups[name]
         elif classname == 'Leaf':
             # Returns all the leaves alphanumerically sorted
-            names = sorted(self._v_leaves.keys())
+            names = sorted(self._v_leaves)
             for name in names:
                 yield self._v_leaves[name]
         elif classname == 'Link':
             # Returns all the links alphanumerically sorted
-            names = sorted(self._v_links.keys())
+            names = sorted(self._v_links)
             for name in names:
                 yield self._v_links[name]
         elif classname == 'IndexArray':
@@ -759,7 +759,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             class_ = get_class_by_name(classname)
 
             children = self._v_children
-            childnames = sorted(children.keys())
+            childnames = sorted(children)
 
             for childname in childnames:
                 childnode = children[childname]
@@ -783,7 +783,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         # Iterate over the descendants
         while stack:
             objgroup = stack.pop()
-            groupnames = sorted(objgroup._v_groups.keys())
+            groupnames = sorted(objgroup._v_groups)
             # Sort the groups before delivering. This uses the groups names
             # for groups in tree (in order to sort() can classify them).
             for groupname in groupnames:

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -630,7 +630,7 @@ cdef class AttributeSet:
     self.name = node._v_name
 
   def _g_list_attr(self, node):
-    "Return a tuple with the attribute list"
+    """Return a tuple with the attribute list"""
     a = Aiterate(node._v_objectid)
     return a
 

--- a/tables/index.py
+++ b/tables/index.py
@@ -157,7 +157,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
     @property
     def kind(self):
-        "The kind of this index."
+        """The kind of this index."""
         return {1: 'ultralight', 2: 'light',
                 4: 'medium', 8: 'full'}[self.indsize]
 
@@ -209,22 +209,22 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
     @property
     def nblockssuperblock(self):
-        "The number of blocks in a superblock."
+        """The number of blocks in a superblock."""
         return self.superblocksize // self.blocksize
 
     @property
     def nslicesblock(self):
-        "The number of slices in a block."
+        """The number of slices in a block."""
         return self.blocksize // self.slicesize
 
     @property
     def nchunkslice(self):
-        "The number of chunks in a slice."
+        """The number of chunks in a slice."""
         return self.slicesize // self.chunksize
 
     @property
     def nsuperblocks(self):
-        "The total number of superblocks in index."
+        """The total number of superblocks in index."""
         # Last row should not be considered as a superblock
         nelements = self.nelements - self.nelementsILR
         nblocks = nelements // self.superblocksize
@@ -234,7 +234,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
     @property
     def nblocks(self):
-        "The total number of blocks in index."
+        """The total number of blocks in index."""
         # Last row should not be considered as a block
         nelements = self.nelements - self.nelementsILR
         nblocks = nelements // self.blocksize
@@ -244,27 +244,27 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
     @property
     def nslices(self):
-        "The number of complete slices in index."
+        """The number of complete slices in index."""
         return self.nelements // self.slicesize
 
     @property
     def nchunks(self):
-        "The number of complete chunks in index."
+        """The number of complete chunks in index."""
         return self.nelements // self.chunksize
 
     @property
     def shape(self):
-        "The shape of this index (in slices and elements)."
+        """The shape of this index (in slices and elements)."""
         return (self.nrows, self.slicesize)
 
     @property
     def temp_required(self):
-        "Whether a temporary file for indexes is required or not."
+        """Whether a temporary file for indexes is required or not."""
         return self.indsize > 1 and self.optlevel > 0 and self.table.nrows > self.slicesize
 
     @property
     def want_complete_sort(self):
-        "Whether we should try to build a completely sorted index or not."
+        """Whether we should try to build a completely sorted index or not."""
         return self.indsize == 8 and self.optlevel == 9
 
     @property
@@ -1784,7 +1784,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         return self.nelements
 
     def restorecache(self):
-        "Clean the limits cache and resize starts and lengths arrays"
+        """Clean the limits cache and resize starts and lengths arrays"""
 
         params = self._v_file.params
         # The sorted IndexArray is absolutely required to be in memory
@@ -2210,7 +2210,7 @@ class IndexesTableG(NotLoggedMixin, Group):
 
     @property
     def table(self):
-        "Accessor for the `Table` object of this `IndexesTableG` container."
+        """Accessor for the `Table` object of this `IndexesTableG` container."""
         names = self._v_pathname.split("/")
         tablename = names.pop()[3:]   # "_i_" is at the beginning
         parentpathname = "/".join(names)

--- a/tables/index.py
+++ b/tables/index.py
@@ -992,7 +992,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if rmult < thmult:
             return True
         # Additional check for the overlap ratio
-        if tover >= 0. and tover < thtover:
+        if 0. <= tover < thtover:
             return True
         return False
 

--- a/tables/index.py
+++ b/tables/index.py
@@ -1843,8 +1843,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             # Reset the lengths array (not necessary for starts)
             self.lengths[:] = 0
             # Now, set the interesting rows
-            for nrow in range(len(startlengths)):
-                nrow2, start, length = startlengths[nrow]
+            for nrow2, start, length in startlengths:
                 self.starts[nrow2] = start
                 self.lengths[nrow2] = length
                 tlen = tlen + length
@@ -2052,8 +2051,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             idx = chunkmap.nonzero()[0]
             starts = (idx * ratio).astype('int_')
             stops = numpy.ceil((idx + 1) * ratio).astype('int_')
-            for i in range(len(idx)):
-                tchunkmap[starts[i]:stops[i]] = True
+            for start, stop in zip(starts, stops):
+                tchunkmap[start:stop] = True
             chunkmap = tchunkmap
         if profile:
             show_stats("Exiting get_chunkmap", tref)

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -169,7 +169,7 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
         return (result1, result2)
 
     def __str__(self):
-        "A compact representation of this class"
+        """A compact representation of this class"""
         return "IndexArray(path=%s)" % self._v_pathname
 
     def __repr__(self):

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -485,7 +485,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         return new_node
 
     def _g_fix_byteorder_data(self, data, dbyteorder):
-        "Fix the byteorder of data passed in constructors."
+        """Fix the byteorder of data passed in constructors."""
         dbyteorder = byteorders[dbyteorder]
         # If self.byteorder has not been passed as an argument of
         # the constructor, then set it to the same value of data.

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -430,7 +430,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         if start is not None and stop is None and step is None:
             # Protection against start greater than available records
             # nrows == 0 is a special case for empty objects
-            if nrows > 0 and start >= nrows:
+            if 0 < nrows <= start:
                 raise IndexError("start of range (%s) is greater than "
                                  "number of rows (%s)" % (start, nrows))
             step = 1

--- a/tables/misc/proxydict.py
+++ b/tables/misc/proxydict.py
@@ -48,10 +48,7 @@ class ProxyDict(dict):
 
     def values(self):
         # C implementation does not use `self.__getitem__()`. :(
-        valueList = []
-        for key in self.keys():
-            valueList.append(self[key])
-        return valueList
+        return [self[key] for key in self.keys()]
 
     def itervalues(self):
         # C implementation does not use `self.__getitem__()`. :(
@@ -60,10 +57,7 @@ class ProxyDict(dict):
 
     def items(self):
         # C implementation does not use `self.__getitem__()`. :(
-        itemList = []
-        for key in self.keys():
-            itemList.append((key, self[key]))
-        return itemList
+        return [(key, self[key]) for key in self.keys()]
 
     def iteritems(self):
         # C implementation does not use `self.__getitem__()`. :(

--- a/tables/node.py
+++ b/tables/node.py
@@ -150,7 +150,7 @@ class Node(metaclass=MetaNode):
 
     # `_v_parent` is accessed via its file to avoid upwards references.
     def _g_getparent(self):
-        "The parent :class:`Group` instance"
+        """The parent :class:`Group` instance"""
         (parentpath, nodename) = split_path(self._v_pathname)
         return self._v_file._get_node(parentpath)
 
@@ -173,7 +173,7 @@ class Node(metaclass=MetaNode):
     # '_v_title' is a direct read-write shorthand for the 'TITLE' attribute
     # with the empty string as a default value.
     def _g_gettitle(self):
-        "A description of this node. A shorthand for TITLE attribute."
+        """A description of this node. A shorthand for TITLE attribute."""
         if hasattr(self._v_attrs, 'TITLE'):
             return self._v_attrs.TITLE
         else:

--- a/tables/node.py
+++ b/tables/node.py
@@ -64,30 +64,30 @@ class MetaNode(type):
 
     """
 
-    def __new__(class_, name, bases, dict_):
+    def __new__(mcs, name, bases, dict_):
         # Add default behaviour for representing closed nodes.
         for mname in ['__str__', '__repr__']:
             if mname in dict_:
                 dict_[mname] = _closedrepr(dict_[mname])
 
-        return type.__new__(class_, name, bases, dict_)
+        return type.__new__(mcs, name, bases, dict_)
 
-    def __init__(class_, name, bases, dict_):
+    def __init__(cls, name, bases, dict_):
         super().__init__(name, bases, dict_)
 
         # Always register into class name dictionary.
-        class_name_dict[class_.__name__] = class_
+        class_name_dict[cls.__name__] = cls
 
         # Register into class identifier dictionary only if the class
         # has an identifier and it is different from its parents'.
-        cid = getattr(class_, '_c_classid', None)
+        cid = getattr(cls, '_c_classid', None)
         if cid is not None:
             for base in bases:
                 pcid = getattr(base, '_c_classid', None)
                 if pcid == cid:
                     break
             else:
-                class_id_dict[cid] = class_
+                class_id_dict[cid] = cls
 
 
 class Node(metaclass=MetaNode):

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -310,7 +310,7 @@ class OpenFileTestCase(TempFileMixin, TestCase):
         fnode.close()
 
     def test02_OpenFileInvalidMode(self):
-        "Opening an existing file node with an invalid mode."
+        """Opening an existing file node with an invalid mode."""
 
         self.assertRaises(
             IOError, filenode.open_node, self.h5file.get_node('/test'), 'w')

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -472,7 +472,7 @@ new2oldnames = {v: k for k, v in old2newnames.items()}
 
 def make_subs(ns):
     names = new2oldnames if ns.reverse else old2newnames
-    s = r'(?<=\W)({})(?=\W)'.format('|'.join(list(names.keys())))
+    s = r'(?<=\W)({})(?=\W)'.format('|'.join(list(names)))
     if ns.ignore_previous:
         s += r'(?!\s*?=\s*?previous_api(_property)?\()'
         s += r'(?!\* to \*\w+\*)'

--- a/tables/table.py
+++ b/tables/table.py
@@ -958,7 +958,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             return arr
 
     def _get_container(self, shape):
-        "Get the appropriate buffer for data depending on table nestedness."
+        """Get the appropriate buffer for data depending on table nestedness."""
 
         # This is *much* faster than the numpy.rec.array counterpart
         return numpy.empty(shape=shape, dtype=self._v_dtype)
@@ -2767,7 +2767,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         self._do_reindex(dirty=True)
 
     def _g_copy_rows(self, object, start, stop, step, sortby, checkCSI):
-        "Copy rows from self to object"
+        """Copy rows from self to object"""
         if sortby is None:
             self._g_copy_rows_optim(object, start, stop, step)
             return
@@ -3036,7 +3036,7 @@ class Cols:
 
     @property
     def _v_table(self):
-        "The parent Table instance (see :ref:`TableClassDescr`)."
+        """The parent Table instance (see :ref:`TableClassDescr`)."""
         return self._v__tableFile._get_node(self._v__tablePath)
 
     def __init__(self, table, desc):
@@ -3342,12 +3342,12 @@ class Column:
 
     @property
     def shape(self):
-        "The shape of this column."
+        """The shape of this column."""
         return (self.table.nrows,) + self.descr._v_dtypes[self.name].shape
 
     @property
     def is_indexed(self):
-        "True if the column is indexed, false otherwise."
+        """True if the column is indexed, false otherwise."""
         if self.index is None:
             return False
         else:

--- a/tables/table.py
+++ b/tables/table.py
@@ -342,7 +342,7 @@ class _ColIndexes(dict):
     def __repr__(self):
         """Gives a detailed Description column representation."""
 
-        rep = ['  \"{}\": {}'.format(k, self[k]) for k in self.keys()]
+        rep = ['  \"{}\": {}'.format(k, v) for k, v in self.items()]
         return '{\n  %s}' % (',\n  '.join(rep))
 
 
@@ -1207,7 +1207,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             # Protection against growing the cache too much
             if len(exprvarscache) > 256:
                 # Remove 10 (arbitrary) elements from the cache
-                for k in list(exprvarscache.keys())[:10]:
+                for k in list(exprvarscache)[:10]:
                     del exprvarscache[k]
             cexpr = compile(expression, '<string>', 'eval')
             exprvars = [var for var in cexpr.co_names

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -230,7 +230,7 @@ class PyTablesTestCase(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         for key in self.__dict__:
-            if self.__dict__[key].__class__.__name__ not in ('instancemethod'):
+            if self.__dict__[key].__class__.__name__ != 'instancemethod':
                 self.__dict__[key] = None
 
     def _getName(self):

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -899,11 +899,11 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
         group = self.h5file.root
 
         # Get the metadata on the previosly saved arrays
-        for i in range(len(typecodes)):
+        for i, typecode in enumerate(typecodes):
             # Create an array for later comparison
-            a = numpy.ones((3,), typecodes[i])
+            a = numpy.ones((3,), typecode)
             # Get the dset object hanging from group
-            dset = getattr(group, 'array_' + typecodes[i])
+            dset = getattr(group, 'array_' + typecode)
             # Get the actual array
             b = dset.read()
             if common.verbose:
@@ -1896,14 +1896,14 @@ class GeneratorTestCase(common.TempFileMixin, TestCase):
             arr = self.h5file.root.somearray
 
         # Get and compare an element
-        ga = [i for i in a]
-        garr = [i for i in arr]
+        ga = list(a)
+        garr = list(arr)
 
         if common.verbose:
             print("Result of original iterator:", ga)
             print("Result of read generator:", garr)
-        for i in range(len(ga)):
-            self.assertTrue(allequal(ga[i], garr[i]))
+        for x_ga, x_garr in zip(ga, garr):
+            self.assertTrue(allequal(x_ga, x_garr))
 
     def test01a_single(self):
         """Testing generator access to Arrays, single elements (numeric)"""
@@ -1938,13 +1938,13 @@ class GeneratorTestCase(common.TempFileMixin, TestCase):
             arr = self.h5file.root.somearray
 
         # Get and compare an element
-        ga = [i for i in a]
-        garr = [i for i in arr]
+        ga = list(a)
+        garr = list(arr)
         if common.verbose:
             print("Result of original iterator:", ga)
             print("Result of read generator:", garr)
-        for i in range(len(ga)):
-            self.assertTrue(allequal(ga[i], garr[i]))
+        for x_ga, x_garr in zip(ga, garr):
+            self.assertTrue(allequal(x_ga, x_garr))
 
 
 class GE1NATestCase(GeneratorTestCase):

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -2423,8 +2423,7 @@ class TestDescription(TestCase):
         descr = Description(d)
         self.assertEqual(sorted(descr._v_names), sorted(d.keys()))
         self.assertIsInstance(descr._v_dtype, numpy.dtype)
-        self.assertTrue(sorted(descr._v_dtype.fields.keys()),
-                        sorted(d.keys()))
+        self.assertTrue(sorted(descr._v_dtype.fields), sorted(d.keys()))
 
 
 class TestAtom(TestCase):

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -2031,7 +2031,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
         array[s] = na
 
     def test01_basiccheck(self):
-        "Some basic checks for carrays exceeding 2**31 rows"
+        """Some basic checks for carrays exceeding 2**31 rows"""
 
         array = self.h5file.root.array
 
@@ -2122,7 +2122,7 @@ class BigArrayTestCase(common.TempFileMixin, TestCase):
 class DfltAtomTestCase(common.TempFileMixin, TestCase):
 
     def test00_dflt(self):
-        "Check that Atom.dflt is honored (string version)."
+        """Check that Atom.dflt is honored (string version)."""
 
         # Create a CArray with default values
         self.h5file.create_carray('/', 'bar',
@@ -2140,7 +2140,7 @@ class DfltAtomTestCase(common.TempFileMixin, TestCase):
             allequal(values, numpy.array(["abdef"]*100, "S5").reshape(10, 10)))
 
     def test01_dflt(self):
-        "Check that Atom.dflt is honored (int version)."
+        """Check that Atom.dflt is honored (int version)."""
 
         # Create a CArray with default values
         self.h5file.create_carray('/', 'bar',
@@ -2156,7 +2156,7 @@ class DfltAtomTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(values, numpy.ones((10, 10), "i4")))
 
     def test02_dflt(self):
-        "Check that Atom.dflt is honored (float version)."
+        """Check that Atom.dflt is honored (float version)."""
 
         # Create a CArray with default values
         self.h5file.create_carray('/', 'bar',

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -706,10 +706,11 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
         group._v_attrs.attr1 = "an string for root group"
         group._v_attrs.attr2 = 124
         # Create a tree
-        for j in range(5):
-            for i in range(2):
+        for group_i in range(5):
+            for bgroup_i in range(2):
                 # Create a new group (brother of group)
-                group2 = self.h5file.create_group(group, 'bgroup' + str(i),
+                group2 = self.h5file.create_group(group,
+                                                  'bgroup' + str(bgroup_i),
                                                   filters=None)
 
                 # Create a table
@@ -719,10 +720,10 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
                 # Get the record object associated with the new table
                 d = table.row
                 # Fill the table
-                for i in range(self.nrows):
-                    d['var1'] = '%04d' % (self.nrows - i)
-                    d['var2'] = i
-                    d['var3'] = i * 2
+                for row_i in range(self.nrows):
+                    d['var1'] = '%04d' % (self.nrows - row_i)
+                    d['var2'] = row_i
+                    d['var3'] = row_i * 2
                     d.append()      # This injects the Record values
                 # Flush the buffer for this table
                 table.flush()
@@ -752,7 +753,7 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
                 ea2.append(var3List)
 
             # Create a new group (descendant of group)
-            group3 = self.h5file.create_group(group, 'group' + str(j),
+            group3 = self.h5file.create_group(group, 'group' + str(group_i),
                                               filters=None)
             # Iterate over this new group (group3)
             group = group3
@@ -1048,10 +1049,11 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
         group._v_attrs.attr1 = "an string for root group"
         group._v_attrs.attr2 = 124
         # Create a tree
-        for j in range(5):
-            for i in range(2):
+        for group_i in range(5):
+            for bgroup_i in range(2):
                 # Create a new group (brother of group)
-                group2 = self.h5file.create_group(group, 'bgroup' + str(i),
+                group2 = self.h5file.create_group(group,
+                                                  'bgroup' + str(bgroup_i),
                                                   filters=None)
 
                 # Create a table
@@ -1061,10 +1063,10 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
                 # Get the record object associated with the new table
                 d = table.row
                 # Fill the table
-                for i in range(self.nrows):
-                    d['var1'] = '%04d' % (self.nrows - i)
-                    d['var2'] = i
-                    d['var3'] = i * 2
+                for row_i in range(self.nrows):
+                    d['var1'] = '%04d' % (self.nrows - row_i)
+                    d['var2'] = row_i
+                    d['var3'] = row_i * 2
                     d.append()      # This injects the Record values
                 # Flush the buffer for this table
                 table.flush()
@@ -1095,7 +1097,7 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
                 ea2.append(var3List)
 
             # Create a new group (descendant of group)
-            group3 = self.h5file.create_group(group, 'group' + str(j),
+            group3 = self.h5file.create_group(group, 'group' + str(group_i),
                                               filters=None)
             # Iterate over this new group (group3)
             group = group3

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -790,8 +790,8 @@ class CopyGroupTestCase(common.TempFileMixin, TestCase):
 
         # Check that the copy has been done correctly
         dstgroup = self.h5file2.root
-        nodelist1 = list(srcgroup._v_children.keys())
-        nodelist2 = list(dstgroup._v_children.keys())
+        nodelist1 = list(srcgroup._v_children)
+        nodelist2 = list(dstgroup._v_children)
         # Sort the lists
         nodelist1.sort()
         nodelist2.sort()
@@ -1140,8 +1140,8 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
         # Check that the copy has been done correctly
         srcgroup = self.h5file.root
         dstgroup = self.h5file2.root
-        nodelist1 = list(srcgroup._v_children.keys())
-        nodelist2 = list(dstgroup._v_children.keys())
+        nodelist1 = list(srcgroup._v_children)
+        nodelist2 = list(dstgroup._v_children)
         # Sort the lists
         nodelist1.sort()
         nodelist2.sort()
@@ -1184,8 +1184,8 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
         # Check that the copy has been done correctly
         srcgroup = self.h5file.root
         dstgroup = self.h5file2.root
-        nodelist1 = list(srcgroup._v_children.keys())
-        nodelist2 = list(dstgroup._v_children.keys())
+        nodelist1 = list(srcgroup._v_children)
+        nodelist2 = list(dstgroup._v_children)
 
         # Sort the lists
         nodelist1.sort()
@@ -1219,8 +1219,8 @@ class CopyFileTestCase(common.TempFileMixin, TestCase):
         # Check that the copy has been done correctly
         srcgroup = self.h5file.root
         dstgroup = self.h5file2.root
-        nodelist1 = list(srcgroup._v_children.keys())
-        nodelist2 = list(dstgroup._v_children.keys())
+        nodelist1 = list(srcgroup._v_children)
+        nodelist2 = list(dstgroup._v_children)
 
         # Sort the lists
         nodelist1.sort()

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -997,7 +997,7 @@ class MD6WriteTestCase(BasicTestCase):
 
 
 class NP_MD6WriteTestCase(BasicTestCase):
-    "Testing NumPy scalars as indexes"
+    """Testing NumPy scalars as indexes"""
     type = 'int32'
     shape = (2, 3, 3, 0, 5, 6)
     chunksize = 1
@@ -2471,7 +2471,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(ea[2], a * 3))
 
     def test03b_MDMDMD(self):
-        "Complex append of a MD array in a MD EArray with a MD atom (II)."
+        """Complex append of a MD array in a MD EArray with a MD atom (II)."""
         # Create an EArray
         ea = self.h5file.create_earray('/', 'test', atom=Int32Atom((2, 4)),
                                        shape=(2, 0, 3))
@@ -2490,7 +2490,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(ea[:, 2, ...], a.reshape((2, 3, 2, 4))*3))
 
     def test03c_MDMDMD(self):
-        "Complex append of a MD array in a MD EArray with a MD atom (III)."
+        """Complex append of a MD array in a MD EArray with a MD atom (III)."""
         # Create an EArray
         ea = self.h5file.create_earray('/', 'test', atom=Int32Atom((2, 4)),
                                        shape=(2, 3, 0))

--- a/tables/tests/test_enum.py
+++ b/tables/tests/test_enum.py
@@ -342,12 +342,12 @@ class EnumTableTestCase(common.TempFileMixin, TestCase):
         tbl.flush()
         tbl.flavor = 'python'
         read = tbl.read()
-        for i in range(len(appended)):
-            self.assertEqual(appended[i][0], read[i][0],
+        for x_appended, x_read in zip(appended, read):
+            self.assertEqual(x_appended[0], x_read[0],
                              "Written and read values differ.")
-            self.assertEqual(appended[i][1][0], read[i][1][0],
+            self.assertEqual(x_appended[1][0], x_read[1][0],
                              "Written and read values differ.")
-            self.assertEqual(appended[i][1][1], read[i][1][1],
+            self.assertEqual(x_appended[1][1], x_read[1][1],
                              "Written and read values differ.")
 
     def test05_where(self):

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -114,7 +114,7 @@ def append_columns(classdict, shape=()):
 
     """
     heavy = common.heavy
-    for (itype, type_) in enumerate(sorted(type_info.keys())):
+    for (itype, type_) in enumerate(sorted(type_info)):
         if not heavy and type_ in heavy_types:
             continue  # skip heavy type in non-heavy mode
         colpos = itype + 1

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -838,11 +838,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test02a_AppendRows..." % self.__class__.__name__)
 
         group = self.rootgroup
-        for i in range(3):
+        for group_i in range(3):
             # Get a table
-            table = self.h5file.get_node(group, 'table'+str(i))
+            table = self.h5file.get_node(group, 'table'+str(group_i))
             # Get the next group
-            group = self.h5file.get_node(group, 'group'+str(i))
+            group = self.h5file.get_node(group, 'group'+str(group_i))
             # Get their row object
             row = table.row
             if common.verbose:
@@ -850,56 +850,56 @@ class BasicTestCase(common.TempFileMixin, TestCase):
                 print("Record Format ==>", table.description._v_nested_formats)
                 print("Record Size ==>", table.rowsize)
             # Append some rows
-            for i in range(self.appendrows):
-                row['var1'] = '%04d' % (self.appendrows - i)
+            for row_i in range(self.appendrows):
+                row['var1'] = '%04d' % (self.appendrows - row_i)
                 row['var7'] = row['var1'][-1]
-                row['var2'] = i
-                row['var3'] = i % self.maxshort
+                row['var2'] = row_i
+                row['var3'] = row_i % self.maxshort
                 if isinstance(row['var4'], np.ndarray):
-                    row['var4'] = [float(i), float(i * i)]
+                    row['var4'] = [float(row_i), float(row_i * row_i)]
                 else:
-                    row['var4'] = float(i)
+                    row['var4'] = float(row_i)
                 if isinstance(row['var8'], np.ndarray):
                     row['var8'] = [0, 1]
                 else:
                     row['var8'] = 1
                 if isinstance(row['var9'], np.ndarray):
-                    row['var9'] = [0.+float(i)*1j, float(i)+0.j]
+                    row['var9'] = [0.+float(row_i)*1j, float(row_i)+0.j]
                 else:
-                    row['var9'] = float(i)+0.j
+                    row['var9'] = float(row_i)+0.j
                 if isinstance(row['var10'], np.ndarray):
-                    row['var10'] = [float(i)+0.j, 1.+float(i)*1j]
+                    row['var10'] = [float(row_i)+0.j, 1.+float(row_i)*1j]
                 else:
-                    row['var10'] = 1.+float(i)*1j
+                    row['var10'] = 1.+float(row_i)*1j
                 if isinstance(row['var5'], np.ndarray):
-                    row['var5'] = np.array((float(i),)*4)
+                    row['var5'] = np.array((float(row_i),)*4)
                 else:
-                    row['var5'] = float(i)
+                    row['var5'] = float(row_i)
                 if hasattr(tables, 'Float16Col'):
                     if isinstance(row['var11'], np.ndarray):
-                        row['var11'] = np.array((float(i),)*4)
+                        row['var11'] = np.array((float(row_i),)*4)
                     else:
-                        row['var11'] = float(i)
+                        row['var11'] = float(row_i)
                 if hasattr(tables, 'Float96Col'):
                     if isinstance(row['var12'], np.ndarray):
-                        row['var12'] = np.array((float(i),)*4)
+                        row['var12'] = np.array((float(row_i),)*4)
                     else:
-                        row['var12'] = float(i)
+                        row['var12'] = float(row_i)
                 if hasattr(tables, 'Float128Col'):
                     if isinstance(row['var13'], np.ndarray):
-                        row['var13'] = np.array((float(i),)*4)
+                        row['var13'] = np.array((float(row_i),)*4)
                     else:
-                        row['var13'] = float(i)
+                        row['var13'] = float(row_i)
                 if hasattr(tables, 'Complex192Col'):
                     if isinstance(row['var14'], np.ndarray):
-                        row['var14'] = [float(i)+0j, 1 + float(i)*1j]
+                        row['var14'] = [float(row_i)+0j, 1 + float(row_i)*1j]
                     else:
-                        row['var14'] = 1 + float(i)*1j
+                        row['var14'] = 1 + float(row_i)*1j
                 if hasattr(tables, 'Complex256Col'):
                     if isinstance(row['var15'], np.ndarray):
-                        row['var15'] = [float(i)+0j, 1 + float(i)*1j]
+                        row['var15'] = [float(row_i)+0j, 1 + float(row_i)*1j]
                     else:
-                        row['var15'] = 1 + float(i)*1j
+                        row['var15'] = 1 + float(row_i)*1j
 
                 row.append()
             table.flush()

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -3819,7 +3819,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         self.assertEqual(r1.tobytes(), r2.tobytes())
 
     def test02(self):
-        "Checking saving a large recarray with an offset in its buffer"
+        """Checking saving a large recarray with an offset in its buffer"""
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -6135,7 +6135,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
 # Test for building very large MD columns without defaults
 class MDLargeColTestCase(common.TempFileMixin, TestCase):
     def test01_create(self):
-        "Create a Table with a very large MD column.  Ticket #211."
+        """Create a Table with a very large MD column.  Ticket #211."""
         N = 2**18      # 4x larger than maximum object header size (64 KB)
         cols = {'col1': Int8Col(shape=N, dflt=0)}
         tbl = self.h5file.create_table('/', 'test', cols)

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -315,7 +315,7 @@ def log_instance_creation(instance, name=None):
 
 def string_to_classes(s):
     if s == '*':
-        c = sorted(tracked_classes.keys())
+        c = sorted(tracked_classes)
         return c
     else:
         return s.split()
@@ -370,7 +370,7 @@ class CacheDict(dict):
         if len(self) > self.maxentries:
             # Remove a 10% of (arbitrary) elements from the cache
             entries_to_remove = self.maxentries / 10
-            for k in list(self.keys())[:entries_to_remove]:
+            for k in list(self)[:entries_to_remove]:
                 super().__delitem__(k)
         super().__setitem__(key, value)
 
@@ -424,7 +424,7 @@ class NailedDict:
         if len(cache) > self.maxentries:
             # Remove a 10% of (arbitrary) elements from the cache
             entries_to_remove = max(self.maxentries // 10, 1)
-            for k in list(cache.keys())[:entries_to_remove]:
+            for k in list(cache)[:entries_to_remove]:
                 del cache[k]
         cache[key] = value
 

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -222,7 +222,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
 
     @property
     def shape(self):
-        "The shape of the stored array."
+        """The shape of the stored array."""
         return (self.nrows,)
 
     @property


### PR DESCRIPTION
This is a bunch of independent code-improvement refactorings. Please feel free to discuss/accept/reject any number of them. I'd like to know your opinion on them.

1. Remove `.keys()` calls on dicts when the keys are needed, since the dict provides them implicitly
2. Change loops with `yield` to `yield from`
3. Bugfix: `if … in ('instancemethod')`. That's not a tuple and therefore it tested against the string `in 'instancemethod'`
4. `"""Docstrings use triple double quotes."""`
5. Remove one try/except with a method changed in Python 3.5
6. Simplify chained conditions
7. classmethods are usually called on `cls` variables
8. Change a mutable (list) default argument to a tuple and refactor the method
9. Nested repeating `for i in …` replaced with more meaningful variable names to avoid confusion
10. refactor `get_nrows` to have less code to read
11. `isinstance(obj, (cls1, cls2, …))` accepts multiple classes
12. simplify range loops to get the variables immediately and not through index  