### PR TITLE
Drop Python 3.5 support, use f-strings and underscores in integers 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        python: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -44,7 +44,7 @@ b = a.copy(f.root, "b", chunkshape=newchunkshape)
 tcpy = round(time() - t1, 3)
 thcpy = round(dim1 * dim2 * 8 / (tcpy * 1024 * 1024), 1)
 print("Chunkshape for row-wise chunkshape array:", b.chunkshape)
-print("Time to copy the original array: {} sec ({} MB/s)".format(tcpy, thcpy))
+print(f"Time to copy the original array: {tcpy} sec ({thcpy} MB/s)")
 
 # Read the same ten rows from the new copied array
 t1 = time()

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -28,9 +28,9 @@ def show_stats(explain, tref):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-    print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-    print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -31,9 +31,9 @@ def show_stats(explain, tref):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-    print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-    print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow

--- a/bench/get-figures-ranges.py
+++ b/bench/get-figures-ranges.py
@@ -207,7 +207,7 @@ if __name__ == '__main__':
         plegend = filename[filename.find('-'):filename.index('.out')]
         plegend = plegend.replace('-', ' ')
         xval, yval = get_values(filename)
-        print("Values for {} --> {}, {}".format(filename, xval, yval))
+        print(f"Values for {filename} --> {xval}, {yval}")
         if "PyTables" in filename or "pytables" in filename:
             plot = loglog(xval, yval, linewidth=2)
             #plot = semilogx(xval, yval, linewidth=2)

--- a/bench/get-figures.py
+++ b/bench/get-figures.py
@@ -265,7 +265,7 @@ if __name__ == '__main__':
         #plegend = plegend.replace('zlib1', '')
         if filename.find('PyTables') != -1:
             xval, yval = get_values(filename)
-            print("Values for {} --> {}, {}".format(filename, xval, yval))
+            print(f"Values for {filename} --> {xval}, {yval}")
             if xval != []:
                 plot = loglog(xval, yval)
                 #plot = semilogx(xval, yval)
@@ -275,7 +275,7 @@ if __name__ == '__main__':
                 legends.append(plegend)
         else:
             xval, yval = get_values(filename)
-            print("Values for {} --> {}, {}".format(filename, xval, yval))
+            print(f"Values for {filename} --> {xval}, {yval}")
             plots.append(loglog(xval, yval, linewidth=3, color='m'))
             #plots.append(semilogx(xval, yval, linewidth=linewidth, color='m'))
             legends.append(plegend)

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -92,11 +92,11 @@ class DB:
             # print "Times for warm cache:\n", wtimes
             print("Histogram for warm cache: %s\n%s" %
                   numpy.histogram(wtimes))
-        print("{}1st query time for {}:".format(r, colname),
+        print(f"{r}1st query time for {colname}:",
               round(qtime1, prec))
-        print("{}Query time for {} (cold cache):".format(r, colname),
+        print(f"{r}Query time for {colname} (cold cache):",
               round(cmean, prec), "+-", round(cstd, prec))
-        print("{}Query time for {} (warm cache):".format(r, colname),
+        print(f"{r}Query time for {colname} (warm cache):",
               round(wmean, prec), "+-", round(wstd, prec))
 
     def print_db_sizes(self, init, filled, indexed):

--- a/bench/open_close-bench.py
+++ b/bench/open_close-bench.py
@@ -38,9 +38,9 @@ def show_stats(explain, tref):
     sout.close()
     print("WallClock time:", time.time() - tref)
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-    print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-    print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
 
 
 def check_open_close():

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -48,7 +48,7 @@ def print_filesize(filename, clib=None, clevel=0):
     print("\t\tTotal file sizes: %d -- (%s MB)" % (
         filesize_bytes, filesize_MB), end=' ')
     if clevel > 0:
-        print("(using {} lvl{})".format(clib, clevel))
+        print(f"(using {clib} lvl{clevel})")
     else:
         print()
 
@@ -169,7 +169,7 @@ if __name__ == '__main__':
             populate_x_memmap()
             compute = compute_memmap
         print("*** Time elapsed populating:", round(time() - t0, 3))
-        print("Computing: '{}' using {}".format(expr, what))
+        print(f"Computing: '{expr}' using {what}")
         t0 = time()
         compute()
         print("**************** Time elapsed computing:",
@@ -187,7 +187,7 @@ if __name__ == '__main__':
                 print("Populating x using %s with %d points..." % (what, N))
                 populate_x_tables(clib, clevel)
                 print("*** Time elapsed populating:", round(time() - t0, 3))
-                print("Computing: '{}' using {}".format(expr, what))
+                print(f"Computing: '{expr}' using {what}")
                 t0 = time()
                 compute_tables(clib, clevel)
                 print("**************** Time elapsed computing:",

--- a/bench/pytables_backend.py
+++ b/bench/pytables_backend.py
@@ -26,7 +26,7 @@ class PyTables_DB(DB):
                 dir_path = self.datadir
             os.makedirs(dir_path)
             self.datadir = dir_path
-            print("Created {}.".format(self.datadir))
+            print(f"Created {self.datadir}.")
         self.filename = self.datadir + '/' + self.filename + '.h5'
         # The chosen filters
         self.filters = tables.Filters(complevel=self.docompress,

--- a/bench/search-bench-plot.py
+++ b/bench/search-bench-plot.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
         plegend = filename[filename.find('cl-') + 3:filename.index('.h5')]
         plegend = plegend.replace('-', ' ')
         xval, yval = get_values(filename, '')
-        print("Values for {} --> {}, {}".format(filename, xval, yval))
+        print(f"Values for {filename} --> {xval}, {yval}")
         #plots.append(loglog(xval, yval, linewidth=5))
         plots.append(semilogx(xval, yval, linewidth=4))
         legends.append(plegend)

--- a/bench/split-file.py
+++ b/bench/split-file.py
@@ -29,11 +29,11 @@ for line in f:
                 complib = param
         if 'PyTables' in prefix:
             if complib:
-                sfilename = "{}-O{}-{}.out".format(prefix, optlevel, complib)
+                sfilename = f"{prefix}-O{optlevel}-{complib}.out"
             else:
-                sfilename = "{}-O{}.out".format(prefix, optlevel)
+                sfilename = f"{prefix}-O{optlevel}.out"
         else:
-            sfilename = "{}.out".format(prefix)
+            sfilename = f"{prefix}.out"
         sf = file(sfilename, 'a')
     if sf:
         sf.write(line)

--- a/bench/table-copy.py
+++ b/bench/table-copy.py
@@ -31,7 +31,7 @@ def create_table(output_path):
 
 
 def copy1(input_path, output_path):
-    print("copying data from {} to {}...".format(input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 
@@ -42,14 +42,14 @@ def copy1(input_path, output_path):
 
 
 def copy2(input_path, output_path):
-    print("copying data from {} to {}...".format(input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     input_file.copy_file(output_path, overwrite=True)
     input_file.close()
 
 
 def copy3(input_path, output_path):
-    print("copying data from {} to {}...".format(input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
     table = input_file.root.test
@@ -59,7 +59,7 @@ def copy3(input_path, output_path):
 
 
 def copy4(input_path, output_path, complib='zlib', complevel=0):
-    print("copying data from {} to {}...".format(input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 
@@ -82,7 +82,7 @@ def copy4(input_path, output_path, complib='zlib', complevel=0):
 
 
 def copy5(input_path, output_path, complib='zlib', complevel=0):
-    print("copying data from {} to {}...".format(input_path, output_path))
+    print(f"copying data from {input_path} to {output_path}...")
     input_file = tables.open_file(input_path, mode="r")
     output_file = tables.open_file(output_path, mode="w")
 

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -49,7 +49,7 @@ Prerequisites
 
 First, make sure that you have
 
-* Python_ >= 3.4 (PyTables-3.5 was the last release with Python 2.7 support)
+* Python_ >= 3.6 (PyTables-3.5 was the last release with Python 2.7 support)
 * HDF5_ >= 1.8.4 (>=1.8.15 is strongly recommended)
 * NumPy_ >= 1.9.3
 * Numexpr_ >= 2.6.2
@@ -508,8 +508,8 @@ can be found e.g. at the `Unofficial Windows Binaries for Python Extension Packa
 matching the version of python and either the 32 or 64-bit version and install
 using pip::
 
-    # python 3.5 64-bit:
-    $ python3 -m pip install tables-3.3-cp35-cp35m-win_amd64.whl
+    # python 3.6 64-bit:
+    $ python3 -m pip install tables-3.6.1-2-cp36-cp36m-win_amd64.whl
 
 You can (and *you should*) test your installation by running the next
 commands::

--- a/examples/earray1.py
+++ b/examples/earray1.py
@@ -10,6 +10,6 @@ array_c.append(numpy.array(['a' * 6, 'b' * 8, 'c' * 10], dtype='S8'))
 
 # Read the string ``EArray`` we have created on disk.
 for s in array_c:
-    print('array_c[{}] => {!r}'.format(array_c.nrow, s))
+    print(f'array_c[{array_c.nrow}] => {s!r}')
 # Close the file.
 fileh.close()

--- a/examples/links.py
+++ b/examples/links.py
@@ -12,7 +12,7 @@ t1 = f1.create_table(g2, 't1', {'f1': tb.IntCol(), 'f2': tb.FloatCol()})
 # Create new group and a first hard link
 gl = f1.create_group('/', 'gl')
 ht = f1.create_hard_link(gl, 'ht', '/g1/g2/t1')  # ht points to t1
-print("``{}`` is a hard link to: ``{}``".format(ht, t1))
+print(f"``{ht}`` is a hard link to: ``{t1}``")
 
 # Remove the orginal link to the t1 table
 t1.remove()
@@ -20,13 +20,13 @@ print("table continues to be accessible in: ``%s``" % f1.get_node('/gl/ht'))
 
 # Let's continue with soft links
 la1 = f1.create_soft_link(gl, 'la1', '/g1/a1')  # la1 points to a1
-print("``{}`` is a soft link to: ``{}``".format(la1, la1.target))
+print(f"``{la1}`` is a soft link to: ``{la1.target}``")
 lt = f1.create_soft_link(gl, 'lt', '/g1/g2/t1')  # lt points to t1 (dangling)
-print("``{}`` is a soft link to: ``{}``".format(lt, lt.target))
+print(f"``{lt}`` is a soft link to: ``{lt.target}``")
 
 # Recreate the '/g1/g2/t1' path
 t1 = f1.create_hard_link('/g1/g2', 't1', '/gl/ht')
-print("``{}`` is not dangling anymore".format(lt))
+print(f"``{lt}`` is not dangling anymore")
 
 # Dereferrencing
 plt = lt()
@@ -42,7 +42,7 @@ f2.close()  # close the other file
 # Remove the original soft link and create an external link
 la1.remove()
 la1 = f1.create_external_link(gl, 'la1', 'links2.h5:/a1')
-print("``{}`` is an external link to: ``{}``".format(la1, la1.target))
+print(f"``{la1}`` is an external link to: ``{la1.target}``")
 new_a1 = la1()  # dereferrencing la1 returns a1 in links2.h5
 print("dereferred la1 node:  ``%s``" % new_a1)
 print("new_a1 file:", new_a1._v_file.filename)

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     print()
     for output_file in output_files:
         print()
-        print('contents of log file {}'.format(output_file))
+        print(f'contents of log file {output_file}')
         print(open(output_file).read())
         os.remove(output_file)
 

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -93,7 +93,7 @@ def main():
             thread.join()
 
     # print results
-    print('Mean: {}'.format(mean_))
+    print(f'Mean: {mean_}')
 
 
 if __name__ == '__main__':

--- a/examples/table1.py
+++ b/examples/table1.py
@@ -55,7 +55,7 @@ print()
 
 table = fileh.root.newgroup.table
 print("Object:", table)
-print("Table name: {}. Table title: {}".format(table.name, table.title))
+print(f"Table name: {table.name}. Table title: {table.title}")
 print("Rows saved on table: %d" % (table.nrows))
 
 print("Variable names on table with their type:")

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -129,7 +129,7 @@ def main():
             thread.join()
 
     # print results
-    print('Mean: {}'.format(mean_))
+    print(f'Mean: {mean_}')
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     def _print_admonition(kind, head, body):
         tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
 
-        print(".. {}:: {}".format(kind.upper(), head))
+        print(f".. {kind.upper()}:: {head}")
         for line in tw.wrap(body):
             print(line)
 
@@ -391,7 +391,7 @@ if __name__ == '__main__':
         if (major_version == -1 or minor_version == -1 or
                 release_version == -1):
             exit_with_error("Unable to detect Blosc library version!")
-        return "{}.{}.{}".format(major_version, minor_version, release_version)
+        return f"{major_version}.{minor_version}.{release_version}"
 
 
     _cp = convert_path

--- a/setup.py
+++ b/setup.py
@@ -96,10 +96,10 @@ if __name__ == '__main__':
 
 
     # The minimum required versions
-    min_python_version = (3, 5)
+    min_python_version = (3, 6)
     # Check for Python
     if sys.version_info < min_python_version:
-        exit_with_error("You need Python 3.5 or greater to install PyTables!")
+        exit_with_error("You need Python 3.6 or greater to install PyTables!")
     print("* Using Python %s" % sys.version.splitlines()[0])
 
     # Minimum required versions for numpy, numexpr and HDF5
@@ -1033,7 +1033,6 @@ Operating System :: Unix
 Programming Language :: Python
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3 :: Only
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
@@ -1062,7 +1061,7 @@ interactively save and retrieve large amounts of data.
         maintainer_email='pytables@pytables.org',
         url='http://www.pytables.org/',
         license='BSD 2-Clause',
-        python_requires='>=3.5',
+        python_requires='>=3.6',
         platforms=['any'],
         ext_modules=extensions,
         cmdclass=cmdclass,

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -130,7 +130,7 @@ def _normalize_shape(shape):
     # HDF5 does not support ranks greater than 32
     if len(shape) > 32:
         raise ValueError(
-            "shapes with rank > 32 are not supported: {!r}".format(shape))
+            f"shapes with rank > 32 are not supported: {shape!r}")
 
     return tuple(SizeType(s) for s in shape)
 
@@ -343,7 +343,7 @@ class Atom(metaclass=MetaAtom):
         if (not isinstance(sctype, type)
            or not issubclass(sctype, numpy.generic)):
             if sctype not in numpy.sctypeDict:
-                raise ValueError("unknown NumPy scalar type: {!r}".format(sctype))
+                raise ValueError(f"unknown NumPy scalar type: {sctype!r}")
             sctype = numpy.sctypeDict[sctype]
         return cls.from_dtype(numpy.dtype((sctype, shape)), dflt)
 
@@ -415,7 +415,7 @@ class Atom(metaclass=MetaAtom):
         """
 
         if type not in all_types:
-            raise ValueError("unknown type: {!r}".format(type))
+            raise ValueError(f"unknown type: {type!r}")
         kind, itemsize = split_type(type)
         return cls.from_kind(kind, itemsize, shape, dflt)
 
@@ -456,7 +456,7 @@ class Atom(metaclass=MetaAtom):
 
         kwargs = {'shape': shape}
         if kind not in atom_map:
-            raise ValueError("unknown kind: {!r}".format(kind))
+            raise ValueError(f"unknown kind: {kind!r}")
         # This incompatibility detection may get out-of-date and is
         # too hard-wired, but I couldn't come up with something
         # smarter.  -- Ivan (2007-02-08)
@@ -534,10 +534,10 @@ class Atom(metaclass=MetaAtom):
         as NumPy objects."""
 
     def __repr__(self):
-        args = 'shape={}, dflt={!r}'.format(self.shape, self.dflt)
+        args = f'shape={self.shape}, dflt={self.dflt!r}'
         if not hasattr(self.__class__.itemsize, '__int__'):  # non-fixed
-            args = 'itemsize={}, {}'.format(self.itemsize, args)
-        return '{}({})'.format(self.__class__.__name__, args)
+            args = f'itemsize={self.itemsize}, {args}'
+        return f'{self.__class__.__name__}({args})'
 
     __eq__ = _cmp_dispatcher('_is_equal_to_atom')
 
@@ -1020,7 +1020,7 @@ class ReferenceAtom(Atom):
         Atom.__init__(self, self.type, shape, self._defvalue)
 
     def __repr__(self):
-        return 'ReferenceAtom(shape={})'.format(self.shape)
+        return f'ReferenceAtom(shape={self.shape})'
 
 # Pseudo-atom classes
 # ===================
@@ -1116,7 +1116,7 @@ class VLStringAtom(_BufferedAtom):
             warnings.warn("Storing non bytestrings in VLStringAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, bytes):
-            raise TypeError("object is not a string: {!r}".format(object_))
+            raise TypeError(f"object is not a string: {object_!r}")
         return numpy.string_(object_)
 
     def fromarray(self, array):
@@ -1158,7 +1158,7 @@ class VLUnicodeAtom(_BufferedAtom):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, str):
-            raise TypeError("object is not a string: {!r}".format(object_))
+            raise TypeError(f"object is not a string: {object_!r}")
         ustr = str(object_)
         uarr = numpy.array(ustr, dtype='U')
         return numpy.ndarray(
@@ -1172,7 +1172,7 @@ class VLUnicodeAtom(_BufferedAtom):
             warnings.warn("Storing bytestrings in VLUnicodeAtom is "
                           "deprecated.", DeprecationWarning)
         elif not isinstance(object_, str):
-            raise TypeError("object is not a string: {!r}".format(object_))
+            raise TypeError(f"object is not a string: {object_!r}")
         return numpy.unicode_(object_)
 
     def fromarray(self, array):

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -659,7 +659,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # However, we need to know Node here.
         # Using class_name_dict avoids a circular import.
         if not isinstance(where, class_name_dict['Node']):
-            raise TypeError("destination object is not a node: {!r}".format(where))
+            raise TypeError(f"destination object is not a node: {where!r}")
         self._g_copy(where._v_attrs, where._v_attrs.__setattr__)
 
     def _g_close(self):

--- a/tables/description.py
+++ b/tables/description.py
@@ -227,7 +227,7 @@ class Col(atom.Atom, metaclass=type):
         rpar = atomrepr.rindex(')')
         atomargs = atomrepr[lpar + 1:rpar]
         classname = self.__class__.__name__
-        return '{}({}, pos={})'.format(classname, atomargs, self._v_pos)
+        return f'{classname}({atomargs}, pos={self._v_pos})'
 
     # Private methods
     # ~~~~~~~~~~~~~~~
@@ -659,7 +659,7 @@ class Description:
         def join_paths(path1, path2):
             if not path1:
                 return path2
-            return '{}/{}'.format(path1, path2)
+            return f'{path1}/{path2}'
 
         # The top of the stack always has a nested description
         # and a list of its child columns

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -161,7 +161,7 @@ class HDF5ExtError(RuntimeError):
 
             if len(self.args) == 1 and isinstance(self.args[0], str):
                 msg = super().__str__()
-                msg = "{}\n\n{}".format(bt, msg)
+                msg = f"{bt}\n\n{msg}"
             elif self.h5backtrace[-1][-1]:
                 msg = "{}\n\n{}".format(bt, self.h5backtrace[-1][-1])
             else:

--- a/tables/file.py
+++ b/tables/file.py
@@ -1640,7 +1640,7 @@ class File(hdf5extension.File):
             node = self._get_node(nodepath)
         else:
             raise TypeError(
-                "``where`` must be a string or a node: {!r}".format(where))
+                f"``where`` must be a string or a node: {where!r}")
 
         # Finally, check whether the desired node is an instance
         # of the expected class.
@@ -2165,7 +2165,7 @@ class File(hdf5extension.File):
     def _check_group(self, node):
         # `node` must already be a node.
         if not isinstance(node, Group):
-            raise TypeError("node ``{}`` is not a group".format(node._v_pathname))
+            raise TypeError(f"node ``{node._v_pathname}`` is not a group")
 
 
     # <Undo/Redo support>

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -270,7 +270,7 @@ def _register_converters():
             # contiguous).  Otherwise, an identity function is used.
             convfunc = None
             try:
-                convfunc = eval('_conv_{}_to_{}'.format(src_flavor, dst_flavor))
+                convfunc = eval(f'_conv_{src_flavor}_to_{dst_flavor}')
             except NameError:
                 if src_flavor == dst_flavor:
                     convfunc = identity

--- a/tables/group.py
+++ b/tables/group.py
@@ -182,7 +182,7 @@ class Group(hdf5extension.Group, Node):
     def _g_setfilters(self, value):
         if not isinstance(value, Filters):
             raise TypeError(
-                "value is not an instance of `Filters`: {!r}".format(value))
+                f"value is not an instance of `Filters`: {value!r}")
         self._v_attrs.FILTERS = value
 
     def _g_delfilters(self):
@@ -1078,7 +1078,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         pathname = self._v_pathname
         classname = self.__class__.__name__
         title = self._v_title
-        return "{} ({}) {!r}".format(pathname, classname, title)
+        return f"{pathname} ({classname}) {title!r}"
 
     def __repr__(self):
         """Return a detailed string representation of the group.
@@ -1096,7 +1096,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         """
 
         rep = [
-            '{!r} ({})'.format(childname, child.__class__.__name__)
+            f'{childname!r} ({child.__class__.__name__})'
             for (childname, child) in self._v_children.items()
         ]
         childlist = '[%s]' % (', '.join(rep))

--- a/tables/index.py
+++ b/tables/index.py
@@ -947,7 +947,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if self.verbose:
             t = round(time() - t1, 4)
             c = round(perf_counter() - c1, 4)
-            print("time: {}. clock: {}".format(t, c))
+            print(f"time: {t}. clock: {c}")
 
     def swap(self, what, mode=None):
         """Swap chunks or slices using a certain bounds reference."""
@@ -967,16 +967,16 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         elif what == "slices":
             self.swap_slices(mode)
         if mode:
-            message = "swap_{}({})".format(what, mode)
+            message = f"swap_{what}({mode})"
         else:
-            message = "swap_{}".format(what)
+            message = f"swap_{what}"
         (nover, mult, tover) = self.compute_overlaps(
             self.tmp, message, self.verbose)
         rmult = len(mult.nonzero()[0]) / float(len(mult))
         if self.verbose:
             t = round(time() - t1, 4)
             c = round(perf_counter() - c1, 4)
-            print("time: {}. clock: {}".format(t, c))
+            print(f"time: {t}. clock: {c}")
         # Check that entropy is actually decreasing
         if what == "chunks" and self.last_tover > 0. and self.last_nover > 0:
             tover_var = (self.last_tover - tover) / self.last_tover

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -535,15 +535,15 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         if type(key) in (list, tuple):
             if isinstance(key, tuple) and len(key) > len(self.shape):
-                raise IndexError("Invalid index or slice: {!r}".format(key))
+                raise IndexError(f"Invalid index or slice: {key!r}")
             # Try to convert key to a numpy array.  If not possible,
             # a TypeError will be issued (to be catched later on).
             try:
                 key = toarray(key)
             except ValueError:
-                raise TypeError("Invalid index or slice: {!r}".format(key))
+                raise TypeError(f"Invalid index or slice: {key!r}")
         elif not isinstance(key, numpy.ndarray):
-            raise TypeError("Invalid index or slice: {!r}".format(key))
+            raise TypeError(f"Invalid index or slice: {key!r}")
 
         # Protection against empty keys
         if len(key) == 0:

--- a/tables/link.py
+++ b/tables/link.py
@@ -426,7 +426,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
         """
 
         classname = self.__class__.__name__
-        return "{} ({}) -> {}".format(self._v_pathname, classname, self.target)
+        return f"{self._v_pathname} ({classname}) -> {self.target}"
 
 
 ## Local Variables:

--- a/tables/misc/enum.py
+++ b/tables/misc/enum.py
@@ -139,7 +139,7 @@ sequences, mappings and other enumerations""")
 
         if not isinstance(name, str):
             raise TypeError(
-                "name of enumerated value is not a string: {!r}".format(name))
+                f"name of enumerated value is not a string: {name!r}")
         if name.startswith('_'):
             raise ValueError(
                 "name of enumerated value can not start with ``_``: %r"
@@ -185,7 +185,7 @@ sequences, mappings and other enumerations""")
         try:
             return self._names[name]
         except KeyError:
-            raise KeyError("no enumerated value with that name: {!r}".format(name))
+            raise KeyError(f"no enumerated value with that name: {name!r}")
 
     def __setitem__(self, name, value):
         """This operation is forbidden."""
@@ -265,7 +265,7 @@ sequences, mappings and other enumerations""")
 
         if not isinstance(name, str):
             raise TypeError(
-                "name of enumerated value is not a string: {!r}".format(name))
+                f"name of enumerated value is not a string: {name!r}")
         return name in self._names
 
     def __call__(self, value, *default):
@@ -303,7 +303,7 @@ sequences, mappings and other enumerations""")
             if len(default) > 0:
                 return default[0]
             raise ValueError(
-                "no enumerated value with that concrete value: {!r}".format(value))
+                f"no enumerated value with that concrete value: {value!r}")
 
     def __len__(self):
         """Return the number of enumerated values in the enumerated type.

--- a/tables/node.py
+++ b/tables/node.py
@@ -43,7 +43,7 @@ def _closedrepr(oldmethod):
             cmod = self.__class__.__module__
             cname = self.__class__.__name__
             addr = hex(id(self))
-            return '<closed {}.{} at {}>'.format(cmod, cname, addr)
+            return f'<closed {cmod}.{cname} at {addr}>'
         return oldmethod(self)
 
     return newmethod

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -113,7 +113,7 @@ class RawPyTablesIO(io.RawIOBase):
             raise TypeError("an integer is required")
         if whence == 0:
             if pos < 0:
-                raise ValueError("negative seek position {!r}".format(pos))
+                raise ValueError(f"negative seek position {pos!r}")
             self._pos = pos
         elif whence == 1:
             self._pos = max(0, self._pos + pos)
@@ -192,7 +192,7 @@ class RawPyTablesIO(io.RawIOBase):
         if pos is None:
             pos = self._pos
         elif pos < 0:
-            raise ValueError("negative truncate position {!r}".format(pos))
+            raise ValueError(f"negative truncate position {pos!r}")
 
         if pos < self._node.nrows:
             raise OSError("truncating is only allowed for growing a file")
@@ -454,10 +454,10 @@ class RawPyTablesIO(io.RawIOBase):
         ltypever = getattr(attrs, 'NODE_TYPE_VERSION', None)
 
         if ltype != NodeType:
-            raise ValueError("invalid type of node object: {}".format(ltype))
+            raise ValueError(f"invalid type of node object: {ltype}")
         if ltypever not in NodeTypeVersions:
             raise ValueError(
-                "unsupported type version of node object: {}".format(ltypever))
+                f"unsupported type version of node object: {ltypever}")
 
 
     def _append_zeros(self, size):
@@ -686,7 +686,7 @@ def open_node(node, mode='r'):
     elif mode == 'a+':
         return RAFileNode(node, None)
     else:
-        raise OSError("invalid mode: {}".format(mode))
+        raise OSError(f"invalid mode: {mode}")
 
 
 

--- a/tables/path.py
+++ b/tables/path.py
@@ -95,7 +95,7 @@ def check_attribute_name(name):
     ValueError: the empty string is not allowed as an object name
     """
     if not isinstance(name, str):  # Python >= 2.3
-        raise TypeError("object name is not a string: {!r}".format(name))
+        raise TypeError(f"object name is not a string: {name!r}")
 
     if name == '':
         raise ValueError("the empty string is not allowed as an object name")
@@ -187,9 +187,9 @@ def join_path(parentpath, name):
     if parentpath == '/' and name.startswith('/'):
         pstr = '%s' % name
     elif parentpath == '/' or name.startswith('/'):
-        pstr = '{}{}'.format(parentpath, name)
+        pstr = f'{parentpath}{name}'
     else:
-        pstr = '{}/{}'.format(parentpath, name)
+        pstr = f'{parentpath}/{name}'
     if pstr.endswith('/'):
         pstr = pstr[:-1]
     return pstr

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -505,7 +505,7 @@ def main():
     ns = parser.parse_args()
 
     if not os.path.isfile(ns.filename):
-        sys.exit('file {!r} not found'.format(ns.filename))
+        sys.exit(f'file {ns.filename!r} not found')
     with open(ns.filename) as f:
         src = f.read()
 

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -144,7 +144,7 @@ def copy_leaf(srcfile, dstfile, srcnode, dstnode, title,
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcnode, dstfile, dstnode))
-        print("The error was --> {}: {}".format(type_, value))
+        print(f"The error was --> {type_}: {value}")
         print("The destination file looks like:\n", dstfileh)
         # Close all the open files:
         srcfileh.close()
@@ -233,7 +233,7 @@ def copy_children(srcfile, dstfile, srcgroup, dstgroup, title,
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcgroup, dstfile, dstgroup))
-        print("The error was --> {}: {}".format(type_, value))
+        print(f"The error was --> {type_}: {value}")
         print("The destination file looks like:\n", dstfileh)
         # Close all the open files:
         srcfileh.close()

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -434,7 +434,7 @@ def bytes2human(use_si_units=False):
             if scaled >= 1:
                 break
 
-        return "{:.1f}{}".format(scaled, prefix)
+        return f"{scaled:.1f}{prefix}"
 
     return b2h
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -285,7 +285,7 @@ def _column__create_index(self, optlevel, kind, filters, tmp_dir,
             else:
                 dname += '/' + iname
             try:
-                idgroup = get_node('{}/{}'.format(itgroup._v_pathname, dname))
+                idgroup = get_node(f'{itgroup._v_pathname}/{dname}')
             except NoSuchNodeError:
                 idgroup = create_indexes_descr(idgroup, dname, iname, filters)
 
@@ -342,7 +342,7 @@ class _ColIndexes(dict):
     def __repr__(self):
         """Gives a detailed Description column representation."""
 
-        rep = ['  \"{}\": {}'.format(k, v) for k, v in self.items()]
+        rep = [f'  \"{k}\": {v}' for k, v in self.items()]
         return '{\n  %s}' % (',\n  '.join(rep))
 
 
@@ -2078,7 +2078,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             return self._read_coordinates(key, None)
         else:
-            raise IndexError("Invalid index or slice: {!r}".format(key))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def __setitem__(self, key, value):
         """Set a row or a range of rows in the table.
@@ -2148,7 +2148,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             return self.modify_coordinates(key, value)
         else:
-            raise IndexError("Invalid index or slice: {!r}".format(key))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def _save_buffered_rows(self, wbufRA, lenrows):
         """Update the indexes after a flushing of rows."""
@@ -3164,7 +3164,7 @@ class Cols:
                 else:
                     return get_nested_field(crecarray, colgroup)  # numpy case
         else:
-            raise TypeError("invalid index or slice: {!r}".format(key))
+            raise TypeError(f"invalid index or slice: {key!r}")
 
     def __setitem__(self, key, value):
         """Set a row or a range of rows in a table or nested column.
@@ -3208,7 +3208,7 @@ class Cols:
             (start, stop, step) = table._process_range(
                 key.start, key.stop, key.step)
         else:
-            raise TypeError("invalid index or slice: {!r}".format(key))
+            raise TypeError(f"invalid index or slice: {key!r}")
 
         # Actually modify the correct columns
         colgroup = self._v_desc._v_pathname
@@ -3263,7 +3263,7 @@ class Cols:
                 tcol = "Description"
                 # Description doesn't have a shape currently
                 shape = ()
-            out += "  {} ({}{}, {})".format(name, classname, shape, tcol) + "\n"
+            out += f"  {name} ({classname}{shape}, {tcol})" + "\n"
         return out
 
 

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -27,9 +27,9 @@ def show_mem(explain):
                 vmlib = int(line.split()[1])
 
     print("\nMemory usage: ******* %s *******" % explain)
-    print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-    print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-    print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     print("WallClock time:", time.time() - tref, end=' ')
     print("  Delta time:", time.time() - trel)
     trel = time.time()

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -95,7 +95,7 @@ def print_versions():
         vml_avail = "using VML/MKL %s" % vml_version
     else:
         vml_avail = "not using Intel's VML/MKL"
-    print("Numexpr version:     {} ({})".format(numexpr.__version__, vml_avail))
+    print(f"Numexpr version:     {numexpr.__version__} ({vml_avail})")
     if tinfo is not None:
         print("Zlib version:        {} ({})".format(tinfo[1],
                                                 "in Python interpreter"))
@@ -248,7 +248,7 @@ class PyTablesTestCase(unittest.TestCase):
             name = self._getName()
             methodName = self._getMethodName()
 
-            title = "Running {}.{}".format(name, methodName)
+            title = f"Running {name}.{methodName}"
             print('{}\n{}'.format(title, '-' * len(title)))
 
     # COMPATIBILITY: assertWarns is new in Python 3.2
@@ -372,9 +372,9 @@ class ShowMemTime(PyTablesTestCase):
                 vmlib = int(line.split()[1])
         print("\nWallClock time:", time.time() - self.tref)
         print("Memory usage: ******* %s *******" % self._getName())
-        print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-        print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-        print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+        print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+        print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+        print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
 
 
 ## Local Variables:

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -1757,7 +1757,7 @@ class IndexFiltersTestCase(TempFileMixin, TestCase):
         icol.reindex()
         ni = icol.index
         if verbose:
-            print("Old parameters: {}, {}, {}".format(kind, optlevel, filters))
+            print(f"Old parameters: {kind}, {optlevel}, {filters}")
             print("New parameters: {}, {}, {}".format(
                 ni.kind, ni.optlevel, ni.filters))
         self.assertEqual(ni.kind, kind)

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3191,10 +3191,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> {} {} {} {}".format(idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: {} != {}, {}".format(idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
     def test01_nocache(self):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=0)
@@ -3210,10 +3210,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> {} {} {} {}".format(idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: {} != {}, {}".format(idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
     def test02_dictcache(self):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=-64)
@@ -3229,10 +3229,10 @@ class LastRowReuseBuffers(TestCase):
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
-                            "idx--> {} {} {} {}".format(idx, i, nrow, value))
+                            f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
-                "nrow not found: {} != {}, {}".format(idx, nrow, value))
+                f"nrow not found: {idx} != {nrow}, {value}")
 
 
 normal_tests = (
@@ -3328,7 +3328,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
         v1 = numpy.unique(arr['o'])[0]
         v2 = numpy.unique(arr['o'])[1]
         res = numpy.array([v1, v2])
-        selector = '((o == {}) | (o == {}))'.format(v1, v2)
+        selector = f'((o == {v1}) | (o == {v2}))'
         if verbose:
             print("selecting values: %s" % selector)
 
@@ -3338,7 +3338,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
         numpy.testing.assert_almost_equal(result, res)
         if verbose:
             print("select entire table:")
-            print("result: {}\texpected: {}".format(result, res))
+            print(f"result: {result}\texpected: {res}")
 
         if verbose:
             print("index the column o")
@@ -3351,7 +3351,7 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
             result = numpy.unique(result['o'])
             numpy.testing.assert_almost_equal(numpy.unique(result), res)
             if verbose:
-                print("result: {}\texpected: {}".format(result, res))
+                print(f"result: {result}\texpected: {res}")
 
 
 # Test case for issue #441

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -278,7 +278,7 @@ class BaseTableQueryTestCase(common.TempFileMixin, TestCase):
             return
         try:
             kind = self.kind
-            vprint("* Indexing ``{}`` columns. Type: {}.".format(colname, kind))
+            vprint(f"* Indexing ``{colname}`` columns. Type: {kind}.")
             for acolname in [colname, ncolname, extracolname]:
                 acolumn = self.table.colinstances[acolname]
                 acolumn.create_index(
@@ -377,11 +377,11 @@ def create_test_method(type_, op, extracond, func=None):
         cond = ('(lbound %s %s) & (%s %s rbound)'
                 % (op[0], colname, colname, op[1]))
     elif func is not None:
-        cond = '{}({}) {} func_bound'.format(func, colname, op)
+        cond = f'{func}({colname}) {op} func_bound'
     else:  # function or binary variable-variable
-        cond = '{} {} bound'.format(colname, op)
+        cond = f'{colname} {op} bound'
     if extracond:
-        cond = '({}) {}'.format(cond, extracond)
+        cond = f'({cond}) {extracond}'
 
     def ignore_skipped(oldmethod):
         @functools.wraps(oldmethod)

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -26,7 +26,7 @@ class Record(tables.IsDescription):
 class TrackTimesMixin:
     def _add_datasets(self, group, j, track_times):
         # Create a table
-        table = self.h5file.create_table(group, 'table{}'.format(j),
+        table = self.h5file.create_table(group, f'table{j}',
                                          Record,
                                          title=self.title,
                                          filters=None,
@@ -46,18 +46,18 @@ class TrackTimesMixin:
         var1List = [x['var1'] for x in table.iterrows()]
         var3List = [x['var3'] for x in table.iterrows()]
 
-        self.h5file.create_array(group, 'array{}'.format(j),
-                                 var1List, "col {}".format(j),
+        self.h5file.create_array(group, f'array{j}',
+                                 var1List, f"col {j}",
                                  track_times=track_times)
 
         # Create CArrays as well
-        self.h5file.create_carray(group, name='carray{}'.format(j),
+        self.h5file.create_carray(group, name=f'carray{j}',
                                   obj=var3List,
                                   title="col {}".format(j + 2),
                                   track_times=track_times)
 
         # Create EArrays as well
-        ea = self.h5file.create_earray(group, 'earray{}'.format(j),
+        ea = self.h5file.create_earray(group, f'earray{j}',
                                        StringAtom(itemsize=4), (0,),
                                        "col {}".format(j + 4),
                                        track_times=track_times)
@@ -65,7 +65,7 @@ class TrackTimesMixin:
         ea.append(var1List)
 
         # Finally VLArrays too
-        vla = self.h5file.create_vlarray(group, 'vlarray{}'.format(j),
+        vla = self.h5file.create_vlarray(group, f'vlarray{j}',
                                          Int16Atom(),
                                          "col {}".format(j + 6),
                                          track_times=track_times)

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -146,7 +146,7 @@ class Unknown(Node):
     def __str__(self):
         pathname = self._v_pathname
         classname = self.__class__.__name__
-        return "{} ({})".format(pathname, classname)
+        return f"{pathname} ({classname})"
 
     def __repr__(self):
         return """%s

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -148,9 +148,9 @@ def check_file_access(filename, mode='r'):
     if mode == 'r':
         # The file should be readable.
         if not os.access(filename, os.F_OK):
-            raise OSError("``{}`` does not exist".format(filename))
+            raise OSError(f"``{filename}`` does not exist")
         if not os.path.isfile(filename):
-            raise OSError("``{}`` is not a regular file".format(filename))
+            raise OSError(f"``{filename}`` is not a regular file")
         if not os.access(filename, os.R_OK):
             raise OSError("file ``%s`` exists but it can not be read"
                           % (filename,))
@@ -166,9 +166,9 @@ def check_file_access(filename, mode='r'):
             if not parentname:
                 parentname = '.'
             if not os.access(parentname, os.F_OK):
-                raise OSError("``{}`` does not exist".format(parentname))
+                raise OSError(f"``{parentname}`` does not exist")
             if not os.path.isdir(parentname):
-                raise OSError("``{}`` is not a directory".format(parentname))
+                raise OSError(f"``{parentname}`` is not a directory")
             if not os.access(parentname, os.W_OK):
                 raise OSError("directory ``%s`` exists but it can not be "
                               "written" % (parentname,))
@@ -183,7 +183,7 @@ def check_file_access(filename, mode='r'):
             raise OSError("file ``%s`` exists but it can not be written"
                           % (filename,))
     else:
-        raise ValueError("invalid mode: {!r}".format(mode))
+        raise ValueError(f"invalid mode: {mode!r}")
 
 
 
@@ -265,9 +265,9 @@ def show_stats(explain, tref, encoding=None):
             vmlib = int(line.split()[1])
     sout.close()
     print("Memory usage: ******* %s *******" % explain)
-    print("VmSize: {:>7} kB\tVmRSS: {:>7} kB".format(vmsize, vmrss))
-    print("VmData: {:>7} kB\tVmStk: {:>7} kB".format(vmdata, vmstk))
-    print("VmExe:  {:>7} kB\tVmLib: {:>7} kB".format(vmexe, vmlib))
+    print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
+    print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
+    print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
     print("WallClock time:", round(tnow - tref, 3))
     return tnow
@@ -351,7 +351,7 @@ def dump_logged_instances(classes, file=sys.stdout):
             if obj is not None:
                 file.write('    %s:\n' % obj)
                 for key, value in obj.__dict__.items():
-                    file.write('        {:>20} : {}\n'.format(key, value))
+                    file.write(f'        {key:>20} : {value}\n')
 
 
 

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -682,7 +682,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
             coords = self._point_selection(key)
             return self._read_coordinates(coords)
         else:
-            raise IndexError("Invalid index or slice: {!r}".format(key))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
     def _assign_values(self, coords, values):
         """Assign the `values` to the positions stated in `coords`."""
@@ -784,7 +784,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
         elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
             coords = self._point_selection(key)
         else:
-            raise IndexError("Invalid index or slice: {!r}".format(key))
+            raise IndexError(f"Invalid index or slice: {key!r}")
 
         # Do the assignment row by row
         self._assign_values(coords, value)


### PR DESCRIPTION
This drops Python 3.5 support from CIs and PyPI metadata. PyTables will be then Python 3.6+ and this introduces following new syntax features: 

- PEP 498, formatted string literals.
- PEP 515, underscores in numeric literals.
- PEP 526, syntax for variable annotations.
- PEP 525, asynchronous generators.
- PEP 530: asynchronous comprehensions.

The first two can be added automatically using `pyupgrade` and manually. Variable annotations should be discussed. Async stuff is not relevant for PyTables yet.

Closes #840 