### PR TITLE
Doc code and typos

### DIFF
--- a/doc/scripts/filenode.py
+++ b/doc/scripts/filenode.py
@@ -1,17 +1,13 @@
 # Copy this file into the clipboard and paste into 'script -c python'.
 
+import tables
 from tables.nodes import FileNode
 
-
-import tables
 h5file = tables.open_file('fnode.h5', 'w')
-
 
 fnode = FileNode.new_node(h5file, where='/', name='fnode_test')
 
-
 print(h5file.getAttrNode('/fnode_test', 'NODE_TYPE'))
-
 
 print("This is a test text line.", file=fnode)
 print("And this is another one.", file=fnode)
@@ -23,10 +19,8 @@ fnode.seek(0)  # Go back to the beginning of file.
 for line in fnode:
     print(repr(line))
 
-
 fnode.close()
 print(fnode.closed)
-
 
 node = h5file.root.fnode_test
 fnode = FileNode.open_node(node, 'a+')
@@ -35,14 +29,11 @@ print(fnode.tell())
 print("This is a new line.", file=fnode)
 print(repr(fnode.readline()))
 
-
 fnode.seek(0)
 for line in fnode:
     print(repr(line))
 
-
 fnode.attrs.content_type = 'text/plain; charset=us-ascii'
-
 
 fnode.attrs.author = "Ivan Vilata i Balaguer"
 fnode.attrs.creation_date = '2004-10-20T13:25:25+0200'
@@ -50,7 +41,6 @@ fnode.attrs.keywords_en = ["FileNode", "test", "metadata"]
 fnode.attrs.keywords_ca = ["FileNode", "prova", "metadades"]
 fnode.attrs.owner = 'ivan'
 fnode.attrs.acl = {'ivan': 'rw', '@users': 'r'}
-
 
 fnode.close()
 h5file.close()

--- a/doc/scripts/pickletrouble.py
+++ b/doc/scripts/pickletrouble.py
@@ -4,24 +4,24 @@ import tables
 class MyClass:
     foo = 'bar'
 
+
 # An object of my custom class.
 myObject = MyClass()
 
-h5f = tables.open_file('test.h5', 'w')
-h5f.root._v_attrs.obj = myObject  # store the object
-print(h5f.root._v_attrs.obj.foo)  # retrieve it
-h5f.close()
+with tables.open_file('test.h5', 'w') as h5f:
+    h5f.root._v_attrs.obj = myObject  # store the object
+    print(h5f.root._v_attrs.obj.foo)  # retrieve it
 
 # Delete class of stored object and reopen the file.
 del MyClass, myObject
 
-h5f = tables.open_file('test.h5', 'r')
-print(h5f.root._v_attrs.obj.foo)
-# Let us inspect the object to see what is happening.
-print(repr(h5f.root._v_attrs.obj))
-# Maybe unpickling the string will yield more information:
-import pickle
-pickle.loads(h5f.root._v_attrs.obj)
-# So the problem was not in the stored object,
-# but in the *environment* where it was restored.
-h5f.close()
+with tables.open_file('test.h5', 'r') as h5f:
+    print(h5f.root._v_attrs.obj.foo)
+    # Let us inspect the object to see what is happening.
+    print(repr(h5f.root._v_attrs.obj))
+    # Maybe unpickling the string will yield more information:
+    import pickle
+
+    pickle.loads(h5f.root._v_attrs.obj)
+    # So the problem was not in the stored object,
+    # but in the *environment* where it was restored.

--- a/doc/scripts/tutorial1.py
+++ b/doc/scripts/tutorial1.py
@@ -5,8 +5,8 @@ with any HDF5 generic utility.
 
 """
 
-
 import os
+import sys
 import traceback
 
 SECTION = "I HAVE NO TITLE"
@@ -32,32 +32,31 @@ def tutexc():
 
 
 SECTION = "Importing tables objects"
-from numpy import *
-from tables import *
-
+import numpy as np
+import tables as tb
 
 SECTION = "Declaring a Column Descriptor"
+
+
 # Define a user record to characterize some kind of particles
-class Particle(IsDescription):
-    name      = StringCol(16)   # 16-character String
-    idnumber  = Int64Col()      # Signed 64-bit integer
-    ADCcount  = UInt16Col()     # Unsigned short integer
-    TDCcount  = UInt8Col()      # unsigned byte
-    grid_i    = Int32Col()      # integer
-    grid_j    = IntCol()        # integer (equivalent to Int32Col)
-    pressure  = Float32Col()    # float  (single-precision)
-    energy    = FloatCol()      # double (double-precision)
+class Particle(tb.IsDescription):
+    name = tb.StringCol(16)  # 16-character String
+    idnumber = tb.Int64Col()  # Signed 64-bit integer
+    ADCcount = tb.UInt16Col()  # Unsigned short integer
+    TDCcount = tb.UInt8Col()  # unsigned byte
+    grid_i = tb.Int32Col()  # integer
+    grid_j = tb.IntCol()  # integer (equivalent to Int32Col)
+    pressure = tb.Float32Col()  # float  (single-precision)
+    energy = tb.FloatCol()  # double (double-precision)
 
 
 SECTION = "Creating a PyTables file from scratch"
 # Open a file in "w"rite mode
-h5file = open_file('tutorial1.h5', mode="w", title="Test file")
-
+h5file = tb.open_file('tutorial1.h5', mode="w", title="Test file")
 
 SECTION = "Creating a new group"
 # Create a new group under "/" (root)
 group = h5file.create_group("/", 'detector', 'Detector information')
-
 
 SECTION = "Creating a new table"
 # Create one table on it
@@ -71,12 +70,12 @@ particle = table.row
 
 # Fill the table with 10 particles
 for i in range(10):
-    particle['name'] = 'Particle: %6d' % (i)
+    particle['name'] = f'Particle: {i:6d}'
     particle['TDCcount'] = i % 256
     particle['ADCcount'] = (i * 256) % (1 << 16)
     particle['grid_i'] = i
     particle['grid_j'] = 10 - i
-    particle['pressure'] = float(i*i)
+    particle['pressure'] = float(i * i)
     particle['energy'] = float(particle['pressure'] ** 4)
     particle['idnumber'] = i * (2 ** 34)
     # Insert a new particle record
@@ -85,13 +84,13 @@ for i in range(10):
 # Flush the buffers for table
 table.flush()
 
-
 SECTION = "Reading (and selecting) data in a table"
 # Read actual data from table. We are interested in collecting pressure values
 # on entries where TDCcount field is greater than 3 and pressure less than 50
 table = h5file.root.detector.readout
 pressure = [
-    x['pressure'] for x in table
+    x['pressure']
+    for x in table
     if x['TDCcount'] > 3 and 20 <= x['pressure'] < 50
 ]
 
@@ -99,19 +98,19 @@ tutrepr(pressure)
 
 # Read also the names with the same cuts
 names = [
-    x['name'] for x in table
+    x['name']
+    for x in table
     if x['TDCcount'] > 3 and 20 <= x['pressure'] < 50
 ]
 
 tutrepr(names)
 
-
 SECTION = "Creating new array objects"
 gcolumns = h5file.create_group(h5file.root, "columns", "Pressure and Name")
 
 tutrepr(
-    h5file.create_array(gcolumns, 'pressure', array(pressure),
-                       "Pressure column selection")
+    h5file.create_array(gcolumns, 'pressure', np.array(pressure),
+                        "Pressure column selection")
 )
 
 tutrepr(
@@ -119,7 +118,6 @@ tutrepr(
 )
 
 tutprint(h5file)
-
 
 SECTION = "Closing the file and looking at its content"
 # Close the file
@@ -130,7 +128,6 @@ os.system('h5ls -rd tutorial1.h5')
 tutsep()
 os.system('ptdump tutorial1.h5')
 
-
 """This example shows how to browse the object tree and enlarge tables.
 
 Before to run this program you need to execute first tutorial1-1.py
@@ -138,10 +135,9 @@ that create the tutorial1.h5 file needed here.
 
 """
 
-
 SECTION = "Traversing the object tree"
 # Reopen the file in append mode
-h5file = open_file("tutorial1.h5", "a")
+h5file = tb.open_file("tutorial1.h5", "a")
 
 # Print the object tree created from this filename
 # List all the nodes (Group and Leaf objects) on tree
@@ -173,7 +169,6 @@ for array in h5file.walk_nodes("/", "Array"):
 tutsep()
 for leaf in h5file.root.detector('Leaf'):
     print(leaf)
-
 
 SECTION = "Setting and getting user attributes"
 # Get a pointer to '/detector/readout'
@@ -223,7 +218,6 @@ h5file.flush()
 tutsep()
 os.system('h5ls -vr tutorial1.h5/detector/readout')
 
-
 SECTION = "Getting object metadata"
 # Get metadata from table
 tutsep()
@@ -238,7 +232,7 @@ tutsep()
 print("Table variable names with their type and shape:")
 tutsep()
 for name in table.colnames:
-    print(name, ':= {}, {}'.format(table.coltypes[name], table.colshapes[name]))
+    print(f'{name}:= {table.coltypes[name]}, {table.colshapes[name]}')
 
 tutprint(table.__doc__)
 
@@ -247,34 +241,32 @@ pressureObject = h5file.get_node("/columns", "pressure")
 
 # Get some metadata on this object
 tutsep()
-print("Info on the object:", repr(pressureObject))
+print(f"Info on the object: {pressureObject!r}")
 tutsep()
-print(" shape: ==>", pressureObject.shape)
+print(f" shape: ==> {pressureObject.shape}")
 tutsep()
-print(" title: ==>", pressureObject.title)
+print(f" title: ==> {pressureObject.title}")
 tutsep()
-print(" type: ==>", pressureObject.type)
-
+print(f" type: ==> {pressureObject.type}")
 
 SECTION = "Reading data from Array objects"
 # Read the 'pressure' actual data
 pressureArray = pressureObject.read()
 tutrepr(pressureArray)
 tutsep()
-print("pressureArray is an object of type:", type(pressureArray))
+print(f"pressureArray is an object of type: {type(pressureArray)}")
 
 # Read the 'name' Array actual data
 nameArray = h5file.root.columns.name.read()
 tutrepr(nameArray)
-print("nameArray is an object of type:", type(nameArray))
+print(f"nameArray is an object of type: {type(nameArray)}")
 
 # Print the data for both arrays
 tutprint("Data on arrays nameArray and pressureArray:")
 tutsep()
 for i in range(pressureObject.shape[0]):
-    print(nameArray[i], "-->", pressureArray[i])
+    print(f"{nameArray[i]} --> {pressureArray[i]}")
 tutrepr(pressureObject.name)
-
 
 SECTION = "Appending data to an existing table"
 # Create a shortcut to table object
@@ -284,12 +276,12 @@ particle = table.row
 
 # Append 5 new particles to table
 for i in range(10, 15):
-    particle['name'] = 'Particle: %6d' % (i)
+    particle['name'] = f'Particle: {i:6d}'
     particle['TDCcount'] = i % 256
     particle['ADCcount'] = (i * 256) % (1 << 16)
     particle['grid_i'] = i
     particle['grid_j'] = 10 - i
-    particle['pressure'] = float(i*i)
+    particle['pressure'] = float(i * i)
     particle['energy'] = float(particle['pressure'] ** 4)
     particle['idnumber'] = i * (2 ** 34)  # This exceeds long integer range
     particle.append()
@@ -300,9 +292,8 @@ table.flush()
 # Print the data using the table iterator:
 tutsep()
 for r in table:
-    print("%-16s | %11.1f | %11.4g | %6d | %6d | %8d |" % \
-          (r['name'], r['pressure'], r['energy'], r['grid_i'], r['grid_j'],
-           r['TDCcount']))
+    print(f"{r['name']:<16s} | {r['pressure']:11.1f} | {r['energy']:11.4g} | "
+          f"{r['grid_i']:6d} | {r['grid_j']:6d} | {r['TDCcount']:8d} |")
 
 # Delete some rows on the Table (yes, rows can be removed!)
 tutrepr(table.remove_rows(5, 10))

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -48,7 +48,7 @@ that can reproduce it.
 Hopefully, someone on the list will be able to help you.
 It is also a good idea to check out the `archives of the user's list`_ (you may
 want to check the `Gmane archives`_ instead) so as to see if the answer to your
-question has already been dealed with.
+question has already been dealt with.
 
 
 Why HDF5?

--- a/doc/source/MIGRATING_TO_2.x.rst
+++ b/doc/source/MIGRATING_TO_2.x.rst
@@ -59,7 +59,7 @@ Important changes in ``Atom`` specification
 - ``vlstring`` pseudo-atoms used in ``VLArray`` nodes do no longer imply UTF-8
   (nor any other) encoding, they only store and load *raw strings of bytes*.
   All encoding and decoding is left to the user.  Be warned that reading old
-  files may yield raw UTF-8 encoded strings, which may be coverted back to
+  files may yield raw UTF-8 encoded strings, which may be converted back to
   Unicode in this way::
 
       unistr = vlarray[index].decode('utf-8')
@@ -105,7 +105,7 @@ New indexing system
 
 The indexing system has been totally rewritten from scratch for PyTables 2.0
 Pro Edition (http://www.pytables.com/moin/PyTablesPro).  The new indexing
-systemsame has been included into PyTables with release 2.3.  Due to this,
+system has been included into PyTables with release 2.3.  Due to this,
 your existing indexes created with PyTables 1.x will be useless, and although
 you will be able to continue using the actual data in files, you won't be
 able to take advantage of any improvement in speed.

--- a/doc/source/MIGRATING_TO_3.x.rst
+++ b/doc/source/MIGRATING_TO_3.x.rst
@@ -90,7 +90,7 @@ method. By using regexes, ``pt2to3`` works on Python and Cython code.
       -o OUTPUT             output file to write to.
       -i, --inplace         overwrites the file in-place.
 
-Note that ``pt2to3`` only works on a single file, not a a directory.  However,
+Note that ``pt2to3`` only works on a single file, not a directory.  However,
 a simple BASH script may be written to run ``pt2to3`` over an entire directory
 and all sub-directories:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'PyTables'
-copyright = '2011-2019, PyTables maintainers'
+copyright = '2011–2020, PyTables maintainers'
 author = 'PyTables maintainers'
 
 # The short X.Y version

--- a/doc/source/cookbook/hints_for_sql_users.rst
+++ b/doc/source/cookbook/hints_for_sql_users.rst
@@ -76,7 +76,7 @@ Creating a table
 ================
 
 PyTables supports some other *datasets* besides tables, and they're not
-arranged in a flat namespace, but rather into a *hierarchicalé one (see an
+arranged in a flat namespace, but rather into a *hierarchical* one (see an
 introduction to the _ref:`object tree <ObjectTreeSection>`);
 however, due to the nature of these recipes, we'll limit ourselves to tables
 in the *root group*.
@@ -102,26 +102,26 @@ This is specially useful for creating temporary tables holding query results.
 You can create a table description using a dictionary::
 
     description_name = {
-        'column_name1': colum_type1,
-        'column_name2': colum_type2,
-        'column_name3': colum_type3,
+        'column_name1': column_type1,
+        'column_name2': column_type2,
+        'column_name3': column_type3,
         ...
-        'column_nameN': colum_typeN
+        'column_nameN': column_typeN
     }
 
 or a subclass of :class:`tables.IsDescription`::
 
     class description_name(tables.IsDescription):
-        column_name1 = colum_type1
-        column_name2 = colum_type2
-        column_name3 = colum_type3
+        column_name1 = column_type1
+        column_name2 = column_type2
+        column_name3 = column_type3
         ...
-        column_nameN = colum_typeN
+        column_nameN = column_typeN
 
 Please note that dictionaries are the only way of describing structures with
 names which cannot be Python identifiers.
-Also, if an explicit order is desired for colums, it must be specified through
-the column type declarations (see below), since dictionariy keys and class
+Also, if an explicit order is desired for columns, it must be specified through
+the column type declarations (see below), since dictionary keys and class
 attributes aren't ordered.
 Otherwise, columns are ordered in alphabetic increasing order.
 It is important to note that PyTables doesn't have a concept of primary or
@@ -219,11 +219,11 @@ method (:meth:`tables.Column.create_index`) of a :class:`tables.Column` object
 of a table, which you can access trough its ``cols`` accessor.
 
 ::
-    tbl.cols.colum_name.create_index()
+    tbl.cols.column_name.create_index()
 
 For dropping an index on a column::
 
-    tbl.cols.colum_name.remove_index()
+    tbl.cols.column_name.remove_index()
 
 
 Altering a table
@@ -473,7 +473,7 @@ This is similar to using the ``fetchone()`` method of a DB ``cursor`` in a
 `Python DBAPI`_-compliant package, i.e. you *iterate* over the list of wanted
 rows, getting one *row handle* at a time.
 In this case, the handle is an instance of the :class:`tables.Row` class,
-which allows access to individual columns as items acessed by key (so there
+which allows access to individual columns as items accessed by key (so there
 is no special way of selecting columns: you just use the ones you want
 whenever you want).
 

--- a/doc/source/cookbook/no_root_install.rst
+++ b/doc/source/cookbook/no_root_install.rst
@@ -12,7 +12,7 @@ Installing PyTables when you're not root
 
 By `Koen van de Sande <http://www.tibed.net>`_.
 
-.. warning:: contents of this recipe recipe may be outdated.
+.. warning:: contents of this recipe may be outdated.
 
 This guide describes how to install PyTables and its dependencies on Linux or
 other \*nix systems when your user account is not root.

--- a/doc/source/cookbook/py2exe_howto/pytables_test.py
+++ b/doc/source/cookbook/py2exe_howto/pytables_test.py
@@ -1,41 +1,42 @@
-from tables import *
-import numarray
+import tables as tb
 
-class Particle(IsDescription):
-    name = StringCol(16) # 16-character String
-    idnumber = Int64Col() # Signed 64-bit integer
-    ADCcount = UInt16Col() # Unsigned short integer
-    TDCcount = UInt8Col() # Unsigned byte
-    grid_i = Int32Col() # Integer
-    grid_j = IntCol() # Integer (equivalent to Int32Col)
-    pressure = Float32Col() # Float (single-precision)
-    energy = FloatCol() # Double (double-precision)
 
-h5file = openFile("tutorial.h5", mode="w", title="Test file")
-group = h5file.createGroup("/", "detector", "Detector information")
-table = h5file.createTable(group, "readout", Particle, "Readout example")
+class Particle(tb.IsDescription):
+    name = tb.StringCol(16)  # 16-character String
+    idnumber = tb.Int64Col()  # Signed 64-bit integer
+    ADCcount = tb.UInt16Col()  # Unsigned short integer
+    TDCcount = tb.UInt8Col()  # Unsigned byte
+    grid_i = tb.Int32Col()  # Integer
+    grid_j = tb.IntCol()  # Integer (equivalent to Int32Col)
+    pressure = tb.Float32Col()  # Float (single-precision)
+    energy = tb.FloatCol()  # Double (double-precision)
 
-print(h5file)
 
-particle = table.row
+with tb.open_file("tutorial.h5", mode="w", title="Test file") as h5file:
+    group = h5file.create_group("/", "detector", "Detector information")
+    table = h5file.create_table(group, "readout", Particle, "Readout example")
 
-for i in xrange(10):
-    particle['name'] = 'Particle: %6d' % i
-    particle['TDCcount'] = i % 256
-    particle['ADCcount'] = (i*256) % (1<<16)
-    particle['grid_i'] = i
-    particle['grid_j'] = 10 - i
-    particle['pressure'] = float(i*i)
-    particle['energy'] = float(particle['pressure']**4)
-    particle['idnumber'] = i * (2**34)
-    particle.append()
+    print(h5file)
 
-table.flush()
+    particle = table.row
 
-table = h5file.root.detector.readout
-pressure = [x['pressure'] for x in table.iterrows() if x['TDCcount']>3 and
-                                                       20<=x['pressure']<50]
+    for i in range(10):
+        particle['name'] = f'Particle: {i:6d}'
+        particle['TDCcount'] = i % 256
+        particle['ADCcount'] = (i * 256) % (1 << 16)
+        particle['grid_i'] = i
+        particle['grid_j'] = 10 - i
+        particle['pressure'] = float(i * i)
+        particle['energy'] = float(particle['pressure'] ** 4)
+        particle['idnumber'] = i * (2 ** 34)
+        particle.append()
 
-print(pressure)
+    table.flush()
 
-h5file.close()
+with tb.open_file("tutorial.h5", mode="r", title="Test file") as h5file:
+    table = h5file.root.detector.readout
+    pressure = [x['pressure']
+                for x in table.iterrows()
+                if x['TDCcount'] > 3 and 20 <= x['pressure'] < 50]
+
+    print(pressure)

--- a/doc/source/other_material.rst
+++ b/doc/source/other_material.rst
@@ -10,7 +10,7 @@ PyTables in a visual and easy to grasp manner.
 More videos will be made available with the time:
 
 * `HDF5 is for Lovers, SciPy 2012 Tutorial <http://www.youtube.com/watch?v=Nzx0HAd3FiI>`_:
-  a beginer's introduction to PyTables and HDF5.
+  a beginner's introduction to PyTables and HDF5.
 * `PyTables, part I: Introduction
   <http://showmedo.com/videos/video?name=1780000&fromSeriesID=178>`_:
   HDF5 file creation, the object tree, homogeneous array storage, natural

--- a/doc/source/release-notes/RELEASE_NOTES_v0.8.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v0.8.rst
@@ -6,7 +6,7 @@ been fixed. Here is the (non-exhaustive) list:
 
 - The new VLArray class enables you to store large lists of rows
   containing variable numbers of elements. The elements can
-  be scalars or fully multimensional objects, in the PyTables
+  be scalars or fully multidimensional objects, in the PyTables
   tradition. This class supports two special objects as rows:
   Unicode strings (UTF-8 codification is used internally) and
   generic Python objects (through the use of cPickle).

--- a/doc/source/release-notes/RELEASE_NOTES_v0.9.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v0.9.rst
@@ -12,14 +12,14 @@ New features:
 
 - Indexing of columns in tables. That allow to make data selections on
   tables up to 500 times faster than standard selections (for
-  ex. doing a selection along an indexed column of 100 milion of rows
+  ex. doing a selection along an indexed column of 100 million of rows
   takes less than 1 second on a modern CPU). Perhaps the most
   interesting thing about the indexing algorithm implemented by
-  PyTables is that the time taken to index grows *lineraly* with the
+  PyTables is that the time taken to index grows *linearly* with the
   length of the data, so, making the indexation process to be
   *scalable* (quite differently to many relational databases). This
   means that it can index, in a relatively quick way, arbitrarily
-  large table columns (for ex. indexing a column of 100 milion of rows
+  large table columns (for ex. indexing a column of 100 million of rows
   takes just 100 seconds, i.e. at a rate of 1 Mrow/sec). See more
   detailed info about that in http://www.pytables.org/docs/SciPy04.pdf.
 
@@ -38,7 +38,7 @@ New features:
   well as updating the User's Manual and adding unit tests for the new
   functionality.
 
-- Modification of values. You can modifiy Table, Array, EArray and
+- Modification of values. You can modify Table, Array, EArray and
   VLArray values. See Table.modifyRows, Table.modifyColumns() and the
   newly introduced __setitem__() method for Table, Array, EArray and
   VLArray entities in the Library Reference of User's Manual.

--- a/doc/source/release-notes/RELEASE_NOTES_v1.0.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v1.0.rst
@@ -24,7 +24,7 @@ API additions
 - The new ``Table.readCoordinates()`` method reads a set of rows given their
   indexes into an in-memory object.
 
-- The new ``Table.readAppend()`` method Append rows fullfilling the condition
+- The new ``Table.readAppend()`` method Append rows fulfilling the condition
   to a destination table.
 
 Backward-incompatible changes

--- a/doc/source/release-notes/RELEASE_NOTES_v2.0.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.0.x.rst
@@ -75,7 +75,7 @@ Changes from 2.0.1 to 2.0.2
 - Return 0 when no rows are given to ``Table.modifyRows()``; fixes #128.
 
 - Added an informative message when the ``nctoh5`` utility is run without the
-  NetCDF interface of ScientificPython bening installed.
+  NetCDF interface of ScientificPython being installed.
 
 - Now, a default representation of closed nodes is provided; fixes #129.
 

--- a/doc/source/release-notes/RELEASE_NOTES_v2.1.x-pro.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.1.x-pro.rst
@@ -37,7 +37,7 @@ Other changes
 -------------
 
 - When retrieving a row of a 1-dimensional array, a 0-dim array was
-  returned instead of a numpy scalar.  Now, an actuall numpy scalar is
+  returned instead of a numpy scalar.  Now, an actual numpy scalar is
   returned.  Closes #222.
 
 - LZO and bzip2 filters adapted to an API fix introduced in HDF5

--- a/doc/source/release-notes/RELEASE_NOTES_v2.1.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.1.x.rst
@@ -37,7 +37,7 @@ Other changes
 -------------
 
 - When retrieving a row of a 1-dimensional array, a 0-dim array was
-  returned instead of a numpy scalar.  Now, an actuall numpy scalar is
+  returned instead of a numpy scalar.  Now, an actual numpy scalar is
   returned.  Closes #222.
 
 - LZO and bzip2 filters adapted to an API fix introduced in HDF5

--- a/doc/source/release-notes/RELEASE_NOTES_v2.2.x-pro.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.2.x-pro.rst
@@ -73,7 +73,7 @@ Changes from 2.2 to 2.2.1rc1
 
 - Column names in tables can start with '__' now.  Closes #291.
 
-- Unicode empty strings are supported now as atributes.  Addresses #307.
+- Unicode empty strings are supported now as attributes.  Addresses #307.
 
 - Cython 0.13 and higher is supported now.  Fixes #293.
 
@@ -196,9 +196,9 @@ Changes from 2.2b3 to 2.2rc1
   if arrays were not contiguous, incorrect data was saved in attr.
   Fixes #270.
 
-- EXTDIM attribute for CArray/EArray now saves the correct extendeable
+- EXTDIM attribute for CArray/EArray now saves the correct extendable
   dimension, instead of rubbish.  This does not affected functionality,
-  because extendeable dimension was retrieved directly from shape
+  because extendable dimension was retrieved directly from shape
   information, but it was providing misleading information to the user.
   Fixes #268.
 
@@ -218,7 +218,7 @@ Changes from 2.2b2 to 2.2b3
   fast compression and extremely fast decompression.  Fixes #265.
 
 - In `File.copyFile()` method, `copyuserattrs` was set to false as
-  default.  This was unconsistent with other methods where the default
+  default.  This was inconsistent with other methods where the default
   value for `copyuserattrs` is true.  The default for this is true now.
   Closes #261.
 
@@ -228,7 +228,7 @@ Changes from 2.2b2 to 2.2b3
 - Backported fix for issue #25 in Numexpr (OP_NEG_LL treats the argument
   as an int, not a long long).  Thanks to David Cooke for this.
 
-- CHUNK_CACHE_NELMTS in `tables/paramters.py` set to a prime number as
+- CHUNK_CACHE_NELMTS in `tables/parameters.py` set to a prime number as
   Neil Fortner suggested.
 
 - Workaround for a problem in Python 2.6.4 (and probably other versions

--- a/doc/source/release-notes/RELEASE_NOTES_v2.2.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.2.x.rst
@@ -63,7 +63,7 @@ Changes from 2.2 to 2.2.1rc1
 
 - Column names in tables can start with '__' now.  Closes #291.
 
-- Unicode empty strings are supported now as atributes.  Addresses #307.
+- Unicode empty strings are supported now as attributes.  Addresses #307.
 
 - Cython 0.13 and higher is supported now.  Fixes #293.
 
@@ -186,9 +186,9 @@ Changes from 2.2b3 to 2.2rc1
   if arrays were not contiguous, incorrect data was saved in attr.
   Fixes #270.
 
-- EXTDIM attribute for CArray/EArray now saves the correct extendeable
+- EXTDIM attribute for CArray/EArray now saves the correct extendable
   dimension, instead of rubbish.  This does not affected functionality,
-  because extendeable dimension was retrieved directly from shape
+  because extendable dimension was retrieved directly from shape
   information, but it was providing misleading information to the user.
   Fixes #268.
 
@@ -208,7 +208,7 @@ Changes from 2.2b2 to 2.2b3
   fast compression and extremely fast decompression.  Fixes #265.
 
 - In `File.copyFile()` method, `copyuserattrs` was set to false as
-  default.  This was unconsistent with other methods where the default
+  default.  This was inconsistent with other methods where the default
   value for `copyuserattrs` is true.  The default for this is true now.
   Closes #261.
 
@@ -218,7 +218,7 @@ Changes from 2.2b2 to 2.2b3
 - Backported fix for issue #25 in Numexpr (OP_NEG_LL treats the argument
   as an int, not a long long).  Thanks to David Cooke for this.
 
-- CHUNK_CACHE_NELMTS in `tables/paramters.py` set to a prime number as
+- CHUNK_CACHE_NELMTS in `tables/parameters.py` set to a prime number as
   Neil Fortner suggested.
 
 - Workaround for a problem in Python 2.6.4 (and probably other versions

--- a/doc/source/release-notes/RELEASE_NOTES_v2.4.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v2.4.x.rst
@@ -86,7 +86,7 @@ Other improvements
 Documentation improvements
 --------------------------
 
-- new coockbook section (contents have been coming from the PyTables wiki
+- new cookbook section (contents have been coming from the PyTables wiki
   on http://www.pytables.org)
 
 - complete rework of the library reference.  Now the entire chapter is

--- a/doc/source/release-notes/RELEASE_NOTES_v3.0.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v3.0.x.rst
@@ -268,7 +268,7 @@ Bugs fixed
   selection from a Tables. Thanks to Jeff Reback.
 
 - Fixed ``tables.tests.test_nestedtypes.ColsTestCase.test_00a_repr`` test
-  method.  Now the ``repr`` of of cols on big-endian platforms is correctly
+  method.  Now the ``repr`` of cols on big-endian platforms is correctly
   handled  (closes :issue:`237`).
 
 - Fixes bug with completely sorted indexes where *nrowsinbuf* must be equal

--- a/doc/source/release-notes/RELEASE_NOTES_v3.2.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v3.2.x.rst
@@ -68,7 +68,7 @@ Bug fixed
 - Fix issues with Cython 0.23. See :issue:`481`.
 - Only run `tables.tests.test_basics.UnicodeFilename` if the filesystem
   encoding is utf-8. Closes :issue:`485`.
-- Fix missing missing PyErr_Clear. See :issue:`#486`.
+- Fix missing PyErr_Clear. See :issue:`#486`.
 - Fix the C type of some numpy attributes. See :issue:`494`.
 - Cast selection indices to integer. See :issue:`496`.
 - Fix indexesextension._keysort_string. Closes :issue:`497` and :issue:`498`.

--- a/doc/source/release-notes/RELEASE_NOTES_v3.5.x.rst
+++ b/doc/source/release-notes/RELEASE_NOTES_v3.5.x.rst
@@ -11,9 +11,9 @@
 Changes from 3.5.1 to 3.5.2
 ===========================
 
-- Fixed compatibility with python 3.8: Fixed `Dictonary keys changed during
-  iteration` RuntimeError while moving/renameing a node.
-  Thanks to Christoph Gohlke for reporting and Miro Hroncok for help with
+- Fixed compatibility with python 3.8: Fixed `Dictionary keys changed during
+  iteration` RuntimeError while moving/renaming a node.
+  Thanks to Christoph Gohlke for reporting and Miro Hrončok for help with
   building PyTables for python 3.8alpha (cython compatibility).
   see :issue:`733` and PR #737.
 - Fixed a bug in offset calculations producing floats instead of ints

--- a/doc/source/usersguide/index.rst
+++ b/doc/source/usersguide/index.rst
@@ -13,7 +13,7 @@ Hierarchical datasets in Python
 
             |copy| 2008, 2009, 2010 - Francesc Alted
 
-            |copy| 2011-2018 - PyTables maintainers
+            |copy| 2011–2020 - PyTables maintainers
 
 --------
 Contents

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -176,8 +176,8 @@ worry too much ;)
 
     The HDF5 libraries and other helper packages are automatically found in
     a conda environment. During installation setup.py uses the `CONDA_PREFIX`
-    environment variable to detect a conda enviroment. If detected it will
-    try to find all packages within this enviroment. PyTables needs at least
+    environment variable to detect a conda environment. If detected it will
+    try to find all packages within this environment. PyTables needs at least
     the hdf5 package::
 
         conda install hdf5
@@ -188,7 +188,7 @@ worry too much ;)
     :envvar:`BLOSC_DIR` environment variables.
 
     When inside a conda environment *pkg-config* will not work. To disable
-    using the conda enviroment and fall back to *pkg-config* use `--no-conda`::
+    using the conda environment and fall back to *pkg-config* use `--no-conda`::
 
           python3 setup.py install --no-conda
 
@@ -419,7 +419,7 @@ following::
 
   $ python3 -m pip install git+https://github.com/PyTables/PyTables.git@develop#egg=tables
 
-A similar command can be used to install a specific tagged fersion::
+A similar command can be used to install a specific tagged version::
 
   $ python3 -m pip install git+https://github.com/PyTables/PyTables.git@v.2.4.0#egg=tables
 
@@ -442,7 +442,7 @@ libraries have to be installed by the user.
    PyTables >= 3.2 natively supports the new layout via *pkg-config* (that
    is expected to be installed on the system at build time).
 
-   If *pkg-config* is not available or PyTables is older that verison 3.2,
+   If *pkg-config* is not available or PyTables is older than version 3.2,
    then the following command can be used::
 
      $ env CPPFLAGS=-I/usr/include/hdf5/serial \

--- a/doc/source/usersguide/introduction.rst
+++ b/doc/source/usersguide/introduction.rst
@@ -223,15 +223,15 @@ To better understand the dynamic nature of this object tree entity, let's
 start with a sample PyTables script (which you can find in
 examples/objecttree.py) to create an HDF5 file::
 
-    from tables import *
+    import tables as tb
 
-    class Particle(IsDescription):
-        identity = StringCol(itemsize=22, dflt=" ", pos=0)  # character String
-        idnumber = Int16Col(dflt=1, pos = 1)  # short integer
-        speed    = Float32Col(dflt=1, pos = 2)  # single-precision
+    class Particle(tb.IsDescription):
+        identity = tb.StringCol(itemsize=22, dflt=" ", pos=0)  # character String
+        idnumber = tb.Int16Col(dflt=1, pos = 1)  # short integer
+        speed    = tb.Float32Col(dflt=1, pos = 2)  # single-precision
 
     # Open a file in "w"rite mode
-    fileh = open_file("objecttree.h5", mode = "w")
+    fileh = tb.open_file("objecttree.h5", mode = "w")
 
     # Get the HDF5 root group
     root = fileh.root
@@ -256,9 +256,9 @@ examples/objecttree.py) to create an HDF5 file::
         row = table.row
 
         # Fill the table with 10 records
-        for i in xrange(10):
+        for i in range(10):
             # First, assign the values to the Particle record
-            row['identity']  = 'This is particle: %2d' % (i)
+            row['identity']  = f'This is particle: {i:2d}'
             row['idnumber'] = i
             row['speed']  = i * 2.
 

--- a/doc/source/usersguide/libref/link_classes.rst
+++ b/doc/source/usersguide/libref/link_classes.rst
@@ -40,7 +40,7 @@ The SoftLink class
 
 SoftLink special methods
 ~~~~~~~~~~~~~~~~~~~~~~~~
-The following methods are specific for dereferrencing and representing soft
+The following methods are specific for dereferencing and representing soft
 links.
 
 .. automethod:: tables.link.SoftLink.__call__
@@ -65,7 +65,7 @@ ExternalLink methods
 
 ExternalLink special methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The following methods are specific for dereferrencing and representing
+The following methods are specific for dereferencing and representing
 external links.
 
 .. automethod:: tables.link.ExternalLink.__call__

--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -277,7 +277,7 @@ cuts::
     ['Particle:      5', 'Particle:      6', 'Particle:      7']
 
 In-kernel and indexed queries are not only much faster, but as you can see,
-they also look more compact, and are among the greatests features for
+they also look more compact, and are among the greatest features for
 PyTables, so be sure that you use them a lot. See :ref:`condition_syntax` and
 :ref:`searchOptim` for more information on in-kernel and indexed selections.
 
@@ -1675,7 +1675,7 @@ what's more, it is exactly the same object::
     >>> fileh.root.anarray is one
     True
 
-It was just moved to the the hidden group and back again, that's all!
+It was just moved to the hidden group and back again, that's all!
 That's kind of fun, so we are going to do the same with /anotherarray::
 
     >>> fileh.redo()
@@ -2179,7 +2179,7 @@ Accessing meta-information of nested tables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Tables have a *description* attribute, which returns an instance of
 the Description class (see :ref:`DescriptionClassDescr`) with table meta-data.
-It can be helpful in understanding the table structure, including nested colums::
+It can be helpful in understanding the table structure, including nested columns::
 
     >>> table.description
     {

--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -55,7 +55,7 @@ also need to import functions from the numpy package. So most PyTables
 programs begin with::
 
     >>> import tables   # but in this tutorial we use "from tables import \*"
-    >>> import numpy
+    >>> import numpy as np
 
 
 Declaring a Column Descriptor
@@ -205,8 +205,8 @@ actually an *extension class*), using the column names as keys.
 
 Below is an example of how to write rows::
 
-    >>> for i in xrange(10):
-    ...     particle['name']  = 'Particle: %6d' % (i)
+    >>> for i in range(10):
+    ...     particle['name']  = f'Particle: {i:6d}'
     ...     particle['TDCcount'] = i % 256
     ...     particle['ADCcount'] = (i * 256) % (1 << 16)
     ...     particle['grid_i'] = i
@@ -331,7 +331,7 @@ naming* (h5file.root) instead of with an absolute path string ("/").
 
 Now, create the first of the two Array objects we've just mentioned::
 
-    >>> h5file.create_array(gcolumns, 'pressure', numpy.array(pressure), "Pressure column selection")
+    >>> h5file.create_array(gcolumns, 'pressure', np.array(pressure), "Pressure column selection")
     /columns/pressure (Array(3,)) 'Pressure column selection'
       atom := Float64Atom(shape=(), dflt=0.0)
       maindim := 0
@@ -923,8 +923,8 @@ values to it::
 
     >>> table = h5file.root.detector.readout
     >>> particle = table.row
-    >>> for i in xrange(10, 15):
-    ...     particle['name']  = 'Particle: %6d' % (i)
+    >>> for i in range(10, 15):
+    ...     particle['name']  = f'Particle: {i:6d}'
     ...     particle['TDCcount'] = i % 256
     ...     particle['ADCcount'] = (i * 256) % (1 << 16)
     ...     particle['grid_i'] = i
@@ -1176,37 +1176,37 @@ dtype (or even as a dictionary), as you can see in the Event description. See
 :meth:`File.create_table` for different kinds of descriptor objects that
 can be passed to this method::
 
-    from tables import *
-    from numpy import *
+    import tables as tb
+    import numpy as np
 
     # Describe a particle record
-    class Particle(IsDescription):
-        name        = StringCol(itemsize=16)  # 16-character string
-        lati        = Int32Col()              # integer
-        longi       = Int32Col()              # integer
-        pressure    = Float32Col(shape=(2,3)) # array of floats (single-precision)
-        temperature = Float64Col(shape=(2,3)) # array of doubles (double-precision)
+    class Particle(tb.IsDescription):
+        name        = tb.StringCol(itemsize=16)  # 16-character string
+        lati        = tb.Int32Col()              # integer
+        longi       = tb.Int32Col()              # integer
+        pressure    = tb.Float32Col(shape=(2,3)) # array of floats (single-precision)
+        temperature = tb.Float64Col(shape=(2,3)) # array of doubles (double-precision)
 
     # Native NumPy dtype instances are also accepted
-    Event = dtype([
+    Event = np.dtype([
         ("name"     , "S16"),
-        ("TDCcount" , uint8),
-        ("ADCcount" , uint16),
-        ("xcoord"   , float32),
-        ("ycoord"   , float32)
+        ("TDCcount" , np.uint8),
+        ("ADCcount" , np.uint16),
+        ("xcoord"   , np.float32),
+        ("ycoord"   , np.float32)
         ])
 
     # And dictionaries too (this defines the same structure as above)
     # Event = {
-    #     "name"     : StringCol(itemsize=16),
-    #     "TDCcount" : UInt8Col(),
-    #     "ADCcount" : UInt16Col(),
-    #     "xcoord"   : Float32Col(),
-    #     "ycoord"   : Float32Col(),
+    #     "name"     : tb.StringCol(itemsize=16),
+    #     "TDCcount" : tb.UInt8Col(),
+    #     "ADCcount" : tb.UInt16Col(),
+    #     "xcoord"   : tb.Float32Col(),
+    #     "ycoord"   : tb.Float32Col(),
     #     }
 
     # Open a file in "w"rite mode
-    fileh = open_file("tutorial2.h5", mode = "w")
+    fileh = tb.open_file("tutorial2.h5", mode="w")
 
     # Get the HDF5 root group
     root = fileh.root
@@ -1227,18 +1227,18 @@ can be passed to this method::
         particle = table.row
 
         # Fill the table with 257 particles
-        for i in xrange(257):
+        for i in range(257):
             # First, assign the values to the Particle record
-            particle['name'] = 'Particle: %6d' % (i)
+            particle['name'] = f'Particle: {i:6d}'
             particle['lati'] = i
             particle['longi'] = 10 - i
 
             ########### Detectable errors start here. Play with them!
-            particle['pressure'] = array(i*arange(2*3)).reshape((2,4))  # Incorrect
-            #particle['pressure'] = array(i*arange(2*3)).reshape((2,3)) # Correct
+            particle['pressure'] = np.array(i * np.arange(2 * 3)).reshape((2, 4))  # Incorrect
+            #particle['pressure'] = np.array(i * np.arange(2 * 3)).reshape((2, 3)) # Correct
             ########### End of errors
 
-            particle['temperature'] = (i**2)     # Broadcasting
+            particle['temperature'] = i ** 2     # Broadcasting
 
             # This injects the Record values
             particle.append()
@@ -1255,19 +1255,19 @@ can be passed to this method::
         event = table.row
 
         # Fill the table with 257 events
-        for i in xrange(257):
+        for i in range(257):
             # First, assign the values to the Event record
-            event['name']  = 'Event: %6d' % (i)
+            event['name']  = f'Event: {i:6d}'
             event['TDCcount'] = i % (1<<8)   # Correct range
 
             ########### Detectable errors start here. Play with them!
-            event['xcoor'] = float(i**2)     # Wrong spelling
-            #event['xcoord'] = float(i**2)   # Correct spelling
+            event['xcoor'] = float(i ** 2)     # Wrong spelling
+            #event['xcoord'] = float(i ** 2)   # Correct spelling
             event['ADCcount'] = "sss"        # Wrong type
             #event['ADCcount'] = i * 2       # Correct type
             ########### End of errors
 
-            event['ycoord'] = float(i)**4
+            event['ycoord'] = float(i) ** 4
 
             # This injects the Record values
             event.append()
@@ -1278,9 +1278,9 @@ can be passed to this method::
     # Read the records from table "/Events/TEvent3" and select some
     table = root.Events.TEvent3
     e = [ p['TDCcount'] for p in table if p['ADCcount'] < 20 and 4 <= p['TDCcount'] < 15 ]
-    print("Last record ==>", p)
-    print("Selected values ==>", e)
-    print("Total selected records ==> ", len(e))
+    print(f"Last record ==> {p}")
+    print("Selected values ==> {e}")
+    print("Total selected records ==> {len(e)}")
 
     # Finally, close the file (this also will flush all the remaining buffers!)
     fileh.close()
@@ -1296,7 +1296,7 @@ get the following error.
     $ python3 tutorial2.py
     Traceback (most recent call last):
       File "tutorial2.py", line 60, in <module>
-        particle['pressure'] = array(i*arange(2*3)).reshape((2,4))  # Incorrect
+        particle['pressure'] = array(i * arange(2 * 3)).reshape((2, 4))  # Incorrect
     ValueError: total size of new array must be unchanged
     Closing remaining open files: tutorial2.h5... done
 
@@ -1310,7 +1310,7 @@ exception: when you assign a *scalar* value to a multidimensional column
 cell, all the cell elements are populated with the value of the scalar.
 For example::
 
-    particle['temperature'] = (i**2)    # Broadcasting
+    particle['temperature'] = i ** 2    # Broadcasting
 
 The value i**2 is assigned to all the elements of the temperature table cell.
 This capability is provided by the NumPy package and is known as
@@ -1327,7 +1327,7 @@ another error.
     $ python3 tutorial2.py
     Traceback (most recent call last):
       File "tutorial2.py", line 73, in ?
-        event['xcoor'] = float(i**2)     # Wrong spelling
+        event['xcoor'] = float(i ** 2)     # Wrong spelling
       File "tableextension.pyx", line 1094, in tableextension.Row.__setitem__
       File "tableextension.pyx", line 127, in tableextension.get_nested_field_cache
       File "utilsextension.pyx", line 331, in utilsextension.get_nested_field
@@ -1425,7 +1425,7 @@ where we will put our links and will start creating one hard link too::
 
     >>> gl = f1.create_group('/', 'gl')
     >>> ht = f1.create_hard_link(gl, 'ht', '/g1/g2/t1')  # ht points to t1
-    >>> print("``%s`` is a hard link to: ``%s``" % (ht, t1))
+    >>> print(f"``{ht}`` is a hard link to: ``{t1}``")
     ``/gl/ht (Table(0,)) `` is a hard link to: ``/g1/g2/t1 (Table(0,)) ``
 
 You can see how we've created a hard link in /gl/ht which is pointing to the
@@ -1436,16 +1436,16 @@ different paths to access that table, the original /g1/g2/t1 and the new one
 the new path::
 
     >>> t1.remove()
-    >>> print("table continues to be accessible in: ``%s``" % f1.get_node('/gl/ht'))
+    >>> print(f"table continues to be accessible in: ``{f1.get_node('/gl/ht')}``")
     table continues to be accessible in: ``/gl/ht (Table(0,)) ``
 
 So far so good. Now, let's create a couple of soft links::
 
     >>> la1 = f1.create_soft_link(gl, 'la1', '/g1/a1')  # la1 points to a1
-    >>> print("``%s`` is a soft link to: ``%s``" % (la1, la1.target))
+    >>> print(f"``{la1}`` is a soft link to: ``{la1.target}``")
     ``/gl/la1 (SoftLink) -> /g1/a1`` is a soft link to: ``/g1/a1``
     >>> lt = f1.create_soft_link(gl, 'lt', '/g1/g2/t1')  # lt points to t1
-    >>> print("``%s`` is a soft link to: ``%s``" % (lt, lt.target))
+    >>> print(f"``{lt}`` is a soft link to: ``{lt.target}``")
     ``/gl/lt (SoftLink) -> /g1/g2/t1 (dangling)`` is a soft link to: ``/g1/g2/t1``
 
 Okay, we see how the first link /gl/la1 points to the array /g1/a1.  Notice
@@ -1462,7 +1462,7 @@ node or not.
 So, let's re-create the removed path to t1 table::
 
     >>> t1 = f1.create_hard_link('/g1/g2', 't1', '/gl/ht')
-    >>> print("``%s`` is not dangling anymore" % (lt,))
+    >>> print(f"``{lt}`` is not dangling anymore")
     ``/gl/lt (SoftLink) -> /g1/g2/t1`` is not dangling anymore
 
 and the soft link is pointing to an existing node now.
@@ -1472,10 +1472,10 @@ the pointed node.  It happens that soft links are callable, and that's the
 way to get the referred nodes back::
 
     >>> plt = lt()
-    >>> print("dereferred lt node: ``%s``" % plt)
+    >>> print(f"dereferred lt node: ``{plt}``")
     dereferred lt node: ``/g1/g2/t1 (Table(0,)) ``
     >>> pla1 = la1()
-    >>> print("dereferred la1 node: ``%s``" % pla1)
+    >>> print(f"dereferred la1 node: ``{pla1}``")
     dereferred la1 node: ``/g1/a1 (CArray(10000,)) ``
 
 Now, plt is a Python reference to the t1 table while pla1 refers to the a1
@@ -1503,13 +1503,13 @@ its place::
 
     >>> la1.remove()
     >>> la1 = f1.create_external_link(gl, 'la1', 'links2.h5:/a1')
-    >>> print("``%s`` is an external link to: ``%s``" % (la1, la1.target))
+    >>> print(f"``{la1}`` is an external link to: ``{la1.target}``")
     ``/gl/la1 (ExternalLink) -> links2.h5:/a1`` is an external link to: ``links2.h5:/a1``
 
 Let's try dereferring it::
 
     >>> new_a1 = la1()  # dereferrencing la1 returns a1 in links2.h5
-    >>> print("dereferred la1 node:  ``%s``" % new_a1)
+    >>> print(f"dereferred la1 node:  ``{new_a1}``")
     dereferred la1 node:  ``/a1 (CArray(10000,)) ``
 
 Well, it seems like we can access the external node.  But just to make sure
@@ -1884,7 +1884,7 @@ See how accessing a value that is not in the enumeration raises the
 appropriate exception. We can also do the opposite and get the name
 that matches a concrete value by using the __call__() method of Enum::
 
-    >>> print("Name of value %s:" % colors.red, colors(colors.red))
+    >>> print(f"Name of value {colors.red}:", colors(colors.red))
     Name of value 0: red
     >>> print("Name of value 1234:", colors(1234))
     Name of value 1234:
@@ -2005,7 +2005,7 @@ enumerated values.
 Finally, we will print contents of the array::
 
     >>> for (d1, d2) in earr:
-    ...     print("From %s to %s (%d days)." % (wdays(d1), wdays(d2), d2-d1+1))
+    ...     print(f"From {wdays(d1) to {wdays(d2) ({d2 - d1 + 1} days).")
     From Mon to Fri (5 days).
     From Wed to Fri (3 days).
     Traceback (most recent call last):
@@ -2035,29 +2035,29 @@ nested subclasses of IsDescription. The benefit is the ability to group
 and retrieve data more easily. Example below may be a bit silly, but it will serve 
 as an illustration of the concept::
 
-    from tables import *
+    import tables as tb
 
-    class Info(IsDescription):
+    class Info(tb.IsDescription):
         """A sub-structure of NestedDescr"""
         _v_pos = 2   # The position in the whole structure
-        name = StringCol(10)
-        value = Float64Col(pos=0)
+        name = tb.StringCol(10)
+        value = tb.Float64Col(pos=0)
 
-    colors = Enum(['red', 'green', 'blue'])
+    colors = tb.Enum(['red', 'green', 'blue'])
 
-    class NestedDescr(IsDescription):
+    class NestedDescr(tb.IsDescription):
         """A description that has several nested columns"""
-        color = EnumCol(colors, 'red', base='uint32')
-        info1 = Info()
+        color = tb.EnumCol(colors, 'red', base='uint32')
+        info1 = tb.Info()
 
-        class info2(IsDescription):
+        class info2(tb.IsDescription):
             _v_pos = 1
-            name = StringCol(10)
-            value = Float64Col(pos=0)
+            name = tb.StringCol(10)
+            value = tb.Float64Col(pos=0)
 
-            class info3(IsDescription):
-                x = Float64Col(dflt=1)
-                y = UInt8Col(dflt=1)
+            class info3(tb.IsDescription):
+                x = tb.Float64Col(dflt=1)
+                y = tb.UInt8Col(dflt=1)
 
 NestedDescr is the root class with two *substructures* in it: info1 and info2. Note info1 is an instance of class Info which is defined prior to NestedDescr. info2 is declared within NestedDescr. Also, there is a third substructure, info3, that is in turn declared within substructure info2. You can define positions of substructures in the containing object by declaring special class attribute _v_pos.
 
@@ -2067,16 +2067,16 @@ Creating nested tables
 Now that we have defined our nested structure, let's create a *nested* table,
 that is a table with columns which contain subcolumns::
 
-    >>> fileh = open_file("nested-tut.h5", "w")
+    >>> fileh = tb.open_file("nested-tut.h5", "w")
     >>> table = fileh.create_table(fileh.root, 'table', NestedDescr)
 
 Done! Now, to populate the table with values, assign a value to each field. Referencing nested fields can be accomplished by providing a full path. Follow the structure defined earlier - use '/' to access each sublevel of the structure, similar to how you would access a subdirectory on a Unix filesystem::
 
     >>> row = table.row
     >>> for i in range(10):
-    ...     row['color'] = colors[['red', 'green', 'blue'][i%3]]
-    ...     row['info1/name'] = "name1-%s" % i
-    ...     row['info2/name'] = "name2-%s" % i
+    ...     row['color'] = colors[['red', 'green', 'blue'][i % 3]]
+    ...     row['info1/name'] = f"name1-{i}"
+    ...     row['info2/name'] = f"name2-{i}"
     ...     row['info2/info3/y'] =  i
     ...     # Remaining fields will be filled with defaults
     ...     row.append()
@@ -2244,7 +2244,7 @@ Last but not least, there is a special iterator of the Description class: _f_wal
 which returns different columns of the table::
 
     >>> for coldescr in table.description._f_walk():
-    ...     print("column-->",coldescr)
+    ...     print(f"column--> {coldescr}")
     column--> Description([('info2', [('info3', [('x', '()f8'), ('y', '()u1')]),
                            ('name', '()S10'), ('value', '()f8')]),
                            ('info1', [('name', '()S10'), ('value', '()f8')]),

--- a/doc/source/usersguide/usersguide.rst
+++ b/doc/source/usersguide/usersguide.rst
@@ -19,7 +19,7 @@ PyTables User's Guide
 
             |copy| 2008, 2009, 2010 - Francesc Alted
 
-            |copy| 2011-2018 - PyTables maintainers
+            |copy| 2011–2020 - PyTables maintainers
 :Date:      |today|
 :Version:   |version|
 :Home Page: http://www.pytables.org


### PR DESCRIPTION
Fixed some typos in the doc. Modernized the example code snippets.

Then generated everything with `make html`, copied to the `pytables.github.com` repo, but the diff is much larger than expected due to some IE/class/… changes. The new version is also `3.6.2.dev0`, so probably we should run this update when the new release is ready. 