### PR TITLE
Simplify numeric operations

### DIFF
--- a/bench/LRUcache-node-bench.py
+++ b/bench/LRUcache-node-bench.py
@@ -30,7 +30,7 @@ def iternodes():
 #     for a in f.root.NodeContainer:
 #         pass
     indices = numpy.random.randn(nodespergroup * niter) * \
-        30 + nodespergroup / 2.
+        30 + nodespergroup / 2
     indices = indices.astype('i4').clip(0, nodespergroup - 1)
     g = f.get_node("/", "NodeContainer")
     for i in indices:

--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -50,7 +50,7 @@ def create_file(kind, prec, synth):
                 r[:] = col[:]
         f2.close()
         if clevel == 0:
-            size = 1.5 * float(os.stat(oname)[6])
+            size = 1.5 * os.stat(oname)[6]
     f.close()
     return size
 
@@ -88,7 +88,7 @@ def create_synth(kind, prec):
 
         f2.close()
         if clevel == 0:
-            size = 1.5 * float(os.stat(oname)[6])
+            size = 1.5 * os.stat(oname)[6]
     f.close()
     return size
 
@@ -131,7 +131,7 @@ def process_file(kind, prec, clevel, synth):
         expr.eval()
     f.close()
     f2.close()
-    size = float(os.stat(iname)[6]) + float(os.stat(oname)[6])
+    size = os.stat(iname)[6] + os.stat(oname)[6]
     return size
 
 

--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -50,7 +50,7 @@ def create_file(kind, prec, synth):
                 r[:] = col[:]
         f2.close()
         if clevel == 0:
-            size = 1.5 * os.stat(oname)[6]
+            size = 1.5 * os.stat(oname).st_size
     f.close()
     return size
 
@@ -88,7 +88,7 @@ def create_synth(kind, prec):
 
         f2.close()
         if clevel == 0:
-            size = 1.5 * os.stat(oname)[6]
+            size = 1.5 * os.stat(oname).st_size
     f.close()
     return size
 
@@ -131,7 +131,7 @@ def process_file(kind, prec, clevel, synth):
         expr.eval()
     f.close()
     f2.close()
-    size = os.stat(iname)[6] + os.stat(oname)[6]
+    size = os.stat(iname).st_size + os.stat(oname).st_size
     return size
 
 

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -7,7 +7,7 @@ import numpy
 import tables
 from time import time
 
-dim1, dim2 = 360, 6109666
+dim1, dim2 = 360, 6_109_666
 rows_to_read = range(0, 360, 36)
 
 print("=" * 32)

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -7,7 +7,7 @@ from numexpr.necompiler import (
     getContext, getExprNames, getType, NumExpr)
 
 
-shape = (1000, 160000)
+shape = (1000, 160_000)
 #shape = (10,1600)
 filters = tb.Filters(complevel=1, complib="blosc", shuffle=0)
 ofilters = tb.Filters(complevel=1, complib="blosc", shuffle=0)

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -127,15 +127,15 @@ if __name__ == "__main__":
         b = np.ones(shape, dtype='float32') * 2
         c = np.ones(shape, dtype='float32') * 3
     else:
-        a = f.create_carray(f.root, 'a', tb.Float32Atom(dflt=1.),
+        a = f.create_carray(f.root, 'a', tb.Float32Atom(dflt=1),
                             shape=shape, filters=filters)
-        a[:] = 1.
-        b = f.create_carray(f.root, 'b', tb.Float32Atom(dflt=2.),
+        a[:] = 1
+        b = f.create_carray(f.root, 'b', tb.Float32Atom(dflt=2),
                             shape=shape, filters=filters)
-        b[:] = 2.
-        c = f.create_carray(f.root, 'c', tb.Float32Atom(dflt=3.),
+        b[:] = 2
+        c = f.create_carray(f.root, 'c', tb.Float32Atom(dflt=3),
                             shape=shape, filters=filters)
-        c[:] = 3.
+        c[:] = 3
     if oarrays:
         out = np.empty(shape, dtype='float32')
     else:

--- a/bench/get-figures-ranges.py
+++ b/bench/get-figures-ranges.py
@@ -220,8 +220,8 @@ if __name__ == '__main__':
         #plots.append(semilogx(xval, yval, linewidth=5))
         legends.append(plegend)
     if 0:  # Per a introduir dades simulades si es vol...
-        xval = [1000, 10000, 100000, 1000000, 10000000,
-                100000000, 1000000000]
+        xval = [1000, 10_000, 100_000, 1_000_000, 10_000_000,
+                100_000_000, 1_000_000_000]
 #         yval = [0.003, 0.005, 0.02, 0.06, 1.2,
 #                 40, 210]
         yval = [0.0009, 0.0011, 0.0022, 0.005, 0.02,

--- a/bench/get-figures.py
+++ b/bench/get-figures.py
@@ -280,8 +280,8 @@ if __name__ == '__main__':
             #plots.append(semilogx(xval, yval, linewidth=linewidth, color='m'))
             legends.append(plegend)
     if 0:  # Per a introduir dades simulades si es vol...
-        xval = [1000, 10000, 100000, 1000000, 10000000,
-                100000000, 1000000000]
+        xval = [1000, 10_000, 100_000, 1_000_000, 10_000_000,
+                100_000_000, 1_000_000_000]
 #         yval = [0.003, 0.005, 0.02, 0.06, 1.2,
 #                 40, 210]
         yval = [0.0009, 0.0011, 0.0022, 0.005, 0.02,

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -15,7 +15,7 @@ NI_NTIMES = 1       # The number of queries for doing a mean (non-idx cols)
 # COLDCACHE = 50   # The number of reads where the cache is considered 'cold'
 # WARMCACHE = 50   # The number of reads until the cache is considered 'warmed'
 # READ_TIMES = WARMCACHE+50    # The number of complete calls to DB.query_db()
-MROW = 1000 * 1000.
+MROW = 1000 * 1000
 
 # Test values
 COLDCACHE = 5   # The number of reads where the cache is considered 'cold'
@@ -99,8 +99,8 @@ class DB:
               f"{wmean:.{prec}f} +- {wstd:.{prec}f}")
 
     def print_db_sizes(self, init, filled, indexed):
-        table_size = (filled - init) / 1024.
-        indexes_size = (indexed - filled) / 1024.
+        table_size = (filled - init) / 1024
+        indexes_size = (indexed - filled) / 1024
         print(f"Table size (MB): {table_size:.3f}")
         print(f"Indexes size (MB): {indexes_size:.3f}")
         print(f"Full size (MB): {table_size + indexes_size:.3f}")

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -52,10 +52,10 @@ class DB:
     def print_mtime(self, t1, explain):
         mtime = time() - t1
         print(f"{explain}: {mtime:.6f}")
-        print(f"Krows/s: {self.nrows / 1000. / mtime:.6f}")
+        print(f"Krows/s: {self.nrows / 1000 / mtime:.6f}")
 
     def print_db_sizes(self, init, filled):
-        array_size = (filled - init) / 1024.
+        array_size = (filled - init) / 1024
         print(f"Array size (MB): {array_size:.3f}")
 
     def open_db(self, remove=0):

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -66,7 +66,7 @@ def bench(chunkshape, filters):
     # os.system("sync")
     print(f"Creation time: {time() - t1:.3f}", end=' ')
     filesize = get_db_size(filename)
-    filesize_bytes = os.stat(filename)[6]
+    filesize_bytes = os.stat(filename).st_size
     print("\t\tFile size: %d -- (%s)" % (filesize_bytes, filesize))
 
     # Read in sequential mode:

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -17,7 +17,7 @@ import tables
 # N, M = 512, 2**16     # 256 MB
 # N, M = 512, 2**18     # 1 GB
 # N, M = 512, 2**19     # 2 GB
-N, M = 2000, 1000000  # 15 GB
+N, M = 2000, 1_000_000  # 15 GB
 # N, M = 4000, 1000000  # 30 GB
 datom = tables.Float64Atom()   # elements are double precision
 

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -34,9 +34,9 @@ def quantize(data, least_significant_digit):
     precision = 10 ** -least_significant_digit
     exp = math.log(precision, 10)
     if exp < 0:
-        exp = int(math.floor(exp))
+        exp = math.floor(exp)
     else:
-        exp = int(math.ceil(exp))
+        exp = math.ceil(exp)
     bits = math.ceil(math.log(10 ** -exp, 2))
     scale = 2 ** bits
     return numpy.around(scale * data) / scale

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -31,14 +31,14 @@ def quantize(data, least_significant_digit):
 
     """
 
-    precision = 10. ** -least_significant_digit
+    precision = 10 ** -least_significant_digit
     exp = math.log(precision, 10)
     if exp < 0:
         exp = int(math.floor(exp))
     else:
         exp = int(math.ceil(exp))
-    bits = math.ceil(math.log(10. ** -exp, 2))
-    scale = 2. ** bits
+    bits = math.ceil(math.log(10 ** -exp, 2))
+    scale = 2 ** bits
     return numpy.around(scale * data) / scale
 
 

--- a/bench/plot-bar.py
+++ b/bench/plot-bar.py
@@ -19,7 +19,7 @@ def get_values(filename):
     for line in f:
         if show_memory:
             if line.startswith('VmData:'):
-                values.append(float(line.split()[1]) / 1024.)
+                values.append(float(line.split()[1]) / 1024)
         else:
             if line.startswith('WallClock time:'):
                 values.append(float(line.split(':')[1]))
@@ -46,7 +46,7 @@ def show_plot(bars, filenames, tit):
         ylabel('Time (s)')
     title(tit)
     n = len(filenames)
-    xticks(ind + width * n / 2., checks, rotation=45,
+    xticks(ind + width * n / 2, checks, rotation=45,
            horizontalalignment='right', fontsize=8)
     if not gtotal:
         #loc = 'center right'

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -31,7 +31,7 @@ mpfnames = [fprefix + "-x.bin", fprefix + "-r.bin"]
 # Filename for tables.Expr
 h5fname = "tablesExpr.h5"     # the I/O file
 
-MB = 1024 * 1024.               # a MegaByte
+MB = 1024 * 1024               # a MegaByte
 
 
 def print_filesize(filename, clib=None, clevel=0):

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -67,8 +67,8 @@ def populate_x_memmap():
 
     # Populate x in range [-1, 1]
     for i in range(0, N, step):
-        chunk = np.linspace((2 * i - N) / float(N),
-                            (2 * (i + step) - N) / float(N), step)
+        chunk = np.linspace((2 * i - N) / N,
+                            (2 * (i + step) - N) / N, step)
         x[i:i + step] = chunk
     del x        # close x memmap
 
@@ -87,8 +87,8 @@ def populate_x_tables(clib, clevel):
 
     # Populate x in range [-1, 1]
     for i in range(0, N, step):
-        chunk = np.linspace((2 * i - N) / float(N),
-                            (2 * (i + step) - N) / float(N), step)
+        chunk = np.linspace((2 * i - N) / N,
+                            (2 * (i + step) - N) / N, step)
         x[i:i + step] = chunk
     f.close()
 

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -39,11 +39,9 @@ def print_filesize(filename, clib=None, clevel=0):
 
     # os.system("sync")    # make sure that all data has been flushed to disk
     if isinstance(filename, list):
-        filesize_bytes = 0
-        for fname in filename:
-            filesize_bytes += os.stat(fname)[6]
+        filesize_bytes = sum(os.stat(fname).st_size for fname in filename)
     else:
-        filesize_bytes = os.stat(filename)[6]
+        filesize_bytes = os.stat(filename).st_size
     print(
         f"\t\tTotal file sizes: {filesize_bytes} -- "
         f"({filesize_bytes / MB:.1f} MB)", end=' ')

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -116,7 +116,7 @@ def create_db(filename, nrows):
     ctime = time() - t1
     if verbose:
         print(f"insert time: {ctime:.5f}")
-        print(f"Krows/s: {nrows / 1000. / ctime:.5f}")
+        print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
     close_db(con, cur)
 
 
@@ -149,7 +149,7 @@ def query_db(filename, rng):
     qtime = (time() - t1) / ntimes
     if verbose:
         print(f"query time: {qtime:.5f}")
-        print(f"Mrows/s: {nrows / 1000. / qtime:.5f}")
+        print(f"Mrows/s: {nrows / 1000 / qtime:.5f}")
         results = sorted(flatten(results))
         print(results)
     close_db(con, cur)

--- a/bench/postgres_backend.py
+++ b/bench/postgres_backend.py
@@ -127,7 +127,7 @@ class Postgres_DB(DB):
         return results
 
     def do_query(self, con, column, base, *unused):
-        d = (self.rng[1] - self.rng[0]) / 2.
+        d = (self.rng[1] - self.rng[0]) / 2
         inf1 = int(self.rng[0] + base)
         sup1 = int(self.rng[0] + d + base)
         inf2 = self.rng[0] + base * 2

--- a/bench/pytables_backend.py
+++ b/bench/pytables_backend.py
@@ -110,7 +110,7 @@ class PyTables_DB(DB):
         self.condvars['inf'] = self.rng[0] + base
         self.condvars['sup'] = self.rng[1] + base
         # For queries that can use two indexes instead of just one
-        d = (self.rng[1] - self.rng[0]) / 2.
+        d = (self.rng[1] - self.rng[0]) / 2
         inf1 = int(self.rng[0] + base)
         sup1 = int(self.rng[0] + d + base)
         inf2 = self.rng[0] + base * 2

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -16,7 +16,7 @@ except:
     print(usage)
     sys.exit()
 
-delta = 0.000001
+delta = 0.000_001
 
 # Creation of recarrays objects for test
 x1 = np.array(np.arange(reclen))

--- a/bench/search-bench-plot.py
+++ b/bench/search-bench-plot.py
@@ -5,9 +5,9 @@ from pylab import *
 def get_values(filename, complib=''):
     f = tables.open_file(filename)
     nrows = f.root.small.create_best.cols.nrows[:]
-    corrected_sizes = nrows / 10. ** 6
+    corrected_sizes = nrows / 10 ** 6
     if mb_units:
-        corrected_sizes = 16 * nrows / 10. ** 6
+        corrected_sizes = 16 * nrows / 10 ** 6
     if insert:
         values = corrected_sizes / f.root.small.create_best.cols.tfill[:]
     if table_size:

--- a/bench/search-bench-plot.py
+++ b/bench/search-bench-plot.py
@@ -136,8 +136,8 @@ if __name__ == '__main__':
         plots.append(semilogx(xval, yval, linewidth=4))
         legends.append(plegend)
     if 0:  # Per a introduir dades simulades si es vol...
-        xval = [1000, 10000, 100000, 1000000, 10000000,
-                100000000, 1000000000]
+        xval = [1000, 10_000, 100_000, 1_000_000, 10_000_000,
+                100_000_000, 1_000_000_000]
 #         yval = [0.003, 0.005, 0.02, 0.06, 1.2,
 #                 40, 210]
         yval = [0.0009, 0.0011, 0.0022, 0.005, 0.02,

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -115,10 +115,12 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     rowswritten += nrows
     time1 = time.time() - t1
     tcpu1 = time.perf_counter() - cpu1
-    print(f"Time for filling: {time1:.3f} Krows/s: {nrows / 1000. / time1:.3f}", end=' ')
+    print(
+        f"Time for filling: {time1:.3f} Krows/s: {nrows / 1000 / time1:.3f}",
+        end=' ')
     fileh.close()
     size1 = os.stat(filename)[6]
-    print(f", File size: {size1 / (1024. * 1024.):.3f} MB")
+    print(f", File size: {size1 / 1024 / 1024:.3f} MB")
     fileh = open_file(filename, mode="a", title="Searchsorted Benchmark",
                       filters=filters)
     table = fileh.root.table
@@ -135,12 +137,12 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
         tcpu2 = time.perf_counter() - cpu1
         print(
             f"Time for indexing: {time2:.3f} "
-            f"iKrows/s: {indexrows / 1000. / time2:.3f}",
+            f"iKrows/s: {indexrows / 1000 / time2:.3f}",
             end=' ')
     else:
         indexrows = 0
         time2 = 0.0000000001  # an ugly hack
-        tcpu2 = 0.
+        tcpu2 = 0
 
     if verbose:
         if index:
@@ -153,7 +155,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
 
     size2 = os.stat(filename)[6] - size1
     if index:
-        print(f", Index size: {size2 / (1024. * 1024.):.3f} MB")
+        print(f", Index size: {size2 / 1024 / 1024:.3f} MB")
     return (rowswritten, indexrows, rowsize, time1, time2,
             tcpu1, tcpu2, size1, size2)
 
@@ -187,7 +189,7 @@ def benchCreate(file, nrows, filters, index, bfile, heavy,
         f"{tcpu1} s (cpu)  {tcpu1 / time1:.0%}")
     rowsecf = rowsw / time1
     table.row["rowsecf"] = rowsecf
-    print(f"Total file size: {(size1 + size2) / (1024. * 1024.):.3f} MB", end=' ')
+    print(f"Total file size: {(size1 + size2) / 1024 / 1024:.3f} MB", end=' ')
     print(f", Write KB/s (pure data): {rowsw * rowsz / (time1 * 1024):.0f}")
     print(f"Rows indexed: {irows} (IMRows): {irows / 10 ** 6}")
     print(
@@ -231,8 +233,8 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
     #table.nrowsinbuf = 10
     # print "nrowsinbuf-->", table.nrowsinbuf
     rowselected = 0
-    time2 = 0.
-    tcpu2 = 0.
+    time2 = 0
+    tcpu2 = 0
     results = []
     print("Select mode:", indexmode, ". Selecting for type:", atom)
     # Initialize the random generator always with the same integer
@@ -360,11 +362,11 @@ def benchSearch(file, riter, indexmode, bfile, heavy, psyco, dselect, verbose):
                 f"(real) {cpureadrows2:.6f} s (cpu)  {tratio2:.0%}")
         rowsec1 = rowsr / treadrows
         row["rowsec1"] = rowsec1
-        print(f"Read Mrows/sec: {rowsec1 / 10. ** 6:.6f} (first time)", end=' ')
+        print(f"Read Mrows/sec: {rowsec1 / 10 ** 6:.6f} (first time)", end=' ')
         if riter > 1:
             rowsec2 = rowsr / treadrows2
             row["rowsec2"] = rowsec2
-            print(f"{rowsec2 / 10. ** 6:.6f} (cache time)")
+            print(f"{rowsec2 / 10 ** 6:.6f} (cache time)")
         else:
             print()
         # Append the info to the table
@@ -415,8 +417,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     # default options
-    dselect = 3.
-    noise = 0.
+    dselect = 3
+    noise = 0
     verbose = 0
     fieldName = None
     testread = 1

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -141,7 +141,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
             end=' ')
     else:
         indexrows = 0
-        time2 = 0.0000000001  # an ugly hack
+        time2 = 0.000_000_000_1  # an ugly hack
         tcpu2 = 0
 
     if verbose:

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -118,7 +118,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
         f"Time for filling: {time1:.3f} Krows/s: {nrows / 1000 / time1:.3f}",
         end=' ')
     fileh.close()
-    size1 = os.stat(filename)[6]
+    size1 = os.stat(filename).st_size
     print(f", File size: {size1 / 1024 / 1024:.3f} MB")
     fileh = open_file(filename, mode="a", title="Searchsorted Benchmark",
                       filters=filters)
@@ -152,7 +152,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     # Close the file
     fileh.close()
 
-    size2 = os.stat(filename)[6] - size1
+    size2 = os.stat(filename).st_size - size1
     if index:
         print(f", Index size: {size2 / 1024 / 1024:.3f} MB")
     return (rowswritten, indexrows, rowsize, time1, time2,

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import sys
-import math
 import time
 import random
 import warnings

--- a/bench/searchsorted-bench.py
+++ b/bench/searchsorted-bench.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
             f"Time writing rows: {tapprows:.3f} s (real) "
             f"{cpuapprows:.3f} s (cpu)  {cpuapprows / tapprows:.0%}")
         print(f"Write rows/sec: {rowsw / tapprows:.0f}")
-        print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
+        print(f"Write KB/s : {rowsw * rowsz / tapprows / 1024:.0f}")
 
     if testread:
         if psyco_imported and usepsyco:
@@ -325,8 +325,8 @@ if __name__ == "__main__":
         cpu2 = time.perf_counter()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
-        tMrows = rowsr / (1000 * 1000.)
-        sKrows = rowsel / 1000.
+        tMrows = rowsr / 1000 / 1000
+        sKrows = rowsel / 1000
         print(f"Rows read: {rowsr} Mread: {tMrows:.3f} Mrows")
         print(f"Rows selected: {rowsel} Ksel: {sKrows:.3f} Krows")
         print(

--- a/bench/searchsorted-bench2.py
+++ b/bench/searchsorted-bench2.py
@@ -325,8 +325,8 @@ if __name__ == "__main__":
         cpu2 = time.perf_counter()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
-        tMrows = rowsr / (1000 * 1000.)
-        sKrows = rowsel / 1000.
+        tMrows = rowsr / 1000 / 1000
+        sKrows = rowsel / 1000
         print(f"Rows read: {rowsr} Mread: {tMrows:.3f} Mrows")
         print(f"Rows selected: {rowsel} Ksel: {sKrows:.3f} Krows")
         print(

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -10,7 +10,7 @@ from tables import *
 import numpy as np
 
 randomvalues = 0
-standarddeviation = 10000
+standarddeviation = 10_000
 # Initialize the random generator always with the same integer
 # in order to have reproductible results
 random.seed(19)

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -249,7 +249,7 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
         else:
             dev = standarddeviation / 100
 
-        valmax = int(round((nrows / 2) - dev))
+        valmax = round(nrows / 2 - dev)
         # split the selection range in regular chunks
         if riter > valmax * 2:
             riter = valmax * 2

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -150,7 +150,7 @@ CREATE INDEX ivar3 ON small(var3);
         t1 = time.time() - time1
         tcpu1 = time.perf_counter() - cpu1
         rowsecf = nrows / t1
-        size1 = os.stat(dbfile)[6]
+        size1 = os.stat(dbfile).st_size
         print(f"******** Results for writing nrows = {nrows} *********")
         print(f"Insert time: {t1:.5f}, KRows/s: {nrows / 1000 / t1:.3f}")
         print(f", File size: {size1 / 1024 / 1024:.3f} MB")
@@ -170,7 +170,7 @@ CREATE INDEX ivar3 ON small(var3);
         tcpu2 = time.perf_counter() - cpu1
         rowseci = nrows / t2
         print(f"Index time: {t2:.5f}, IKRows/s: {nrows / 1000 / t2:.3f}")
-        size2 = os.stat(dbfile)[6] - size1
+        size2 = os.stat(dbfile).st_size - size1
         print(f", Final size with index: {size2 / 1024 / 1024:.3f} MB")
 
     conn.close()

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -76,14 +76,14 @@ def createFile(filename, nrows, filters, indexmode, heavy, noise, bfile,
                verbose):
 
     # Initialize some variables
-    t1 = 0.
-    t2 = 0.
-    tcpu1 = 0.
-    tcpu2 = 0.
-    rowsecf = 0.
-    rowseci = 0.
-    size1 = 0.
-    size2 = 0.
+    t1 = 0
+    t2 = 0
+    tcpu1 = 0
+    tcpu2 = 0
+    rowsecf = 0
+    rowseci = 0
+    size1 = 0
+    size2 = 0
 
     if indexmode == "standard":
         print("Creating a new database:", dbfile)
@@ -153,7 +153,7 @@ CREATE INDEX ivar3 ON small(var3);
         size1 = os.stat(dbfile)[6]
         print(f"******** Results for writing nrows = {nrows} *********")
         print(f"Insert time: {t1:.5f}, KRows/s: {nrows / 1000 / t1:.3f}")
-        print(f", File size: {size1 / (1024. * 1024.):.3f} MB")
+        print(f", File size: {size1 / 1024 / 1024:.3f} MB")
 
     # Indexem
     if indexmode == "indexed":
@@ -171,7 +171,7 @@ CREATE INDEX ivar3 ON small(var3);
         rowseci = nrows / t2
         print(f"Index time: {t2:.5f}, IKRows/s: {nrows / 1000 / t2:.3f}")
         size2 = os.stat(dbfile)[6] - size1
-        print(f", Final size with index: {size2 / (1024. * 1024):.3f} MB")
+        print(f", Final size with index: {size2 / 1024 / 1024:.3f} MB")
 
     conn.close()
 
@@ -222,8 +222,8 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
     # Open the benchmark database
     bf = open_file(bfile, "a")
     # default values for the case that columns are not indexed
-    t2 = 0.
-    tcpu2 = 0.
+    t2 = 0
+    tcpu2 = 0
     # Some previous computations for the case of random values
     if randomvalues:
         # algorithm to choose a value separated from mean
@@ -241,15 +241,15 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
 #             dev = 100
         # Yet Another Algorithm
         if nrows / 2 > standarddeviation * 10:
-            dev = standarddeviation * 4.
+            dev = standarddeviation * 4
         elif nrows / 2 > standarddeviation:
-            dev = standarddeviation * 2.
-        elif nrows / 2 > standarddeviation / 10.:
-            dev = standarddeviation / 10.
+            dev = standarddeviation * 2
+        elif nrows / 2 > standarddeviation / 10:
+            dev = standarddeviation / 10
         else:
-            dev = standarddeviation / 100.
+            dev = standarddeviation / 100
 
-        valmax = int(round((nrows / 2.) - dev))
+        valmax = int(round((nrows / 2) - dev))
         # split the selection range in regular chunks
         if riter > valmax * 2:
             riter = valmax * 2
@@ -321,7 +321,7 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
         print(f"Query time: {t1:.5f}, cached time: {t2:.5f}")
         print(f"MRows/s: {nrows / 1_000_000 / t1:.3f}", end=' ')
         if t2 > 0:
-            print(f", cached MRows/s: {(nrows / 10. ** 6) / t2:.3f}")
+            print(f", cached MRows/s: {nrows / 10 ** 6 / t2:.3f}")
         else:
             print()
 
@@ -382,8 +382,8 @@ if __name__ == "__main__":
         sys.exit(0)
 
     # default options
-    dselect = 3.
-    noise = 0.
+    dselect = 3
+    noise = 0
     verbose = 0
     heavy = 0
     testread = 1

--- a/bench/table-copy.py
+++ b/bench/table-copy.py
@@ -3,7 +3,7 @@ import time
 import numpy as np
 import tables
 
-N = 144000
+N = 144_000
 #N = 144
 
 
@@ -91,7 +91,7 @@ def copy5(input_path, output_path, complib='zlib', complevel=0):
     filter = tables.Filters(complevel=complevel, complib=complib)
     output_table = output_file.create_table("/", "test", input_table.dtype,
                                             filters=filter)
-    chunksize = 10000
+    chunksize = 10_000
     rowsleft = len(input_table)
     start = 0
     for chunk in range((len(input_table) / chunksize) + 1):

--- a/examples/array2.py
+++ b/examples/array2.py
@@ -7,7 +7,7 @@ fileh = tables.open_file("array2.h5", mode="w")
 root = fileh.root
 
 # Create an array
-a = np.array([1, 2.7182818284590451, 3.141592], float)
+a = np.array([1, np.e, np.pi], float)
 print("About to write array:", a)
 print("  with shape: ==>", a.shape)
 print("  and dtype ==>", a.dtype)

--- a/examples/attrs-with-padding.py
+++ b/examples/attrs-with-padding.py
@@ -11,7 +11,7 @@ attrs = fileh.root._v_attrs
 # Set some attrs
 attrs.pq = np.zeros(2, dt)
 attrs.qr = np.ones((2, 2), dt)
-attrs.rs = np.array([(1, 2.)], dt)
+attrs.rs = np.array([(1, 2)], dt)
 print("repr(attrs)-->", repr(attrs))
 
 fileh.close()
@@ -23,7 +23,7 @@ attrs = fileh.root._v_attrs
 # Set some attrs
 attrs.pq = np.zeros(2, dt)
 attrs.qr = np.ones((2, 2), dt)
-attrs.rs = np.array([(1, 2.)], dt)
+attrs.rs = np.array([(1, 2)], dt)
 print("repr(attrs)-->", repr(attrs))
 
 fileh.close()

--- a/examples/index.py
+++ b/examples/index.py
@@ -2,7 +2,7 @@ import random
 import tables
 print('tables.__version__', tables.__version__)
 
-nrows = 10000 - 1
+nrows = 10_000 - 1
 
 
 class Distance(tables.IsDescription):

--- a/examples/links.py
+++ b/examples/links.py
@@ -6,7 +6,7 @@ g1 = f1.create_group('/', 'g1')
 g2 = f1.create_group(g1, 'g2')
 
 # Create some datasets
-a1 = f1.create_carray(g1, 'a1', tb.Int64Atom(), shape=(10000,))
+a1 = f1.create_carray(g1, 'a1', tb.Int64Atom(), shape=(10_000,))
 t1 = f1.create_table(g2, 't1', {'f1': tb.IntCol(), 'f2': tb.FloatCol()})
 
 # Create new group and a first hard link

--- a/examples/multiprocess_access_benchmarks.py
+++ b/examples/multiprocess_access_benchmarks.py
@@ -174,7 +174,7 @@ def unix_socket_address():
 
 def ipv4_socket_address():
     # create an IPv4 socket address
-    return ('127.0.0.1', random.randint(9000, 10000))
+    return ('127.0.0.1', random.randint(9000, 10_000))
 
 
 def read_and_send_socket(send_type, array_size, array_bytes, address_func,

--- a/examples/multiprocess_access_benchmarks.py
+++ b/examples/multiprocess_access_benchmarks.py
@@ -216,10 +216,10 @@ def print_results(send_type, start_timestamp, recv_timestamp,
 if __name__ == '__main__':
 
     random.seed(os.urandom(2))
-    array_num_bytes = [int(x) for x in [1e5, 1e6, 1e7, 1e8]]
+    array_num_bytes = [10**5, 10**6, 10**7, 10**8]
 
     for array_bytes in array_num_bytes:
-        array_size = int(array_bytes // 8)
+        array_size = array_bytes // 8
 
         create_file(array_size)
         read_and_send_pipe('multiproc.Pipe', array_size)

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -105,13 +105,13 @@ class DataProcessor(multiprocessing.Process):
     def run(self):
         self.output_file = open(self.output_file, 'w')
         # read a random row from the file
-        row_num = random.randint(0, self.array_size - 1)
+        row_num = random.randrange(self.array_size)
         self.read_queue.put((row_num, self.proc_num))
         self.output_file.write(str(row_num) + '\n')
         self.output_file.write(str(self.result_queue.get()) + '\n')
 
         # modify a random row to equal 11 * (self.proc_num + 1)
-        row_num = random.randint(0, self.array_size - 1)
+        row_num = random.randrange(self.array_size)
         new_data = (numpy.zeros((1, self.array_size), 'i8') +
                     11 * (self.proc_num + 1))
         self.write_queue.put((row_num, new_data))

--- a/examples/objecttree.py
+++ b/examples/objecttree.py
@@ -39,7 +39,7 @@ for table in (table1, table2):
         # First, assign the values to the Particle record
         row['identity'] = 'This is particle: %2d' % (i)
         row['idnumber'] = i
-        row['speed'] = i * 2.
+        row['speed'] = i * 2
         # This injects the Record values
         row.append()
 

--- a/examples/particles.py
+++ b/examples/particles.py
@@ -5,7 +5,7 @@ import numpy as np
 import tables
 
 # NEVENTS = 10000
-NEVENTS = 20000
+NEVENTS = 20_000
 MAX_PARTICLES_PER_EVENT = 100
 
 # Particle description

--- a/examples/particles.py
+++ b/examples/particles.py
@@ -23,8 +23,9 @@ class Particle(tables.IsDescription):
 
 # Create a new table for events
 t1 = time()
-print("Creating a table with %s entries aprox.. Wait please..." %
-      (int(NEVENTS * (MAX_PARTICLES_PER_EVENT / 2.))))
+print(
+    f"Creating a table with {NEVENTS * MAX_PARTICLES_PER_EVENT // 2} "
+    f"entries aprox.. Wait please...")
 fileh = tables.open_file("particles-pro.h5", mode="w")
 group = fileh.create_group(fileh.root, "events")
 table = fileh.create_table(group, 'table', Particle, "A table",

--- a/examples/read_array_out_arg.py
+++ b/examples/read_array_out_arg.py
@@ -46,11 +46,11 @@ def pre_allocated_read(array_size):
 
 if __name__ == '__main__':
 
-    array_num_bytes = [int(x) for x in [1e5, 1e6, 1e7, 1e8]]
+    array_num_bytes = [10**5, 10**6, 10**7, 10**8]
 
     for array_bytes in array_num_bytes:
 
-        array_size = int(array_bytes // 8)
+        array_size = array_bytes // 8
 
         create_file(array_size)
         standard_read(array_size)

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -77,7 +77,7 @@ def main():
 
     # collect results
     try:
-        mean_ = 0.
+        mean_ = 0
 
         for _ in range(len(threads)):
             out = outqueue.get()

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import math
 import os
 import queue
 import threading
@@ -22,7 +23,7 @@ def create_test_file(filename):
 
 
 def chunk_generator(data_size, nchunks):
-    chunk_size = int(np.ceil(data_size / nchunks))
+    chunk_size = math.ceil(data_size / nchunks)
     for start in range(0, data_size, chunk_size):
         yield slice(start, start + chunk_size)
 

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -113,7 +113,7 @@ def main():
 
     # collect results
     try:
-        mean_ = 0.
+        mean_ = 0
 
         for _ in range(len(threads)):
             out = outqueue.get()

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import math
 import os
 import queue
 import functools
@@ -73,7 +74,7 @@ def create_test_file(filename):
 
 
 def chunk_generator(data_size, nchunks):
-    chunk_size = int(np.ceil(data_size / nchunks))
+    chunk_size = math.ceil(data_size / nchunks)
     for start in range(0, data_size, chunk_size):
         yield slice(start, start + chunk_size)
 

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -695,10 +695,10 @@ if __name__ == "__main__":
     f = tb.open_file("/tmp/expression.h5", "w")
 
     # Create some arrays
-    a = f.create_carray(f.root, 'a', atom=tb.Float32Atom(dflt=1.), shape=shape)
-    b = f.create_carray(f.root, 'b', atom=tb.Float32Atom(dflt=2.), shape=shape)
-    c = f.create_carray(f.root, 'c', atom=tb.Float32Atom(dflt=3.), shape=shape)
-    out = f.create_carray(f.root, 'out', atom=tb.Float32Atom(dflt=3.),
+    a = f.create_carray(f.root, 'a', atom=tb.Float32Atom(dflt=1), shape=shape)
+    b = f.create_carray(f.root, 'b', atom=tb.Float32Atom(dflt=2), shape=shape)
+    c = f.create_carray(f.root, 'c', atom=tb.Float32Atom(dflt=3), shape=shape)
+    out = f.create_carray(f.root, 'out', atom=tb.Float32Atom(dflt=3),
                           shape=shape)
 
     expr = Expr("a * b + c")

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -690,7 +690,7 @@ value of dimensions that are orthogonal (and preferably close) to the
 if __name__ == "__main__":
 
     # shape = (10000,10000)
-    shape = (10, 10000)
+    shape = (10, 10_000)
 
     f = tb.open_file("/tmp/expression.h5", "w")
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -939,7 +939,7 @@ class File(hdf5extension.File):
 
 
     def create_table(self, where, name, description=None, title="",
-                     filters=None, expectedrows=10000,
+                     filters=None, expectedrows=10_000,
                      chunkshape=None, byteorder=None,
                      createparents=False, obj=None, track_times=True):
         """Create a new table with the given name in where location.

--- a/tables/file.py
+++ b/tables/file.py
@@ -2785,7 +2785,7 @@ class File(hdf5extension.File):
 
         # Print all the nodes (Group and Leaf objects) on object tree
         try:
-            date = time.asctime(time.localtime(os.stat(self.filename)[8]))
+            date = time.asctime(time.localtime(os.stat(self.filename).st_mtime))
         except OSError:
             # in-memory file
             date = ""

--- a/tables/index.py
+++ b/tables/index.py
@@ -974,7 +974,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if self.verbose:
             print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
         # Check that entropy is actually decreasing
-        if what == "chunks" and self.last_tover > 0. and self.last_nover > 0:
+        if what == "chunks" and self.last_tover > 0 and self.last_nover > 0:
             tover_var = (self.last_tover - tover) / self.last_tover
             nover_var = (self.last_nover - nover) / self.last_nover
             if tover_var < 0.05 and nover_var < 0.05:
@@ -988,7 +988,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if rmult < thmult:
             return True
         # Additional check for the overlap ratio
-        if 0. <= tover < thtover:
+        if 0 <= tover < thtover:
             return True
         return False
 
@@ -1541,8 +1541,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             rangeslr = numpy.array([self.bebounds[0], self.bebounds[-1]])
             ranges = numpy.concatenate((ranges, [rangeslr]))
             nslices += 1
-        soverlap = 0.
-        toverlap = -1.
+        soverlap = 0
+        toverlap = -1
         multiplicity = numpy.zeros(shape=nslices, dtype="int_")
         overlaps = multiplicity.copy()
         starts = multiplicity.copy()
@@ -1631,8 +1631,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             ranges = numpy.concatenate((ranges, [rangeslr]))
             nslices += 1
         noverlaps = 0
-        soverlap = 0.
-        toverlap = -1.
+        soverlap = 0
+        toverlap = -1
         multiplicity = numpy.zeros(shape=nslices, dtype="int_")
         for i in range(nslices):
             for j in range(i + 1, nslices):

--- a/tables/index.py
+++ b/tables/index.py
@@ -307,13 +307,13 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             # bucket outside of a slice.
             maxnb = 2**8
             if self.slicesize > maxnb * lbucket:
-                lbucket = int(math.ceil(float(self.slicesize) / maxnb))
+                lbucket = math.ceil(self.slicesize / maxnb)
         elif self.indsize == 2:
             # For light, we will never have to keep track of a
             # bucket outside of a block.
             maxnb = 2**16
             if self.blocksize > maxnb * lbucket:
-                lbucket = int(math.ceil(float(self.blocksize) / maxnb))
+                lbucket = math.ceil(self.blocksize / maxnb)
         else:
             # For medium and full indexes there should not be a need to
             # increase lbucket
@@ -970,7 +970,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             message = f"swap_{what}"
         (nover, mult, tover) = self.compute_overlaps(
             self.tmp, message, self.verbose)
-        rmult = len(mult.nonzero()[0]) / float(len(mult))
+        rmult = len(mult.nonzero()[0]) / len(mult)
         if self.verbose:
             print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
         # Check that entropy is actually decreasing
@@ -2006,8 +2006,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nslices = self.nslices
         lbucket = self.lbucket
         indsize = self.indsize
-        bucketsinblock = float(self.blocksize) / lbucket
-        nchunks = int(math.ceil(float(self.nelements) / lbucket))
+        bucketsinblock = self.blocksize / lbucket
+        nchunks = math.ceil(self.nelements / lbucket)
         chunkmap = numpy.zeros(shape=nchunks, dtype="bool")
         reduction = self.reduction
         starts = (self.starts - 1) * reduction + 1
@@ -2041,9 +2041,9 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if lbucket != nrowsinchunk:
             # Map the 'coarse grain' chunkmap into the 'true' chunkmap
             nelements = self.nelements
-            tnchunks = int(math.ceil(float(nelements) / nrowsinchunk))
+            tnchunks = math.ceil(nelements / nrowsinchunk)
             tchunkmap = numpy.zeros(shape=tnchunks, dtype="bool")
-            ratio = float(lbucket) / nrowsinchunk
+            ratio = lbucket / nrowsinchunk
             idx = chunkmap.nonzero()[0]
             starts = (idx * ratio).astype('int_')
             stops = numpy.ceil((idx + 1) * ratio).astype('int_')

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -53,7 +53,7 @@ class NewFileTestCase(TempFileMixin, TestCase):
 
         try:
             filenode.new_node(
-                self.h5file, where='/', name='test', expectedsize=100000)
+                self.h5file, where='/', name='test', expectedsize=100_000)
         except TypeError:
             self.fail("filenode.new_node() failed to accept 'expectedsize'"
                       " argument.")
@@ -63,7 +63,7 @@ class NewFileTestCase(TempFileMixin, TestCase):
 
         self.assertRaises(
             TypeError, filenode.new_node,
-            self.h5file, where='/', name='test', expectedrows=100000)
+            self.h5file, where='/', name='test', expectedrows=100_000)
 
 
 class ClosedFileTestCase(TempFileMixin, TestCase):

--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -201,7 +201,7 @@ EXPECTED_ROWS_VLARRAY = 1000
 
 """
 
-EXPECTED_ROWS_TABLE = 10000
+EXPECTED_ROWS_TABLE = 10_000
 """Default expected number of rows for :class:`Table` objects."""
 
 PYTABLES_SYS_ATTRS = True

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -568,7 +568,7 @@ def main():
             print("User attrs copied")
         else:
             print("User attrs not copied")
-        print(f"KBytes copied: {nbytescopied / 1024.:.3f}")
+        print(f"KBytes copied: {nbytescopied / 1024:.3f}")
         print(
             f"Time copying: {tcopy:.3f} s (real) {cpucopy:.3f} s "
             f"(cpu)  {cpucopy / tcopy:.0%}")

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -340,7 +340,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
     out_str += str(pretty[root._v_pathname]) + '\n' * 2
 
     if print_total:
-        avg_ratio = float(total_on_disk) / total_in_mem
+        avg_ratio = total_on_disk / total_in_mem
         fsize = os.stat(f.filename).st_size
 
         out_str += '-' * 60 + '\n'
@@ -430,7 +430,7 @@ def bytes2human(use_si_units=False):
     def b2h(nbytes):
 
         for (prefix, value) in zip(prefixes, values):
-            scaled = float(nbytes) / value
+            scaled = nbytes / value
             if scaled >= 1:
                 break
 

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -141,8 +141,8 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
     total_items = 0
 
     # defaultdicts for holding the cumulative branch sizes at each node
-    in_mem = defaultdict(lambda: 0.)
-    on_disk = defaultdict(lambda: 0.)
+    in_mem = defaultdict(lambda: 0)
+    on_disk = defaultdict(lambda: 0)
     leaf_count = defaultdict(lambda: 0)
 
     # keep track of node addresses within the HDF5 file so that we don't count

--- a/tables/table.py
+++ b/tables/table.py
@@ -202,7 +202,7 @@ def _table__where_indexed(self, compiled, condition, condvars,
         if index.reduction == 1 and ncoords == 0:
             # No values from index condition, thus the chunkmap should be empty
             nrowsinchunk = self.chunkshape[0]
-            nchunks = int(math.ceil(float(self.nrows) / nrowsinchunk))
+            nchunks = math.ceil(self.nrows / nrowsinchunk)
             chunkmap = numpy.zeros(shape=nchunks, dtype="bool")
         else:
             # Get the chunkmap from the index

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -2051,7 +2051,7 @@ class FilePropertyTestCase(TestCase):
         h5_filesize = self.h5file.get_filesize()
         self.h5file.close()
 
-        fs_filesize = os.stat(self.h5fname)[6]
+        fs_filesize = os.stat(self.h5fname).st_size
 
         self.assertGreaterEqual(h5_filesize, datasize)
         self.assertEqual(h5_filesize, fs_filesize)

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -2154,7 +2154,7 @@ class BloscSubprocess(TestCase):
         # Create a relatively large table with Blosc level 9 (large blocks)
         h5fname = tempfile.mktemp(prefix="multiproc-blosc9-", suffix=".h5")
         try:
-            size = int(3e5)
+            size = 300_000
             sa = numpy.fromiter(((i, i**2, i//3)
                                  for i in range(size)), 'i4,i8,f8')
             with tables.open_file(h5fname, 'w') as h5file:

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -1106,7 +1106,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.array_size = (10000, 10)
+        self.array_size = (10_000, 10)
         # set chunkshape so it divides evenly into array_size, to avoid
         # partially filled chunks
         self.chunkshape = (1000, 10)
@@ -1125,14 +1125,14 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         complevel = 0
         self.create_array(complevel)
         self.assertEqual(self.array.size_on_disk, 0)
-        self.assertEqual(self.array.size_in_memory, 10000 * 10 * 2)
+        self.assertEqual(self.array.size_in_memory, 10_000 * 10 * 2)
 
     def test_data_no_compression(self):
         complevel = 0
         self.create_array(complevel)
         self.array[:] = 1
-        self.assertEqual(self.array.size_on_disk, 10000 * 10 * 2)
-        self.assertEqual(self.array.size_in_memory, 10000 * 10 * 2)
+        self.assertEqual(self.array.size_on_disk, 10_000 * 10 * 2)
+        self.assertEqual(self.array.size_in_memory, 10_000 * 10 * 2)
 
     def test_highly_compressible_data(self):
         complevel = 1
@@ -1143,7 +1143,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         self.assertTrue(
             abs(self.array.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertTrue(self.array.size_on_disk < self.array.size_in_memory)
-        self.assertEqual(self.array.size_in_memory, 10000 * 10 * 2)
+        self.assertEqual(self.array.size_in_memory, 10_000 * 10 * 2)
 
     # XXX
     def test_random_data(self):
@@ -1157,10 +1157,10 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
 
         # XXX: check. The test fails if blosc is not available
         if tables.which_lib_version('blosc') is not None:
-            self.assertAlmostEqual(self.array.size_on_disk, 10000 * 10 * 2)
+            self.assertAlmostEqual(self.array.size_on_disk, 10_000 * 10 * 2)
         else:
             self.assertTrue(
-                abs(self.array.size_on_disk - 10000 * 10 * 2) < 200)
+                abs(self.array.size_on_disk - 10_000 * 10 * 2) < 200)
 
 
 class OffsetStrideTestCase(common.TempFileMixin, TestCase):
@@ -2091,7 +2091,7 @@ class Rows64bitsTestCase2(Rows64bitsTestCase):
 
 
 class BigArrayTestCase(common.TempFileMixin, TestCase):
-    shape = (3000000000,)  # more than 2**31-1
+    shape = (3_000_000_000,)  # more than 2**31-1
 
     def setUp(self):
         super().setUp()

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -44,7 +44,7 @@ class CreateTestCase(common.TempFileMixin, TestCase):
     title = "This is the table title"
     expectedrows = 100
     maxshort = 2 ** 15
-    maxint = 2147483648   # (2 ** 31)
+    maxint = 2_147_483_648   # (2 ** 31)
     compress = 0
 
     def setUp(self):
@@ -2243,7 +2243,8 @@ class InMemoryCoreDriverTestCase(TestCase):
         self.assertEqual(self.h5file.get_node_attr("/table", "TITLE"), "Table")
         self.assertEqual(self.h5file.root.array.read(), [1, 2])
 
-        self.h5file.create_array(self.h5file.root, 'array2', list(range(10000)),
+        self.h5file.create_array(self.h5file.root, 'array2',
+                                 list(range(10_000)),
                                  title="Array2")
         self.h5file.root._v_attrs.testattr2 = 42
 
@@ -2434,9 +2435,9 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
         super().setUp()
 
         self.data = numpy.linspace(-5., 5., 41)
-        self.randomdata = numpy.random.random_sample(1000000)
-        self.randomints = numpy.random.randint(-1000000, 1000000,
-                                               1000000).astype('int64')
+        self.randomdata = numpy.random.random_sample(1_000_000)
+        self.randomints = numpy.random.randint(-1_000_000, 1_000_000,
+                                               1_000_000).astype('int64')
 
         self.populateFile()
         self.h5file.close()
@@ -2452,10 +2453,10 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
         filters = Filters(complevel=1, complib="blosc",
                           least_significant_digit=1)
         ints = self.h5file.create_carray(root, "integers", Int64Atom(),
-                                         (1000000,), filters=filters)
+                                         (1_000_000,), filters=filters)
         ints[:] = self.randomints
         floats = self.h5file.create_carray(root, "floats", Float32Atom(),
-                                           (1000000,), filters=filters)
+                                           (1_000_000,), filters=filters)
         floats[:] = self.randomdata
         data1 = self.h5file.create_carray(root, "data1", Float64Atom(),
                                           (41,), filters=filters)

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3305,21 +3305,21 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
 
     def test01(self):
         numpy.random.seed(2)
-        n = 700000
-        cs = 50000
+        n = 700_000
+        cs = 50_000
         nchunks = n // cs
 
         arr = numpy.zeros(
             (n,), dtype=[('index', 'i8'), ('o', 'i8'), ('value', 'f8')])
         arr['index'] = numpy.arange(n)
-        arr['o'] = numpy.random.randint(-20000, -15000, size=n)
+        arr['o'] = numpy.random.randint(-20_000, -15_000, size=n)
         arr['value'] = numpy.random.randn(n)
 
         node = self.h5file.create_group('/', 'foo')
         table = self.h5file.create_table(node, 'table', dict(
             index=tables.Int64Col(),
             o=tables.Int64Col(),
-            value=tables.FloatCol(shape=())), expectedrows=10000000)
+            value=tables.FloatCol(shape=())), expectedrows=10_000_000)
 
         table.append(arr)
 

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3187,7 +3187,7 @@ class LastRowReuseBuffers(TestCase):
         ta.cols.id1.create_index()
 
         for i in range(self.nelem):
-            nrow = random.randint(0, self.nelem-1)
+            nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
@@ -3206,7 +3206,7 @@ class LastRowReuseBuffers(TestCase):
         ta.cols.id1.create_index()
 
         for i in range(self.nelem):
-            nrow = random.randint(0, self.nelem-1)
+            nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,
@@ -3225,7 +3225,7 @@ class LastRowReuseBuffers(TestCase):
         ta.cols.id1.create_index()
 
         for i in range(self.nelem):
-            nrow = random.randint(0, self.nelem-1)
+            nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
             self.assertGreater(len(idx), 0,

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1872,7 +1872,7 @@ class BigTablesTestCase(BasicTestCase):
     # reducing to 1000 would be more than enough
     # F. Alted 2004-01-19
     # Will be executed only in common.heavy mode
-    expectedrows = 10000
+    expectedrows = 10_000
     appendrows = 100
 
 
@@ -1992,7 +1992,7 @@ class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):
 
     def test_read_all_out_arg_sliced(self):
         output = np.empty((200, ), self.dtype)
-        output['f0'] = np.random.randint(0, 10000, (200, ))
+        output['f0'] = np.random.randint(0, 10_000, (200, ))
         output_orig = output.copy()
         self.table.read(out=output[0:100])
         npt.assert_array_equal(output[0:100], self.array)
@@ -3826,7 +3826,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test02..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array(b'a'*200000, 'f4,3i4,a5,i2', 3000)
+        r = records.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
 
         # Get an offsetted bytearray
         r1 = r[2000:]
@@ -3849,7 +3849,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test03..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array(b'a'*200000, 'f4,3i4,a5,i2', 3000)
+        r = records.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
 
         # Get an strided recarray
         r2 = r[::2]
@@ -6314,7 +6314,7 @@ class ColumnIterationTestCase(common.TempFileMixin, TestCase):
     def create_non_nested_table(self, nrows, dtype):
         array = np.empty((nrows, ), dtype)
         for name in dtype.names:
-            array[name] = np.random.randint(0, 10000, nrows)
+            array[name] = np.random.randint(0, 10_000, nrows)
         table = self.h5file.create_table('/', 'table', dtype)
         table.append(array)
         return array, table
@@ -6361,7 +6361,7 @@ class TestCreateTableArgs(common.TempFileMixin, TestCase):
     description, _ = descr_from_dtype(obj.dtype)
     title = 'title'
     filters = None
-    expectedrows = 10000
+    expectedrows = 10_000
     chunkshape = None
     byteorder = None
     createparents = False

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -163,7 +163,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test00_Compare32VLArray(self):
         """Comparing written 32-bit time data with read data in a VLArray."""
 
-        wtime = numpy.array((1234567890,) * 2, numpy.int32)
+        wtime = numpy.array((1_234_567_890,) * 2, numpy.int32)
 
         # Create test VLArray with data.
         vla = self.h5file.create_vlarray('/', 'test', self.myTime32Atom)
@@ -179,7 +179,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test01_Compare64VLArray(self):
         """Comparing written 64-bit time data with read data in a VLArray."""
 
-        wtime = numpy.array((1234567890.123456,) * 2, numpy.float64)
+        wtime = numpy.array((1_234_567_890.123456,) * 2, numpy.float64)
 
         # Create test VLArray with data.
         vla = self.h5file.create_vlarray('/', 'test', self.myTime64Atom)
@@ -226,7 +226,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test02_CompareTable(self):
         """Comparing written time data with read data in a Table."""
 
-        wtime = 1234567890.123456
+        wtime = 1_234_567_890.123456
 
         # Create test Table with data.
         tbl = self.h5file.create_table('/', 'test', self.MyTimeRow)
@@ -292,7 +292,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test03_Compare64EArray(self):
         """Comparing written 64-bit time data with read data in an EArray."""
 
-        wtime = 1234567890.123456
+        wtime = 1_234_567_890.123456
 
         # Create test EArray with data.
         ea = self.h5file.create_earray(
@@ -419,7 +419,7 @@ class BigEndianTestCase(TestCase):
         earr = self.h5file.root.earr32[:]
 
         # Generate the expected Time32 array.
-        start = 1178896298
+        start = 1_178_896_298
         nrows = 10
         orig_val = numpy.arange(start, start + nrows, dtype=numpy.int32)
 
@@ -436,7 +436,7 @@ class BigEndianTestCase(TestCase):
         earr = self.h5file.root.earr64[:]
 
         # Generate the expected Time64 array.
-        start = 1178896298.832258
+        start = 1_178_896_298.832258
         nrows = 10
         orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
 
@@ -454,7 +454,7 @@ class BigEndianTestCase(TestCase):
         t32 = tbl.cols.t32[:]
 
         # Generate the expected Time32 array.
-        start = 1178896298
+        start = 1_178_896_298
         nrows = 10
         orig_val = numpy.arange(start, start + nrows, dtype=numpy.int32)
 
@@ -472,7 +472,7 @@ class BigEndianTestCase(TestCase):
         t64 = tbl.cols.nested.t64[:]
 
         # Generate the expected Time64 array.
-        start = 1178896298.832258
+        start = 1_178_896_298.832258
         nrows = 10
         orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
 
@@ -492,7 +492,7 @@ class BigEndianTestCase(TestCase):
         t64 = tbl.cols.nested.t64[:]
 
         # Generate the expected Time64 array.
-        start = 1178896298.832258
+        start = 1_178_896_298.832258
         nrows = 10
         orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -37,7 +37,7 @@ class RangeTestCase(common.TempFileMixin, TestCase):
     title = "This is the table title"
     expectedrows = 100
     maxshort = 2 ** 15
-    maxint = 2147483648   # (2 ** 31)
+    maxint = 2_147_483_648   # (2 ** 31)
     compress = 0
 
     def setUp(self):

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -10,6 +10,7 @@
 
 """Utility functions."""
 
+import math
 import os
 import sys
 import warnings
@@ -285,14 +286,10 @@ def quantize(data, least_significant_digit):
 
     """
 
-    precision = pow(10., -least_significant_digit)
-    exp = numpy.log10(precision)
-    if exp < 0:
-        exp = int(numpy.floor(exp))
-    else:
-        exp = int(numpy.ceil(exp))
-    bits = numpy.ceil(numpy.log2(pow(10., -exp)))
-    scale = pow(2., bits)
+    exp = -least_significant_digit
+    exp = math.floor(exp) if exp < 0 else math.ceil(exp)
+    bits = math.ceil(math.log2(10 ** -exp))
+    scale = 2 ** bits
     datout = numpy.around(scale * data) / scale
 
     return datout

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -369,7 +369,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
         # PyTables 3.0 release and remove the expected_mb parameter.
         # The algorithm for computing the chunkshape should be rewritten as
         # requested by gh-35.
-        expected_mb = expectedrows * elemsize / 1024. ** 2
+        expected_mb = expectedrows * elemsize / 1024 ** 2
 
         chunksize = calc_chunksize(expected_mb)
 


### PR DESCRIPTION
1. In Python 3 `a / b` for two integers returns a float, so there's no need to keep these literal numbers as floats
2. In Python 3.6+ large numbers are better readable with underscores: `123_456`
3. Remove some numeric type operations redundant in Python 3: (`math.ceil`, `math.floor`, `round` return `int`s)
4. Replace `random.randint(0, n-1)` with `random.randrange(n)`. There's currently a mixture of `stdlib/numpy` random number generators, so their effect with `seed` for tests has to be checked.
5. The `quantize` method `is taken verbatim from netcdf4-python`, so its refactoring maybe does not fit here, please comment