### PR TITLE
Replace round() with proper f-string

### DIFF
--- a/bench/LRU-experiments.py
+++ b/bench/LRU-experiments.py
@@ -66,7 +66,7 @@ def modify_junk_LRU2():
             tt = getattr(group, "table" + str(i))
             #for row in tt:
             #    pass
-        print("iter and time -->", j + 1, round(time() - t1, 3))
+        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
     fileh.close()
 
 
@@ -79,7 +79,7 @@ def modify_junk_LRU3():
             tt.attrs.TITLE
             for row in tt:
                 pass
-        print("iter and time -->", j + 1, round(time() - t1, 3))
+        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
     fileh.close()
 
 if 1:

--- a/bench/LRU-experiments2.py
+++ b/bench/LRU-experiments2.py
@@ -39,7 +39,7 @@ def modify_junk_LRU2():
             #print("table-->", tt._v_name)
             tt = getattr(group, "array" + str(i))
             #d = tt.read()
-        print("iter and time -->", j + 1, round(time() - t1, 3))
+        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
     fileh.close()
 
 if 1:

--- a/bench/LRUcache-node-bench.py
+++ b/bench/LRUcache-node-bench.py
@@ -42,7 +42,7 @@ print("reading nodes...")
 t1 = time()
 for a in f.root.NodeContainer:
     pass
-print("time (init cache)-->", round(time() - t1, 3))
+print(f"time (init cache)--> {time() - t1:.3f}")
 
 
 def timeLRU():
@@ -51,7 +51,7 @@ def timeLRU():
 #     for i in range(niter):
 #         iternodes()
     iternodes()
-    print("time (from cache)-->", round((time() - t1) / niter, 3))
+    print(f"time (from cache)--> {(time() - t1) / niter:.3f}")
 
 
 def profile(verbose=False):

--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -124,7 +124,7 @@ def process_file(kind, prec, clevel, synth):
         a2, b2 = a_[:], b_[:]
         t0 = time()
         r = eval(expression, {'a': a2, 'b': b2})
-        print("%5.2f" % round(time() - t0, 3))
+        print(f"{time() - t0:5.2f}")
     else:
         expr = tb.Expr(expression, {'a': a_, 'b': b_})
         expr.set_output(r)
@@ -161,4 +161,4 @@ if __name__ == '__main__':
             ts.append(time() - t0)
             t0 = time()
         ratio = size_orig / size
-        print("{:5.2f}, {:5.2f}".format(round(min(ts), 3), ratio))
+        print(f"{min(ts):5.2f}, {ratio:5.2f}")

--- a/bench/bsddb-table-bench.py
+++ b/bench/bsddb-table-bench.py
@@ -242,20 +242,20 @@ if __name__ == "__main__":
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize, verbose)
     t2 = time.perf_counter()
-    tapprows = round(t2 - t1, 3)
+    tapprows = t2 - t1
 
     t1 = time.perf_counter()
     psyco.bind(readFile)
     readFile(file, recsize, verbose)
     t2 = time.perf_counter()
-    treadrows = round(t2 - t1, 3)
+    treadrows = t2 - t1
 
-    print("Rows written:", rowsw, " Row size:", rowsz)
-    print("Time appending rows:", tapprows)
-    if tapprows > 0.:
-        print("Write rows/sec: ", int(iterations / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
-    print("Time reading rows:", treadrows)
-    if treadrows > 0.:
-        print("Read rows/sec: ", int(iterations / float(treadrows)))
-        print("Read KB/s :", int(rowsw * rowsz / (treadrows * 1024)))
+    print(f"Rows written: {rowsw}, Row size: {rowsz}")
+    print(f"Time appending rows: {tapprows:.3f}")
+    if tapprows > 0.001:
+        print(f"Write rows/sec: {iterations / tapprows:.0f}")
+        print(f"Write KB/s: {rowsw * rowsz / (tapprows * 1024):.0f}")
+    print(f"Time reading rows: {treadrows:.3f}")
+    if treadrows > 0.001:
+        print(f"Read rows/sec: {iterations / treadrows:.0f}")
+        print(f"Read KB/s: {rowsw * rowsz / (treadrows * 1024):.0f}")

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -22,18 +22,17 @@ t1 = time()
 zeros = numpy.zeros((dim1, 1), dtype="float64")
 for i in range(dim2):
     a.append(zeros)
-tcre = round(time() - t1, 3)
-thcre = round(dim1 * dim2 * 8 / (tcre * 1024 * 1024), 1)
-print("Time to append %d rows: %s sec (%s MB/s)" % (a.nrows, tcre, thcre))
+tcre = time() - t1
+thcre = dim1 * dim2 * 8 / (tcre * 1024 * 1024)
+print(f"Time to append {a.nrows} rows: {tcre:.3f} sec ({thcre:.1f} MB/s)")
 
 # Read some row vectors from the original array
 t1 = time()
 for i in rows_to_read:
     r1 = a[i, :]
-tr1 = round(time() - t1, 3)
-thr1 = round(dim2 * len(rows_to_read) * 8 / (tr1 * 1024 * 1024), 1)
-print("Time to read ten rows in original array: {} sec ({} MB/s)".format(tr1,
-                                                                     thr1))
+tr1 = time() - t1
+thr1 = dim2 * len(rows_to_read) * 8 / (tr1 * 1024 * 1024)
+print(f"Time to read ten rows in original array: {tr1:.3f} sec ({thr1:.1f} MB/s)")
 
 print("=" * 32)
 # Copy the array to another with a row-wise chunkshape
@@ -41,20 +40,19 @@ t1 = time()
 #newchunkshape = (1, a.chunkshape[0]*a.chunkshape[1])
 newchunkshape = (1, a.chunkshape[0] * a.chunkshape[1] * 10)  # ten times larger
 b = a.copy(f.root, "b", chunkshape=newchunkshape)
-tcpy = round(time() - t1, 3)
-thcpy = round(dim1 * dim2 * 8 / (tcpy * 1024 * 1024), 1)
+tcpy = time() - t1
+thcpy = dim1 * dim2 * 8 / (tcpy * 1024 * 1024)
 print("Chunkshape for row-wise chunkshape array:", b.chunkshape)
-print(f"Time to copy the original array: {tcpy} sec ({thcpy} MB/s)")
+print(f"Time to copy the original array: {tcpy:.3f} sec ({thcpy:.1f} MB/s)")
 
 # Read the same ten rows from the new copied array
 t1 = time()
 for i in rows_to_read:
     r2 = b[i, :]
-tr2 = round(time() - t1, 3)
-thr2 = round(dim2 * len(rows_to_read) * 8 / (tr2 * 1024 * 1024), 1)
-print("Time to read with a row-wise chunkshape: {} sec ({} MB/s)".format(tr2,
-                                                                     thr2))
+tr2 = time() - t1
+thr2 = dim2 * len(rows_to_read) * 8 / (tr2 * 1024 * 1024)
+print(f"Time to read with a row-wise chunkshape: {tr2:.3f} sec ({thr2:.1f} MB/s)")
 print("=" * 32)
-print("Speed-up with a row-wise chunkshape:", round(tr1 / tr2, 1))
+print(f"Speed-up with a row-wise chunkshape: {tr1 / tr2:.1f}")
 
 f.close()

--- a/bench/collations.py
+++ b/bench/collations.py
@@ -33,7 +33,7 @@ for i in range(0, N, lbucket):
 bucket = fill_bucket(N % lbucket)
 table.append(bucket)
 f.close()
-print("Time to create the table with %d entries: %.3f" % (N, time() - t1))
+print(f"Time to create the table with {N} entries: {t1:.3f}")
 
 # Now, read the table and group it by collection
 f = tables.open_file("data.nobackup/collations.h5", "a")

--- a/bench/copy-bench.py
+++ b/bench/copy-bench.py
@@ -24,9 +24,8 @@ for group in filehsrc.walk_groups():
         ntables += 1
         tsize += table.nrows * table.rowsize
 tsizeMB = tsize / (1024 * 1024)
-ttime = round(time.time() - t1, 3)
-speed = round(tsizeMB / ttime, 2)
-print("Copied %s tables for a total of %s MB in %s seconds (%s MB/s)" %
-      (ntables, tsizeMB, ttime, speed))
+ttime = time.time() - t1
+print(f"Copied {ntables} tables for a total of {tsizeMB:.1f} MB"
+      f" in {ttime:.3f} seconds ({tsizeMB / ttime:.1f} MB/s)")
 filehsrc.close()
 filehdest.close()

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -32,7 +32,7 @@ def show_stats(explain, tref):
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
-    print("WallClock time:", round(tnow - tref, 3))
+    print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 
 

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -35,7 +35,7 @@ def show_stats(explain, tref):
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
-    print("WallClock time:", round(tnow - tref, 3))
+    print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 
 

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
         ofile.close()
     else:
         evaluate("a*b+c", out)
-    print("Time for evaluate-->", round(time() - t0, 3))
+    print(f"Time for evaluate--> {time() - t0:.3f}")
 
     # print "out-->", `out`
     # print `out[:]`

--- a/bench/expression.py
+++ b/bench/expression.py
@@ -50,7 +50,7 @@ def tables(docompute, dowrite, complib, verbose):
             a[i] = row * (i + 1)
             b[i] = row * (i + 1) * 2
         f.close()
-        print("[tables.Expr] Time for creating inputs:", round(time() - t0, 3))
+        print(f"[tables.Expr] Time for creating inputs: {time() - t0:.3f}")
 
     if docompute:
         f = tb.open_file(ifilename, 'r')
@@ -68,8 +68,7 @@ def tables(docompute, dowrite, complib, verbose):
             print("First ten values:", r1[0, :10])
         f.close()
         fr.close()
-        print("[tables.Expr] Time for computing & save:",
-              round(time() - t0, 3))
+        print(f"[tables.Expr] Time for computing & save: {time() - t0:.3f}")
 
 
 def memmap(docompute, dowrite, verbose):
@@ -89,8 +88,7 @@ def memmap(docompute, dowrite, verbose):
             a[i] = row * (i + 1)
             b[i] = row * (i + 1) * 2
         del a, b  # flush data
-        print("[numpy.memmap] Time for creating inputs:",
-              round(time() - t0, 3))
+        print(f"[numpy.memmap] Time for creating inputs: {time() - t0:.3f}")
 
     if docompute:
         t0 = time()
@@ -106,7 +104,7 @@ def memmap(docompute, dowrite, verbose):
             print("First ten values:", r[0, :10])
         del a, b
         del r  # flush output data
-        print("[numpy.memmap] Time for compute & save:", round(time() - t0, 3))
+        print(f"[numpy.memmap] Time for compute & save: {time() - t0:.3f}")
 
 
 def do_bench(what, documpute, dowrite, complib, verbose):

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -55,16 +55,16 @@ class DB:
 
     def print_mtime(self, t1, explain):
         mtime = time() - t1
-        print("%s:" % explain, round(mtime, 6))
-        print("Krows/s:", round((self.nrows / 1000.) / mtime, 6))
+        print(f"{explain}: {mtime:.6f}")
+        print(f"Krows/s: {self.nrows / 1000 / mtime:.6f}")
 
     def print_qtime(self, colname, ltimes):
         qtime1 = ltimes[0]  # First measured time
         qtime2 = ltimes[-1]  # Last measured time
-        print("Query time for %s:" % colname, round(qtime1, 6))
-        print("Mrows/s:", round((self.nrows / (MROW)) / qtime1, 6))
-        print("Query time for %s (cached):" % colname, round(qtime2, 6))
-        print("Mrows/s (cached):", round((self.nrows / (MROW)) / qtime2, 6))
+        print(f"Query time for {colname}: {qtime1:.6f}")
+        print(f"Mrows/s: {self.nrows / MROW / qtime1:.6f}")
+        print(f"Query time for {colname} (cached): {qtime2:.6f}")
+        print(f"Mrows/s (cached): {self.nrows / MROW / qtime2:.6f}")
 
     def norm_times(self, ltimes):
         "Get the mean and stddev of ltimes, avoiding the extreme values."
@@ -90,21 +90,20 @@ class DB:
         if verbose:
             print("Times for cold cache:\n", ctimes)
             # print "Times for warm cache:\n", wtimes
-            print("Histogram for warm cache: %s\n%s" %
-                  numpy.histogram(wtimes))
-        print(f"{r}1st query time for {colname}:",
-              round(qtime1, prec))
-        print(f"{r}Query time for {colname} (cold cache):",
-              round(cmean, prec), "+-", round(cstd, prec))
-        print(f"{r}Query time for {colname} (warm cache):",
-              round(wmean, prec), "+-", round(wstd, prec))
+            hist1, hist2 = numpy.histogram(wtimes)
+            print(f"Histogram for warm cache: {hist1}\n{hist2}")
+        print(f"{r}1st query time for {colname}: {qtime1:.{prec}f}")
+        print(f"{r}Query time for {colname} (cold cache): "
+              f"{cmean:.{prec}f} +- {cstd:.{prec}f}")
+        print(f"{r}Query time for {colname} (warm cache): "
+              f"{wmean:.{prec}f} +- {wstd:.{prec}f}")
 
     def print_db_sizes(self, init, filled, indexed):
         table_size = (filled - init) / 1024.
         indexes_size = (indexed - filled) / 1024.
-        print("Table size (MB):", round(table_size, 3))
-        print("Indexes size (MB):", round(indexes_size, 3))
-        print("Full size (MB):", round(table_size + indexes_size, 3))
+        print(f"Table size (MB): {table_size:.3f}")
+        print(f"Indexes size (MB): {indexes_size:.3f}")
+        print(f"Full size (MB): {table_size + indexes_size:.3f}")
 
     def fill_arrays(self, start, stop):
         arr_f8 = numpy.arange(start, stop, dtype='float64')

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -51,12 +51,12 @@ class DB:
 
     def print_mtime(self, t1, explain):
         mtime = time() - t1
-        print("%s:" % explain, round(mtime, 6))
-        print("Krows/s:", round((self.nrows / 1000.) / mtime, 6))
+        print(f"{explain}: {mtime:.6f}")
+        print(f"Krows/s: {self.nrows / 1000. / mtime:.6f}")
 
     def print_db_sizes(self, init, filled):
         array_size = (filled - init) / 1024.
-        print("Array size (MB):", round(array_size, 3))
+        print(f"Array size (MB): {array_size:.3f}")
 
     def open_db(self, remove=0):
         if remove and os.path.exists(self.filename):
@@ -118,8 +118,8 @@ class DB:
             qtime2 = sum(ltimes[5:]) / (ntimes - 5)
         else:
             qtime2 = ltimes[-1]  # Last measured time
-        print("1st query time:", round(qtime1, 3))
-        print("Mean (skipping the first 5 meas.):", round(qtime2, 3))
+        print(f"1st query time: {qtime1:.3f}")
+        print(f"Mean (skipping the first 5 meas.): {qtime2:.3f}")
 
     def query_db(self, niter, avoidfscache, verbose):
         self.con = self.open_db()

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -64,7 +64,7 @@ def bench(chunkshape, filters):
         # e.append([numpy.random.rand(M)])  # use this for less compressibility
         e.append([quantize(numpy.random.rand(M), 6)])
     # os.system("sync")
-    print("Creation time:", round(time() - t1, 3), end=' ')
+    print(f"Creation time: {time() - t1:.3f}", end=' ')
     filesize = get_db_size(filename)
     filesize_bytes = os.stat(filename)[6]
     print("\t\tFile size: %d -- (%s)" % (filesize_bytes, filesize))
@@ -76,7 +76,7 @@ def bench(chunkshape, filters):
     #os.system("sync; echo 1 > /proc/sys/vm/drop_caches")
     for row in e:
         t = row
-    print("Sequential read time:", round(time() - t1, 3), end=' ')
+    print(f"Sequential read time: {time() - t1:.3f}", end=' ')
 
     # f.close()
     # return
@@ -97,7 +97,7 @@ def bench(chunkshape, filters):
     for i in i_index:
         for j in j_index:
             t = e[i, j]
-    print("\tRandom read time:", round(time() - t1, 3))
+    print(f"\tRandom read time: {time() - t1:.3f}")
 
     f.close()
 

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -44,9 +44,9 @@ def print_filesize(filename, clib=None, clevel=0):
             filesize_bytes += os.stat(fname)[6]
     else:
         filesize_bytes = os.stat(filename)[6]
-    filesize_MB = round(filesize_bytes / MB, 1)
-    print("\t\tTotal file sizes: %d -- (%s MB)" % (
-        filesize_bytes, filesize_MB), end=' ')
+    print(
+        f"\t\tTotal file sizes: {filesize_bytes} -- "
+        f"({filesize_bytes / MB:.1f} MB)", end=' ')
     if clevel > 0:
         print(f"(using {clib} lvl{clevel})")
     else:
@@ -144,8 +144,7 @@ if __name__ == '__main__':
 
     tb.print_versions()
 
-    print("Total size for datasets:",
-          round(2 * N * dtype.itemsize / MB, 1), "MB")
+    print(f"Total size for datasets: {2 * N * dtype.itemsize / MB:.1f} MB")
 
     # Get the compression libraries supported
     # supported_clibs = [clib for clib in ("zlib", "lzo", "bzip2", "blosc")
@@ -168,12 +167,11 @@ if __name__ == '__main__':
         elif what == "numpy.memmap":
             populate_x_memmap()
             compute = compute_memmap
-        print("*** Time elapsed populating:", round(time() - t0, 3))
-        print(f"Computing: '{expr}' using {what}")
+        print(f"*** Time elapsed populating: {time() - t0:.3f}")
+        print(f"Computing: {expr!r} using {what}")
         t0 = time()
         compute()
-        print("**************** Time elapsed computing:",
-              round(time() - t0, 3))
+        print(f"**************** Time elapsed computing: {time() - t0:.3f}")
 
     for what in ["tables.Expr"]:
         t0 = time()
@@ -186,10 +184,11 @@ if __name__ == '__main__':
                     continue
                 print("Populating x using %s with %d points..." % (what, N))
                 populate_x_tables(clib, clevel)
-                print("*** Time elapsed populating:", round(time() - t0, 3))
-                print(f"Computing: '{expr}' using {what}")
+                print(f"*** Time elapsed populating: {time() - t0:.3f}")
+                print(f"Computing: {expr!r} using {what}")
                 t0 = time()
                 compute_tables(clib, clevel)
-                print("**************** Time elapsed computing:",
-                      round(time() - t0, 3))
+                print(
+                    f"**************** Time elapsed computing: "
+                    f"{time() - t0:.3f}")
                 first = False

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -115,8 +115,8 @@ def create_db(filename, nrows):
     con.commit()
     ctime = time() - t1
     if verbose:
-        print("insert time:", round(ctime, 5))
-        print("Krows/s:", round((nrows / 1000.) / ctime, 5))
+        print(f"insert time: {ctime:.5f}")
+        print(f"Krows/s: {nrows / 1000. / ctime:.5f}")
     close_db(con, cur)
 
 
@@ -127,8 +127,8 @@ def index_db(filename):
     con.commit()
     itime = time() - t1
     if verbose:
-        print("index time:", round(itime, 5))
-        print("Krows/s:", round(nrows / itime, 5))
+        print(f"index time: {itime:.5f}")
+        print(f"Krows/s: {nrows / itime:.5f}")
     # Close the DB
     close_db(con, cur)
 
@@ -148,8 +148,8 @@ def query_db(filename, rng):
     con.commit()
     qtime = (time() - t1) / ntimes
     if verbose:
-        print("query time:", round(qtime, 5))
-        print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+        print(f"query time: {qtime:.5f}")
+        print(f"Mrows/s: {nrows / 1000. / qtime:.5f}")
         results = sorted(flatten(results))
         print(results)
     close_db(con, cur)

--- a/bench/pytables-search-bench.py
+++ b/bench/pytables-search-bench.py
@@ -47,8 +47,8 @@ def create_db(filename, nrows):
     table.flush()
     ctime = time() - t1
     if verbose:
-        print("insert time:", round(ctime, 5))
-        print("Krows/s:", round((nrows / 1000.) / ctime, 5))
+        print(f"insert time: {ctime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
     index_db(table)
     close_db(con)
 
@@ -58,14 +58,14 @@ def index_db(table):
     table.cols.col2.create_index()
     itime = time() - t1
     if verbose:
-        print("index time (int):", round(itime, 5))
-        print("Krows/s:", round((nrows / 1000.) / itime, 5))
+        print(f"index time (int): {itime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / itime:.5f}")
     t1 = time()
     table.cols.col4.create_index()
     itime = time() - t1
     if verbose:
-        print("index time (float):", round(itime, 5))
-        print("Krows/s:", round((nrows / 1000.) / itime, 5))
+        print(f"index time (float): {itime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / itime:.5f}")
 
 
 def query_db(filename, rng):
@@ -83,8 +83,8 @@ def query_db(filename, rng):
             ]
         qtime = (time() - t1) / ntimes
         if verbose:
-            print("query time (int, not indexed):", round(qtime, 5))
-            print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+            print(f"query time (int, not indexed): {qtime:.5f}")
+            print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
             print(results)
     # Query for indexed column
     t1 = time()
@@ -96,8 +96,8 @@ def query_db(filename, rng):
         ]
     qtime = (time() - t1) / ntimes
     if verbose:
-        print("query time (int, indexed):", round(qtime, 5))
-        print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+        print(f"query time (int, indexed): {qtime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
         print(results)
     # Query for floating columns
     # Query for non-indexed column
@@ -111,8 +111,8 @@ def query_db(filename, rng):
             ]
         qtime = (time() - t1) / ntimes
         if verbose:
-            print("query time (float, not indexed):", round(qtime, 5))
-            print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+            print(f"query time (float, not indexed): {qtime:.5f}")
+            print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
             print(results)
     # Query for indexed column
     t1 = time()
@@ -122,8 +122,8 @@ def query_db(filename, rng):
                    table.where(rng[0] + i <= table.cols.col4 <= rng[1] + i)]
     qtime = (time() - t1) / ntimes
     if verbose:
-        print("query time (float, indexed):", round(qtime, 5))
-        print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+        print(f"query time (float, indexed): {qtime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
         print(results)
     close_db(con)
 

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -34,8 +34,8 @@ for row in range(reclen):
     #r1.field("b")[row] = "changed"
     r1.field("c")[row] = float(row ** 2)
 t2 = time.perf_counter()
-origtime = round(t2 - t1, 3)
-print("Assign time:", origtime, " Rows/s:", int(reclen / (origtime + delta)))
+origtime = t2 - t1
+print(f"Assign time: {origtime:.3f} Rows/s: {reclen / (origtime + delta):.0f}")
 # print "Field b on row 2 after re-assign:", r1.field("c")[2]
 print()
 
@@ -47,10 +47,9 @@ for row in range(reclen):
     # rec.b = "changed"      # change the "b" field
     rec.c = float(row ** 2)  # Change the "c" field
 t2 = time.perf_counter()
-ttime = round(t2 - t1, 3)
-print("Assign time:", ttime, " Rows/s:", int(reclen / (ttime + delta)),
-      end=' ')
-print(" Speed-up:", round(origtime / ttime, 3))
+ttime = t2 - t1
+print(f"Assign time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
+print(f" Speed-up: {origtime / ttime:.3f}")
 # print "Field b on row 2 after re-assign:", r2.field("c")[2]
 print()
 
@@ -62,8 +61,8 @@ for row in range(reclen):
     if rec.field("a") < 3:
         print("This record pass the cut ==>", rec.field("c"), "(row", row, ")")
 t2 = time.perf_counter()
-origtime = round(t2 - t1, 3)
-print("Select time:", origtime, " Rows/s:", int(reclen / (origtime + delta)))
+origtime = t2 - t1
+print(f"Select time: {origtime:.3f}, Rows/s: {reclen / (origtime + delta):.0f}")
 print()
 
 print("Selection in recarray modified")
@@ -74,10 +73,9 @@ for row in range(reclen):
     if rec.a < 3:
         print("This record pass the cut ==>", rec.c, "(row", row, ")")
 t2 = time.perf_counter()
-ttime = round(t2 - t1, 3)
-print("Select time:", ttime, " Rows/s:", int(reclen / (ttime + delta)),
-      end=' ')
-print(" Speed-up:", round(origtime / ttime, 3))
+ttime = t2 - t1
+print(f"Select time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
+print(f" Speed-up: {origtime / ttime:.3f}")
 print()
 
 print("Printing in recarray original")
@@ -86,10 +84,10 @@ f = open("test.out", "w")
 t1 = time.perf_counter()
 f.write(str(r1))
 t2 = time.perf_counter()
-origtime = round(t2 - t1, 3)
+origtime = t2 - t1
 f.close()
 os.unlink("test.out")
-print("Print time:", origtime, " Rows/s:", int(reclen / (origtime + delta)))
+print(f"Print time: {origtime:.3f} Rows/s: {reclen / (origtime + delta):.0f}")
 print()
 print("Printing in recarray modified")
 print("------------------------------")
@@ -97,9 +95,9 @@ f = open("test2.out", "w")
 t1 = time.perf_counter()
 f.write(str(r2))
 t2 = time.perf_counter()
-ttime = round(t2 - t1, 3)
+ttime = t2 - t1
 f.close()
 os.unlink("test2.out")
-print("Print time:", ttime, " Rows/s:", int(reclen / (ttime + delta)), end=' ')
-print(" Speed-up:", round(origtime / ttime, 3))
+print(f"Print time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
+print(f" Speed-up: {origtime / ttime:.3f}")
 print()

--- a/bench/searchsorted-bench.py
+++ b/bench/searchsorted-bench.py
@@ -301,14 +301,14 @@ if __name__ == "__main__":
                                     atom, recsize, index, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written:", rowsw, " Row size:", rowsz)
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec: {rowsw / tapprows:.0f}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         if psyco_imported and usepsyco:
@@ -323,16 +323,16 @@ if __name__ == "__main__":
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
         tMrows = rowsr / (1000 * 1000.)
         sKrows = rowsel / 1000.
-        print("Rows read:", rowsr, "Mread:", round(tMrows, 3), "Mrows")
-        print("Rows selected:", rowsel, "Ksel:", round(sKrows, 3), "Krows")
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read Mrows/sec: ", round(tMrows / float(treadrows), 3))
+        print(f"Rows read: {rowsr} Mread: {tMrows:.3f} Mrows")
+        print(f"Rows selected: {rowsel} Ksel: {sKrows:.3f} Krows")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read Mrows/sec: {tMrows / treadrows:.3f}")
         # print "Read KB/s :", int(rowsr * rowsz / (treadrows * 1024))
 #       print "Uncompr MB :", int(uncomprB / (1024 * 1024))
 #       print "Uncompr MB/s :", int(uncomprB / (treadrows * 1024 * 1024))

--- a/bench/searchsorted-bench2.py
+++ b/bench/searchsorted-bench2.py
@@ -301,14 +301,14 @@ if __name__ == "__main__":
                                     atom, recsize, index, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec:  {rowsw / tapprows:.0f}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         if psyco_imported and usepsyco:
@@ -323,16 +323,16 @@ if __name__ == "__main__":
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
         tMrows = rowsr / (1000 * 1000.)
         sKrows = rowsel / 1000.
-        print("Rows read:", rowsr, "Mread:", round(tMrows, 3), "Mrows")
-        print("Rows selected:", rowsel, "Ksel:", round(sKrows, 3), "Krows")
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read Mrows/sec: ", round(tMrows / float(treadrows), 3))
+        print(f"Rows read: {rowsr} Mread: {tMrows:.3f} Mrows")
+        print(f"Rows selected: {rowsel} Ksel: {sKrows:.3f} Krows")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read Mrows/sec: {tMrows / treadrows:.3f}")
         # print "Read KB/s :", int(rowsr * rowsz / (treadrows * 1024))
 #       print "Uncompr MB :", int(uncomprB / (1024 * 1024))
 #       print "Uncompr MB/s :", int(uncomprB / (treadrows * 1024 * 1024))

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -181,18 +181,18 @@ if __name__ == "__main__":
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize)
     t2 = time.perf_counter()
-    tapprows = round(t2 - t1, 3)
+    tapprows = t2 - t1
 
     t1 = time.perf_counter()
     psyco.bind(readFile)
     readFile(file, recsize)
     t2 = time.perf_counter()
-    treadrows = round(t2 - t1, 3)
+    treadrows = t2 - t1
 
-    print("Rows written:", rowsw, " Row size:", rowsz)
-    print("Time appending rows:", tapprows)
-    print("Write rows/sec: ", int(iterations * 3 / float(tapprows)))
-    print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
-    print("Time reading rows:", treadrows)
-    print("Read rows/sec: ", int(iterations * 3 / float(treadrows)))
-    print("Read KB/s :", int(rowsw * rowsz / (treadrows * 1024)))
+    print(f"Rows written: {rowsw}  Row size: {rowsz}")
+    print(f"Time appending rows: {tapprows:.3f}")
+    print(f"Write rows/sec: {iterations * 3 / tapprows:.0f}")
+    print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
+    print(f"Time reading rows: {treadrows:.3f}")
+    print(f"Read rows/sec:  {iterations * 3 / treadrows:.0f}")
+    print(f"Read KB/s : {rowsw * rowsz / (treadrows * 1024):.0f}")

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -147,14 +147,13 @@ CREATE INDEX ivar3 ON small(var3);
                 fields = (var1[n], var2[n], var3[n])
                 cursor.execute(SQL, fields)
             conn.commit()
-        t1 = round(time.time() - time1, 5)
-        tcpu1 = round(time.perf_counter() - cpu1, 5)
+        t1 = time.time() - time1
+        tcpu1 = time.perf_counter() - cpu1
         rowsecf = nrows / t1
         size1 = os.stat(dbfile)[6]
-        print("******** Results for writing nrows = %s" % (nrows), "*********")
-        print(("Insert time:", t1, ", KRows/s:",
-              round((nrows / 10. ** 3) / t1, 3),))
-        print(", File size:", round(size1 / (1024. * 1024.), 3), "MB")
+        print(f"******** Results for writing nrows = {nrows} *********")
+        print(f"Insert time: {t1:.5f}, KRows/s: {nrows / 1000 / t1:.3f}")
+        print(f", File size: {size1 / (1024. * 1024.):.3f} MB")
 
     # Indexem
     if indexmode == "indexed":
@@ -167,14 +166,12 @@ CREATE INDEX ivar3 ON small(var3);
         conn.commit()
         cursor.execute("CREATE INDEX ivar3 ON small(var3)")
         conn.commit()
-        t2 = round(time.time() - time1, 5)
-        tcpu2 = round(time.perf_counter() - cpu1, 5)
+        t2 = time.time() - time1
+        tcpu2 = time.perf_counter() - cpu1
         rowseci = nrows / t2
-        print(("Index time:", t2, ", IKRows/s:",
-              round((nrows / 10. ** 3) / t2, 3),))
+        print(f"Index time: {t2:.5f}, IKRows/s: {nrows / 1000 / t2:.3f}")
         size2 = os.stat(dbfile)[6] - size1
-        print((", Final size with index:",
-              round(size2 / (1024. * 1024), 3), "MB"))
+        print(f", Final size with index: {size2 / (1024. * 1024):.3f} MB")
 
     conn.close()
 
@@ -318,12 +315,13 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
             t2 = time2 / (riter - correction)
             tcpu2 = cpu2 / (riter - correction)
 
-        print("*** Query results for atom = %s, nrows = %s, "
-              "indexmode = %s ***" % (atom, nrows, indexmode))
-        print("Query time:", round(t1, 5), ", cached time:", round(t2, 5))
-        print("MRows/s:", round((nrows / 10. ** 6) / t1, 3), end=' ')
+        print(
+            f"*** Query results for atom = {atom}, "
+            f"nrows = {nrows}, indexmode = {indexmode} ***")
+        print(f"Query time: {t1:.5f}, cached time: {t2:.5f}")
+        print(f"MRows/s: {nrows / 1_000_000 / t1:.3f}", end=' ')
         if t2 > 0:
-            print(", cached MRows/s:", round((nrows / 10. ** 6) / t2, 3))
+            print(f", cached MRows/s: {(nrows / 10. ** 6) / t2:.3f}")
         else:
             print()
 

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -59,8 +59,8 @@ def create_db(filename, nrows):
     con.commit()
     ctime = time() - t1
     if verbose:
-        print("insert time:", round(ctime, 5))
-        print("Krows/s:", round((nrows / 1000.) / ctime, 5))
+        print(f"insert time: {ctime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
     close_db(con, cur)
 
 
@@ -71,8 +71,8 @@ def index_db(filename):
     con.commit()
     itime = time() - t1
     if verbose:
-        print("index time:", round(itime, 5))
-        print("Krows/s:", round(nrows / itime, 5))
+        print(f"index time: {itime:.5f}")
+        print(f"Krows/s: {nrows / itime:.5f}")
     # Close the DB
     close_db(con, cur)
 
@@ -92,8 +92,8 @@ def query_db(filename, rng):
     con.commit()
     qtime = (time() - t1) / ntimes
     if verbose:
-        print("query time:", round(qtime, 5))
-        print("Mrows/s:", round((nrows / 1000.) / qtime, 5))
+        print(f"query time: {qtime:.5f}")
+        print(f"Mrows/s: {nrows / 1000 / qtime:.5f}")
         print(results)
     close_db(con, cur)
 

--- a/bench/stress-test.py
+++ b/bench/stress-test.py
@@ -272,14 +272,14 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
                                         complevel, complib, recsize)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec:  {rowsw / tapprows}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         t1 = time.time()
@@ -291,14 +291,14 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
-        print("Rows read:", rowsr, " Row size:", rowsz, "Buf size:", bufsz)
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read rows/sec: ", int(rowsr / float(treadrows)))
-        print("Read KB/s :", int(rowsr * rowsz / (treadrows * 1024)))
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
+        print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read rows/sec:  {rowsr / treadrows}")
+        print(f"Read KB/s : {rowsr * rowsz / (treadrows * 1024):.0f}")
 
 if __name__ == "__main__":
     import getopt

--- a/bench/stress-test2.py
+++ b/bench/stress-test2.py
@@ -206,14 +206,14 @@ if __name__ == "__main__":
                                     complevel, complib, recsize)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec:  {rowsw / tapprows}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         t1 = time.time()
@@ -223,14 +223,14 @@ if __name__ == "__main__":
         (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
-        print("Rows read:", rowsr, " Row size:", rowsz, "Buf size:", bufsz)
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read rows/sec: ", int(rowsr / float(treadrows)))
-        print("Read KB/s :", int(rowsr * rowsz / (treadrows * 1024)))
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
+        print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read rows/sec:  {rowsr / treadrows}")
+        print(f"Read KB/s : {rowsr * rowsz / (treadrows * 1024):.0f}")
 
     # Show the dirt
     if debug > 1:

--- a/bench/stress-test3.py
+++ b/bench/stress-test3.py
@@ -254,14 +254,14 @@ if __name__ == "__main__":
                                         complevel, complib, recsize)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec:  {rowsw / tapprows}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         t1 = time.time()
@@ -275,14 +275,14 @@ if __name__ == "__main__":
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
-        print("Rows read:", rowsr, " Row size:", rowsz, "Buf size:", bufsz)
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read rows/sec: ", int(rowsr / float(treadrows)))
-        print("Read KB/s :", int(rowsr * rowsz / (treadrows * 1024)))
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
+        print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read rows/sec:  {rowsr / treadrows}")
+        print(f"Read KB/s : {rowsr * rowsz / (treadrows * 1024):.0f}")
 
     # Show the dirt
     if debug > 1:

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -389,14 +389,14 @@ if __name__ == "__main__":
             (rowsw, rowsz) = createFile(file, iterations, filters, recsize)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        tapprows = round(t2 - t1, 3)
-        cpuapprows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpuapprows / tapprows, 2) * 100)
-        print("Rows written:", rowsw, " Row size:", rowsz)
-        print("Time writing rows: %s s (real) %s s (cpu)  %s%%" %
-              (tapprows, cpuapprows, tpercent))
-        print("Write rows/sec: ", int(rowsw / float(tapprows)))
-        print("Write KB/s :", int(rowsw * rowsz / (tapprows * 1024)))
+        tapprows = t2 - t1
+        cpuapprows = cpu2 - cpu1
+        print(f"Rows written: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time writing rows: {tapprows:.3f} s (real) "
+            f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
+        print(f"Write rows/sec:  {rowsw / tapprows}")
+        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
         t1 = time.time()
@@ -413,11 +413,11 @@ if __name__ == "__main__":
                 (rowsr, rowsz) = readFile(file, recsize, verbose)
         t2 = time.time()
         cpu2 = time.perf_counter()
-        treadrows = round(t2 - t1, 3)
-        cpureadrows = round(cpu2 - cpu1, 3)
-        tpercent = int(round(cpureadrows / treadrows, 2) * 100)
-        print("Rows read:", rowsr, " Row size:", rowsz)
-        print("Time reading rows: %s s (real) %s s (cpu)  %s%%" %
-              (treadrows, cpureadrows, tpercent))
-        print("Read rows/sec: ", int(rowsr / float(treadrows)))
-        print("Read KB/s :", int(rowsr * rowsz / (treadrows * 1024)))
+        treadrows = t2 - t1
+        cpureadrows = cpu2 - cpu1
+        print(f"Rows read: {rowsw}  Row size: {rowsz}")
+        print(
+            f"Time reading rows: {treadrows:.3f} s (real) "
+            f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")
+        print(f"Read rows/sec:  {rowsr / treadrows}")
+        print(f"Read KB/s : {rowsr * rowsz / (treadrows * 1024):.0f}")

--- a/examples/particles.py
+++ b/examples/particles.py
@@ -45,13 +45,12 @@ for i in range(NEVENTS):
         # This injects the row values.
         particle.append()
 table.flush()
-print("Added %s entries --- Time: %s sec" %
-      (table.nrows, round((time() - t1), 3)))
+print(f"Added {table.nrows} entries --- Time: {time() - t1:.3f} sec")
 
 t1 = time()
 print("Creating index...")
 table.cols.event_id.create_index(optlevel=0, _verbose=True)
-print("Index created --- Time: %s sec" % (round((time() - t1), 3)))
+print(f"Index created --- Time: {time() - t1:.3f} sec")
 # Add the number of events as an attribute
 table.attrs.nevents = NEVENTS
 
@@ -68,7 +67,7 @@ t1 = time()
 for row in table.where("event_id == 34"):
         nrows += 1
 print(nrows)
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 print("Root particles in event 34:", end=' ')
 nrows = 0
@@ -77,7 +76,7 @@ for row in table.where("event_id == 34"):
     if row['parent_id'] < 0:
         nrows += 1
 print(nrows)
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 print("Sum of masses of root particles in event 34:", end=' ')
 smass = 0.0
@@ -86,7 +85,7 @@ for row in table.where("event_id == 34"):
     if row['parent_id'] < 0:
         smass += row['mass']
 print(smass)
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 print(
     "Sum of masses of daughter particles for particle 3 in event 34:", end=' ')
@@ -96,7 +95,7 @@ for row in table.where("event_id == 34"):
     if row['parent_id'] == 3:
         smass += row['mass']
 print(smass)
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 print("Sum of module of momentum for particle 3 in event 34:", end=' ')
 smomentum = 0.0
@@ -106,7 +105,7 @@ for row in table.where("event_id == 34"):
     if row['parent_id'] == 3:
         smomentum += np.sqrt(np.add.reduce(row['momentum'] ** 2))
 print(smomentum)
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 # This is the same than above, but using generator expressions
 # Python >= 2.4 needed here!
@@ -115,7 +114,7 @@ t1 = time()
 print(sum(np.sqrt(np.add.reduce(row['momentum'] ** 2))
           for row in table.where("event_id == 34")
           if row['parent_id'] == 3))
-print("Done --- Time:", round((time() - t1), 3), "sec")
+print(f"Done --- Time: {time() - t1:.3f} sec")
 
 
 fileh.close()

--- a/tables/index.py
+++ b/tables/index.py
@@ -945,9 +945,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         # in verbose mode!).
         self.compute_overlaps(self.tmp, "do_complete_sort()", self.verbose)
         if self.verbose:
-            t = round(time() - t1, 4)
-            c = round(perf_counter() - c1, 4)
-            print(f"time: {t}. clock: {c}")
+            print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
 
     def swap(self, what, mode=None):
         """Swap chunks or slices using a certain bounds reference."""
@@ -974,9 +972,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             self.tmp, message, self.verbose)
         rmult = len(mult.nonzero()[0]) / float(len(mult))
         if self.verbose:
-            t = round(time() - t1, 4)
-            c = round(perf_counter() - c1, 4)
-            print(f"time: {t}. clock: {c}")
+            print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
         # Check that entropy is actually decreasing
         if what == "chunks" and self.last_tover > 0. and self.last_nover > 0:
             tover_var = (self.last_tover - tover) / self.last_tover

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -547,14 +547,9 @@ def main():
 
     # Gather some statistics
     t2 = time.time()
-    cpu2 = cputime ()
-    tcopy = round(t2 - t1, 3)
-    cpucopy = round(cpu2 - cpu1, 3)
-    try:
-        tpercent = int(round(cpucopy / tcopy, 2) * 100)
-    except ZeroDivisionError:
-        tpercent = 'NaN'
-
+    cpu2 = cputime()
+    tcopy = t2 - t1
+    cpucopy = cpu2 - cpu1
     if verbose:
         ngroups = stats['groups']
         nleaves = stats['leaves']
@@ -573,8 +568,9 @@ def main():
             print("User attrs copied")
         else:
             print("User attrs not copied")
-        print("KBytes copied:", round(nbytescopied / 1024., 3))
-        print("Time copying: {} s (real) {} s (cpu)  {}%".format(
-            tcopy, cpucopy, tpercent))
-        print("Copied nodes/sec: ", round((nnodes) / float(tcopy), 1))
-        print("Copied KB/s :", int(nbytescopied / (tcopy * 1024)))
+        print(f"KBytes copied: {nbytescopied / 1024.:.3f}")
+        print(
+            f"Time copying: {tcopy:.3f} s (real) {cpucopy:.3f} s "
+            f"(cpu)  {cpucopy / tcopy:.0%}")
+        print(f"Copied nodes/sec: {nnodes / tcopy:.1f}")
+        print(f"Copied KB/s : {nbytescopied / tcopy / 1024:.0f}")

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -269,7 +269,7 @@ def show_stats(explain, tref, encoding=None):
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
     tnow = time()
-    print("WallClock time:", round(tnow - tref, 3))
+    print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 
 


### PR DESCRIPTION
Most calls to `round()` are used to prepare the values to format into a string. This can be replaced by proper `.Xf` format in an f-string.

The amount of potential new f-strings in the code is very high and I have recognized some patterns that could be refactored later. I'll add new code features in similar batches.