### PR TITLE
Declare support for Python 3.5–3.9 and remove older hacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.5', '3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,16 @@
 .. image:: https://ci.appveyor.com/api/projects/status/github/PyTables/PyTables?branch=master&svg=true
    :target: https://ci.appveyor.com/project/PyTablesCI/pytables
 
+.. image:: https://img.shields.io/pypi/v/tables.svg
+  :target: https://pypi.org/project/tables/
+
+.. image:: https://img.shields.io/pypi/pyversions/tables.svg
+  :target: https://pypi.org/project/tables/
+
+.. image:: https://img.shields.io/pypi/l/tables
+  :target: https://github.com/PyTables/PyTables/
+
+
 :URL: http://www.pytables.org/
 
 

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -3,10 +3,7 @@ queues."""
 
 import sys
 
-if sys.version < '3':
-    import Queue as queue
-else:
-    import queue
+import queue
 
 import multiprocessing
 import os

--- a/setup.py
+++ b/setup.py
@@ -96,10 +96,10 @@ if __name__ == '__main__':
 
 
     # The minimum required versions
-    min_python_version = (3, 4)
+    min_python_version = (3, 5)
     # Check for Python
     if sys.version_info < min_python_version:
-        exit_with_error("You need Python 3.4 or greater to install PyTables!")
+        exit_with_error("You need Python 3.5 or greater to install PyTables!")
     print("* Using Python %s" % sys.version.splitlines()[0])
 
     # Minimum required versions for numpy, numexpr and HDF5
@@ -1028,12 +1028,18 @@ Intended Audience :: Developers
 Intended Audience :: Information Technology
 Intended Audience :: Science/Research
 License :: OSI Approved :: BSD License
-Programming Language :: Python
-Programming Language :: Python :: 3
-Topic :: Database
-Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows
 Operating System :: Unix
+Programming Language :: Python
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3 :: Only
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Topic :: Database
+Topic :: Software Development :: Libraries :: Python Modules
 """
     setup(
         name=name,

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -600,7 +600,6 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         assert_array_equal(self.array.attrs['b'], data.T)
         assert_array_equal(self.array.attrs['c'], data.T)  # AssertionError!
 
-    @unittest.skipIf(sys.version_info[0] < 3, "Special method `__dir__()` introduced in Python-3.")
     def test12_dir(self):
         """Checking AttributeSet.__dir__"""
 
@@ -1711,8 +1710,6 @@ class CompatibilityTestCase(common.TestFileMixin, TestCase):
 class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, TestCase):
     h5fname = test_filename('issue_560.h5')
 
-    @unittest.skipIf(sys.version_info[0] == 3 and sys.version_info[1] < 4,
-                     'bug not fixed on python3<=3.3.')
     def test_pickled_datetime_object(self):
         # See also gh-560
         #

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1364,8 +1364,7 @@ class CheckFileTestCase(common.TempFileMixin, TestCase):
                     ui.copy(self.h5file.root, "newui")
 
 
-@unittest.skipIf((os.name == 'nt' and sys.version_info < (3,))
-                  or tables.file._FILE_OPEN_POLICY == 'strict',
+@unittest.skipIf(tables.file._FILE_OPEN_POLICY == 'strict',
                  'FILE_OPEN_POLICY = "strict"')
 class ThreadingTestCase(common.TempFileMixin, TestCase):
     def setUp(self):


### PR DESCRIPTION
I assume the lowest supported Python version is 3.5.

Declare the support for 3.5–3.9 in PyPI classifiers, add badges to `README.rst` (the new classifiers will appear only after the next release) and fix the test for the lowest supported version in `setup.py`.

Add 3.5 to the GitHub CI as well.

Also remove some further pre-Python3.5 hacks from the code.