### PR TITLE
Refactor `__str__` and `__repr__` with f-strings

### DIFF
--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -675,21 +675,17 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # Get this class name
         classname = self.__class__.__name__
         # The attribute names
-        attrnumber = len([n for n in self._v_attrnames])
-        return "%s._v_attrs (%s), %s attributes" % \
-               (pathname, classname, attrnumber)
+        attrnumber = sum(1 for _ in self._v_attrnames)
+        return f"{pathname}._v_attrs ({classname}), {attrnumber} attributes"
 
     def __repr__(self):
         """A detailed string representation for this object."""
 
         # print additional info only if there are attributes to show
-        attrnames = [n for n in self._v_attrnames]
-        if len(attrnames):
-            rep = ['{} := {!r}'.format(attr, getattr(self, attr))
-                   for attr in attrnames]
-            attrlist = '[%s]' % (',\n    '.join(rep))
-
-            return "{}:\n   {}".format(str(self), attrlist)
+        attrnames = list(self._v_attrnames)
+        if attrnames:
+            rep = [f'{attr} := {getattr(self, attr)!r}' for attr in attrnames]
+            return f"{self!s}:\n   [" + ',\n    '.join(rep) + "]"
         else:
             return str(self)
 

--- a/tables/description.py
+++ b/tables/description.py
@@ -759,7 +759,7 @@ type can only take the parameters 'All', 'Col' or 'Description'.""")
     def __str__(self):
         """Gives a brief Description representation."""
 
-        return 'Description(%s)' % self._v_nested_descr
+        return f'Description({self._v_nested_descr})'
 
 
 class MetaIsDescription(type):

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -163,7 +163,7 @@ class HDF5ExtError(RuntimeError):
                 msg = super().__str__()
                 msg = f"{bt}\n\n{msg}"
             elif self.h5backtrace[-1][-1]:
-                msg = "{}\n\n{}".format(bt, self.h5backtrace[-1][-1])
+                msg = f"{bt}\n\n{self.h5backtrace[-1][-1]}"
             else:
                 msg = bt
         else:

--- a/tables/file.py
+++ b/tables/file.py
@@ -2789,19 +2789,16 @@ class File(hdf5extension.File):
         except OSError:
             # in-memory file
             date = ""
-        astring = str(self.filename) + ' (File) ' + repr(self.title) + '\n'
-#         astring += 'root_uep :=' + repr(self.root_uep) + '; '
-#         astring += 'format_version := ' + self.format_version + '\n'
-#         astring += 'filters :=' + repr(self.filters) + '\n'
-        astring += 'Last modif.: ' + repr(date) + '\n'
-        astring += 'Object Tree: \n'
+        lines = [f'{self.filename} (File) {self.title!r}',
+                 f'Last modif.: {date!r}',
+                 f'Object Tree: ']
 
         for group in self.walk_groups("/"):
-            astring += str(group) + '\n'
+            lines.append(f'{group}')
             for kind in self._node_kinds[1:]:
                 for node in self.list_nodes(group, kind):
-                    astring += str(node) + '\n'
-        return astring
+                    lines.append(f'{node}')
+        return '\n'.join(lines) + '\n'
 
     def __repr__(self):
         """Return a detailed string representation of the object tree."""
@@ -2810,18 +2807,16 @@ class File(hdf5extension.File):
             return "<closed File>"
 
         # Print all the nodes (Group and Leaf objects) on object tree
-        astring = 'File(filename=' + str(self.filename) + \
-                  ', title=' + repr(self.title) + \
-                  ', mode=' + repr(self.mode) + \
-                  ', root_uep=' + repr(self.root_uep) + \
-                  ', filters=' + repr(self.filters) + \
-                  ')\n'
+        lines = [
+            f'File(filename={self.filename!s}, title={self.title!r}, '
+            f'mode={self.mode!r}, root_uep={self.root_uep!r}, '
+            f'filters={self.filters!r})']
         for group in self.walk_groups("/"):
-            astring += str(group) + '\n'
+            lines.append(f'{group}')
             for kind in self._node_kinds[1:]:
                 for node in self.list_nodes(group, kind):
-                    astring += repr(node) + '\n'
-        return astring
+                    lines.append(f'{node!r}')
+        return '\n'.join(lines) + '\n'
 
     def _update_node_locations(self, oldpath, newpath):
         """Update location information of nodes under `oldpath`.

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -379,17 +379,16 @@ class Filters:
         """The least significant digit to which data shall be truncated."""
 
     def __repr__(self):
-        args, complevel = [], self.complevel
-        if complevel >= 0:  # meaningful compression level
-            args.append('complevel=%d' % complevel)
-        if complevel != 0:  # compression enabled (-1 or > 0)
-            args.append('complib=%r' % self.complib)
-        args.append('shuffle=%s' % self.shuffle)
-        args.append('bitshuffle=%s' % self.bitshuffle)
-        args.append('fletcher32=%s' % self.fletcher32)
-        args.append(
-            'least_significant_digit=%s' % self.least_significant_digit)
-        return '{}({})'.format(self.__class__.__name__, ', '.join(args))
+        args = []
+        if self.complevel >= 0:  # meaningful compression level
+            args.append(f'complevel={self.complevel}')
+        if self.complevel != 0:  # compression enabled (-1 or > 0)
+            args.append(f'complib={self.complib!r}')
+        args.append(f'shuffle={self.shuffle}')
+        args.append(f'bitshuffle={self.bitshuffle}')
+        args.append(f'fletcher32={self.fletcher32}')
+        args.append(f'least_significant_digit={self.least_significant_digit}')
+        return f'{self.__class__.__name__}({", ".join(args)})'
 
     def __str__(self):
         return repr(self)

--- a/tables/group.py
+++ b/tables/group.py
@@ -1075,10 +1075,8 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         """
 
-        pathname = self._v_pathname
-        classname = self.__class__.__name__
-        title = self._v_title
-        return f"{pathname} ({classname}) {title!r}"
+        return (f"{self._v_pathname} ({self.__class__.__name__}) "
+                f"{self._v_title!r}")
 
     def __repr__(self):
         """Return a detailed string representation of the group.
@@ -1099,9 +1097,8 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             f'{childname!r} ({child.__class__.__name__})'
             for (childname, child) in self._v_children.items()
         ]
-        childlist = '[%s]' % (', '.join(rep))
+        return f'{self!s}\n  children := [{", ".join(rep)}]'
 
-        return "{}\n  children := {}".format(str(self), childlist)
 
 
 # Special definition for group root

--- a/tables/index.py
+++ b/tables/index.py
@@ -2114,45 +2114,38 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """This provides a more compact representation than __repr__"""
 
         # The filters
-        filters = ""
+        filters = []
         if self.filters.complevel:
             if self.filters.shuffle:
-                filters += ", shuffle"
+                filters.append('shuffle')
             if self.filters.bitshuffle:
-                filters += ", bitshuffle"
-            filters += ", {}({})".format(self.filters.complib,
-                                     self.filters.complevel)
-        return "Index(%s, %s%s).is_csi=%s" % \
-               (self.optlevel, self.kind, filters, self.is_csi)
+                filters.append('bitshuffle')
+            filters.append(f'{self.filters.complib}({self.filters.complevel})')
+        return (f"Index({self.optlevel}, "
+                f"{self.kind}{', '.join(filters)}).is_csi={self.is_csi}")
 
     def __repr__(self):
         """This provides more metainfo than standard __repr__"""
 
-        cpathname = self.table._v_pathname + ".cols." + self.column.pathname
-        retstr = """{} (Index for column {})
-  optlevel := {}
-  kind := {}
-  filters := {}
-  is_csi := {}
-  nelements := {}
-  chunksize := {}
-  slicesize := {}
-  blocksize := {}
-  superblocksize := {}
-  dirty := {}
-  byteorder := {!r}""".format(self._v_pathname, cpathname,
-                        self.optlevel, self.kind,
-                        self.filters, self.is_csi,
-                        self.nelements,
-                        self.chunksize, self.slicesize,
-                        self.blocksize, self.superblocksize,
-                        self.dirty, self.byteorder)
-        retstr += "\n  sorted := %s" % self.sorted
-        retstr += "\n  indices := %s" % self.indices
-        retstr += "\n  ranges := %s" % self.ranges
-        retstr += "\n  bounds := %s" % self.bounds
-        retstr += "\n  sortedLR := %s" % self.sortedLR
-        retstr += "\n  indicesLR := %s" % self.indicesLR
+        cpathname = f"{self.table._v_pathname}.cols.{self.column.pathname}"
+        retstr = f"""{self._v_pathname} (Index for column {cpathname})
+  optlevel := {self.optlevel}
+  kind := {self.kind}
+  filters := {self.filters}
+  is_csi := {self.is_csi}
+  nelements := {self.nelements}
+  chunksize := {self.chunksize}
+  slicesize := {self.slicesize}
+  blocksize := {self.blocksize}
+  superblocksize := {self.superblocksize}
+  dirty := {self.dirty}
+  byteorder := {self.byteorder!r}
+    sorted := {self.sorted}
+    indices := {self.indices}
+    ranges := {self.ranges}
+    bounds := {self.bounds}
+    sortedLR := {self.sortedLR}
+    indicesLR := {self.indicesLR}"""
         return retstr
 
 

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -170,20 +170,18 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
 
     def __str__(self):
         """A compact representation of this class"""
-        return "IndexArray(path=%s)" % self._v_pathname
+        return f"IndexArray(path={self._v_pathname})"
 
     def __repr__(self):
         """A verbose representation of this class."""
 
-        return """{}
-  atom = {!r}
-  shape = {}
-  nrows = {}
-  chunksize = {}
-  slicesize = {}
-  byteorder = {!r}""".format(self, self.atom, self.shape, self.nrows,
-                       self.chunksize, self.slicesize, self.byteorder)
-
+        return f"""{self}
+  atom = {self.atom!r}
+  shape = {self.shape}
+  nrows = {self.nrows}
+  chunksize = {self.chunksize}
+  slicesize = {self.slicesize}
+  byteorder = {self.byteorder!r}"""
 
 ## Local Variables:
 ## mode: python

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -298,23 +298,17 @@ class Leaf(Node):
         """The string representation for this object is its pathname in the
         HDF5 object tree plus some additional metainfo."""
 
-        # Get this class name
-        classname = self.__class__.__name__
-        # The title
-        title = self._v_title
-        # The filters
-        filters = ""
+        filters = []
         if self.filters.fletcher32:
-            filters += ", fletcher32"
+            filters.append("fletcher32")
         if self.filters.complevel:
             if self.filters.shuffle:
-                filters += ", shuffle"
+                filters.append("shuffle")
             if self.filters.bitshuffle:
-                filters += ", bitshuffle"
-            filters += ", {}({})".format(self.filters.complib,
-                                     self.filters.complevel)
-        return "%s (%s%s%s) %r" % \
-               (self._v_pathname, classname, self.shape, filters, title)
+                filters.append("bitshuffle")
+            filters.append(f"{self.filters.complib}({self.filters.complevel})")
+        return (f"{self._v_pathname} ({self.__class__.__name__}"
+                f"{self.shape}{', '.join(filters)}) {self._v_title!r}")
 
     # Private methods
     # ~~~~~~~~~~~~~~~

--- a/tables/link.py
+++ b/tables/link.py
@@ -303,21 +303,14 @@ class SoftLink(linkextension.SoftLink, Link):
 
         """
 
-        classname = self.__class__.__name__
         target = str(self.target)
         # Check for relative pathnames
         if not self.target.startswith('/'):
             target = self._v_parent._g_join(self.target)
-        if self._v_isopen:
-            closed = ""
-        else:
-            closed = "closed "
-        if target not in self._v_file:
-            dangling = " (dangling)"
-        else:
-            dangling = ""
-        return "{}{} ({}) -> {}{}".format(closed, self._v_pathname, classname,
-                                      self.target, dangling)
+        closed = "" if self._v_isopen else "closed "
+        dangling = "" if target in self._v_file else " (dangling)"
+        return (f"{closed}{self._v_pathname} ({self.__class__.__name__}) -> "
+                f"{self.target}{dangling}")
 
 
 class ExternalLink(linkextension.ExternalLink, Link):
@@ -425,8 +418,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
 
         """
 
-        classname = self.__class__.__name__
-        return f"{self._v_pathname} ({classname}) -> {self.target}"
+        return f"{self._v_pathname} ({self.__class__.__name__}) -> {self.target}"
 
 
 ## Local Variables:

--- a/tables/misc/proxydict.py
+++ b/tables/misc/proxydict.py
@@ -42,9 +42,7 @@ class ProxyDict(dict):
 
     def __str__(self):
         # C implementation does not use `self.__getitem__()`. :(
-        itemFormat = '%r: %r'
-        itemReprs = [itemFormat % item for item in self.items()]
-        return '{%s}' % ', '.join(itemReprs)
+        return '{' + ", ".join("{k!r}: {v!r}" for k, v in self.items()) + '}'
 
     def values(self):
         # C implementation does not use `self.__getitem__()`. :(

--- a/tables/node.py
+++ b/tables/node.py
@@ -40,10 +40,8 @@ def _closedrepr(oldmethod):
     @functools.wraps(oldmethod)
     def newmethod(self):
         if not self._v_isopen:
-            cmod = self.__class__.__module__
-            cname = self.__class__.__name__
-            addr = hex(id(self))
-            return f'<closed {cmod}.{cname} at {addr}>'
+            return (f'<closed {self.__class__.__module__}.'
+                    f'{self.__class__.__name__} at 0x{id(self):x}>')
         return oldmethod(self)
 
     return newmethod

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -251,7 +251,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
                 name += " (%s)" % node.__class__.__name__
 
             labels = []
-            pct = 100 * on_disk[path] / total_on_disk
+            ratio = on_disk[path] / total_on_disk
 
             # if the address of this object has a ref_count > 1, it has
             # multiple hardlinks
@@ -274,7 +274,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
                     sizestr = 'mem={}, disk={}'.format(
                         b2h(in_mem[path]), b2h(on_disk[path]))
                     if print_percent:
-                        sizestr += ' [%4.1f%%]' % pct
+                        sizestr += f' [{ratio:5.1%}]'
                     labels.append(sizestr)
 
                 if print_shape:
@@ -297,7 +297,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
                     itemstr += ', mem={}, disk={}'.format(
                         b2h(in_mem[path]), b2h(on_disk[path]))
                 if print_percent:
-                    itemstr += ' [%4.1f%%]' % pct
+                    itemstr += f' [{ratio:5.1%}]'
                 labels.append(itemstr)
 
             # create a PrettyTree for this node, if one doesn't exist already
@@ -307,7 +307,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
             pretty[path].labels = labels
             if sort_by == 'size':
                 # descending size order
-                pretty[path].sort_by = -pct
+                pretty[path].sort_by = -ratio
             elif sort_by == 'name':
                 pretty[path].sort_by = node._v_name
             else:

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -415,7 +415,7 @@ class PrettyTree:
         return "\n".join(self.tree_lines())
 
     def __repr__(self):
-        return '<{} at {}>'.format(self.__class__.__name__, hex(id(self)))
+        return f'<{self.__class__.__name__} at 0x{id(self):x}>'
 
 
 def bytes2human(use_si_units=False):

--- a/tables/table.py
+++ b/tables/table.py
@@ -3235,21 +3235,16 @@ class Cols:
         """The string representation for this object."""
 
         # The pathname
-        tablepathname = self._v__tablePath
         descpathname = self._v_desc._v_pathname
         if descpathname:
             descpathname = "." + descpathname
-        # Get this class name
-        classname = self.__class__.__name__
-        # The number of columns
-        ncols = len(self._v_colnames)
-        return "%s.cols%s (%s), %s columns" % \
-               (tablepathname, descpathname, classname, ncols)
+        return (f"{self._v__tablePath}.cols{descpathname} "
+                f"({self.__class__.__name__}), {len(self._v_colnames)} columns")
 
     def __repr__(self):
         """A detailed string representation for this object."""
 
-        out = str(self) + "\n"
+        lines = [f'{self!s}']
         for name in self._v_colnames:
             # Get this class name
             classname = getattr(self, name).__class__.__name__
@@ -3263,8 +3258,8 @@ class Cols:
                 tcol = "Description"
                 # Description doesn't have a shape currently
                 shape = ()
-            out += f"  {name} ({classname}{shape}, {tcol})" + "\n"
-        return out
+            lines.append(f"  {name} ({classname}{shape}, {tcol})")
+        return '\n'.join(lines) + '\n'
 
 
 class Column:
@@ -3698,17 +3693,9 @@ class Column:
     def __str__(self):
         """The string representation for this object."""
 
-        # The pathname
-        tablepathname = self._table_path
-        pathname = self.pathname.replace('/', '.')
-        # Get this class name
-        classname = self.__class__.__name__
-        # The shape for this column
-        shape = self.shape
-        # The type
-        tcol = self.descr._v_types[self.name]
-        return "%s.cols.%s (%s%s, %s, idx=%s)" % \
-               (tablepathname, pathname, classname, shape, tcol, self.index)
+        return (f"{self._table_path}.cols.{self.pathname.replace('/', '.')} "
+                f"({self.__class__.__name__}{self.shape}, "
+                f"{self.descr._v_types[self.name]}, idx={self.index})")
 
     def __repr__(self):
         """A detailed string representation for this object."""

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -149,11 +149,11 @@ class Unknown(Node):
         return f"{pathname} ({classname})"
 
     def __repr__(self):
-        return """%s
+        return f"""{self!s}
   NOTE: <The Unknown object represents a node which is reported as
          unknown by the underlying HDF5 library, but that might be
          supported in more recent HDF5 versions.>
-""" % (str(self))
+"""
 
 
 # These are listed here for backward compatibility with PyTables 0.9.x indexes


### PR DESCRIPTION
This adds some new f-strings to the codebase, refactoring all `__str__` and `__repr__` methods. Here I have a question about https://github.com/PyTables/PyTables/blob/master/tables/file.py#L2788 (the `Last modif.` line in the `str(h5f)` output), that is formatted as `repr(time.asctime(…))` which looks like `'Mon Sep 20 12:40:47 2004'`. Would be an `isoformat()` alternative (e.g. `2021-01-05 12:34:56+00:00`) more appropriate here? This is the only place where we print/format some datetime info.

The bonus tiny commit changes one percentage variable to a `ratio` variable (0.–1. instead of 0–100) and formats it accordingly. The 