### PR TITLE
Add itersorted test for step=-1 and fix #740

### DIFF
--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -1050,7 +1050,7 @@ cdef class Row:
         self._finish_riterator()
     elif 0 > self.step:
       #print("self.nextelement = ", self.nextelement, self.start, self.nrowsread, self.nextelement <  self.start - self.nrowsread + 1)
-      while self.nextelement - 1 > self.stop:
+      while self.nextelement > self.stop:
         if self.nextelement < self.start - (<long long> self.nrowsread) + 1:
           if 0 > self.nextelement - (<long long> self.nrowsinbuf) + 1:
             tmp = self.coords[0:self.nextelement + 1]

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -2062,7 +2062,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         self.assertTrue(allequal(sortedtable, sortedtable2))
 
     def test04_itersorted9(self):
-        """Testing the Table.itersorted() method with a negative step."""
+        """Testing the Table.itersorted() method with a negative step -5."""
 
         # see also gh-252
         table = self.table
@@ -2070,6 +2070,20 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         sortedtable2 = numpy.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', step=-5)], dtype=table._v_dtype)
+        if verbose:
+            print("Original sorted table:", sortedtable)
+            print("The values from the iterator:", sortedtable2)
+        self.assertTrue(allequal(sortedtable, sortedtable2))
+
+    def test04_itersorted10(self):
+        """Testing the Table.itersorted() method with a negative step -1."""
+
+        # see also gh-252
+        table = self.table
+        sortedtable = numpy.sort(table[:], order='icol')[::-1]
+        sortedtable2 = numpy.array(
+            [row.fetch_all_fields() for row in table.itersorted(
+                'icol', step=-1)], dtype=table._v_dtype)
         if verbose:
             print("Original sorted table:", sortedtable)
             print("The values from the iterator:", sortedtable2)


### PR DESCRIPTION
The current test `test04_itersorted9` tested with `start=None, stop=None, step=-5`, so it did not always have to return the first row. Add a new `test04_itersorted10` test with `start=None, stop=None, step=-1` and fixed a line in `tableextensions.pyx` to include that last missing row.

Fixes #740  