### PR TITLE
Consistent elapsed time measuring both real and cpu

### DIFF
--- a/bench/LRU-experiments.py
+++ b/bench/LRU-experiments.py
@@ -1,7 +1,7 @@
 # Testbed to perform experiments in order to determine best values for
 # the node numbers in LRU cache. Tables version.
 
-from time import time
+from time import perf_counter as clock
 from tables import *
 import tables
 
@@ -60,13 +60,13 @@ def modify_junk_LRU2():
     fileh = open_file(filename, 'a')
     group = fileh.root.newgroup
     for j in range(20):
-        t1 = time()
+        t1 = clock()
         for i in range(100):
             #print("table-->", tt._v_name)
             tt = getattr(group, "table" + str(i))
             #for row in tt:
             #    pass
-        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
+        print(f"iter and time --> {j + 1} {clock() - t1:.3f}")
     fileh.close()
 
 
@@ -74,12 +74,12 @@ def modify_junk_LRU3():
     fileh = open_file(filename, 'a')
     group = fileh.root.newgroup
     for j in range(3):
-        t1 = time()
+        t1 = clock()
         for tt in fileh.walk_nodes(group, "Table"):
             tt.attrs.TITLE
             for row in tt:
                 pass
-        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
+        print(f"iter and time --> {j + 1} {clock() - t1:.3f}")
     fileh.close()
 
 if 1:

--- a/bench/LRU-experiments2.py
+++ b/bench/LRU-experiments2.py
@@ -1,7 +1,7 @@
 # Testbed to perform experiments in order to determine best values for
 # the node numbers in LRU cache. Arrays version.
 
-from time import time
+from time import perf_counter as clock
 import tables
 
 print("PyTables version-->", tables.__version__)
@@ -34,12 +34,12 @@ def modify_junk_LRU2():
     fileh = tables.open_file(filename, 'a')
     group = fileh.root
     for j in range(5):
-        t1 = time()
+        t1 = clock()
         for i in range(100):  # The number
             #print("table-->", tt._v_name)
             tt = getattr(group, "array" + str(i))
             #d = tt.read()
-        print(f"iter and time --> {j + 1} {time() - t1:.3f}")
+        print(f"iter and time --> {j + 1} {clock() - t1:.3f}")
     fileh.close()
 
 if 1:

--- a/bench/LRUcache-node-bench.py
+++ b/bench/LRUcache-node-bench.py
@@ -1,7 +1,7 @@
 import sys
 import numpy
 import tables
-from time import time
+from time import perf_counter as clock
 #import psyco
 
 filename = "/tmp/LRU-bench.h5"
@@ -39,19 +39,19 @@ def iternodes():
 
 print("reading nodes...")
 # First iteration (put in LRU cache)
-t1 = time()
+t1 = clock()
 for a in f.root.NodeContainer:
     pass
-print(f"time (init cache)--> {time() - t1:.3f}")
+print(f"time (init cache)--> {clock() - t1:.3f}")
 
 
 def timeLRU():
     # Next iterations
-    t1 = time()
+    t1 = clock()
 #     for i in range(niter):
 #         iternodes()
     iternodes()
-    print(f"time (from cache)--> {(time() - t1) / niter:.3f}")
+    print(f"time (from cache)--> {(clock() - t1) / niter:.3f}")
 
 
 def profile(verbose=False):

--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from time import time
+from time import perf_counter as clock
 import numpy as np
 import tables as tb
 
@@ -122,9 +122,9 @@ def process_file(kind, prec, clevel, synth):
 
     if kind == "numpy":
         a2, b2 = a_[:], b_[:]
-        t0 = time()
+        t0 = clock()
         r = eval(expression, {'a': a2, 'b': b2})
-        print(f"{time() - t0:5.2f}")
+        print(f"{clock() - t0:5.2f}")
     else:
         expr = tb.Expr(expression, {'a': a_, 'b': b_})
         expr.set_output(r)
@@ -154,11 +154,11 @@ if __name__ == '__main__':
 
     # print "Processing files for compression levels in range(10)..."
     for clevel in range(10):
-        t0 = time()
+        t0 = clock()
         ts = []
         for i in range(niter):
             size = process_file(kind, prec, clevel, synth)
-            ts.append(time() - t0)
-            t0 = time()
+            ts.append(clock() - t0)
+            t0 = clock()
         ratio = size_orig / size
         print(f"{min(ts):5.2f}, {ratio:5.2f}")

--- a/bench/bsddb-table-bench.py
+++ b/bench/bsddb-table-bench.py
@@ -200,7 +200,7 @@ def readFile(filename, recsize, verbose):
 # Add code to test here
 if __name__ == "__main__":
     import getopt
-    import time
+    from time import perf_counter as clock
 
     usage = """usage: %s [-v] [-s recsize] [-i iterations] file
             -v verbose
@@ -238,16 +238,16 @@ if __name__ == "__main__":
     # Catch the hdf5 file passed as the last argument
     file = pargs[0]
 
-    t1 = time.perf_counter()
+    t1 = clock()
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize, verbose)
-    t2 = time.perf_counter()
+    t2 = clock()
     tapprows = t2 - t1
 
-    t1 = time.perf_counter()
+    t1 = clock()
     psyco.bind(readFile)
     readFile(file, recsize, verbose)
-    t2 = time.perf_counter()
+    t2 = clock()
     treadrows = t2 - t1
 
     print(f"Rows written: {rowsw}, Row size: {rowsz}")

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -5,7 +5,7 @@
 
 import numpy
 import tables
-from time import time
+from time import perf_counter as clock
 
 dim1, dim2 = 360, 6_109_666
 rows_to_read = range(0, 360, 36)
@@ -18,38 +18,38 @@ a = f.create_earray(f.root, "a", tables.Float64Atom(), shape=(dim1, 0),
 print("Chunkshape for original array:", a.chunkshape)
 
 # Fill the EArray
-t1 = time()
+t1 = clock()
 zeros = numpy.zeros((dim1, 1), dtype="float64")
 for i in range(dim2):
     a.append(zeros)
-tcre = time() - t1
+tcre = clock() - t1
 thcre = dim1 * dim2 * 8 / (tcre * 1024 * 1024)
 print(f"Time to append {a.nrows} rows: {tcre:.3f} sec ({thcre:.1f} MB/s)")
 
 # Read some row vectors from the original array
-t1 = time()
+t1 = clock()
 for i in rows_to_read:
     r1 = a[i, :]
-tr1 = time() - t1
+tr1 = clock() - t1
 thr1 = dim2 * len(rows_to_read) * 8 / (tr1 * 1024 * 1024)
 print(f"Time to read ten rows in original array: {tr1:.3f} sec ({thr1:.1f} MB/s)")
 
 print("=" * 32)
 # Copy the array to another with a row-wise chunkshape
-t1 = time()
+t1 = clock()
 #newchunkshape = (1, a.chunkshape[0]*a.chunkshape[1])
 newchunkshape = (1, a.chunkshape[0] * a.chunkshape[1] * 10)  # ten times larger
 b = a.copy(f.root, "b", chunkshape=newchunkshape)
-tcpy = time() - t1
+tcpy = clock() - t1
 thcpy = dim1 * dim2 * 8 / (tcpy * 1024 * 1024)
 print("Chunkshape for row-wise chunkshape array:", b.chunkshape)
 print(f"Time to copy the original array: {tcpy:.3f} sec ({thcpy:.1f} MB/s)")
 
 # Read the same ten rows from the new copied array
-t1 = time()
+t1 = clock()
 for i in rows_to_read:
     r2 = b[i, :]
-tr2 = time() - t1
+tr2 = clock() - t1
 thr2 = dim2 * len(rows_to_read) * 8 / (tr2 * 1024 * 1024)
 print(f"Time to read with a row-wise chunkshape: {tr2:.3f} sec ({thr2:.1f} MB/s)")
 print("=" * 32)

--- a/bench/chunkshape-testing.py
+++ b/bench/chunkshape-testing.py
@@ -4,7 +4,7 @@
 
 import numpy
 import tables
-from time import time
+from time import perf_counter as clock
 
 L = 20
 N = 2000
@@ -32,9 +32,9 @@ c1 = f.create_carray(f1.root, 'cfield1',
                      tables.Int32Atom(), (L, N, M),
                      "scalar int32 carray", tables.Filters(complevel=0))
 
-t1 = time()
+t1 = clock()
 c1[:] = numpy.empty(shape=(L, 1, 1), dtype="int32")
-print("carray1 populate time:", time() - t1)
+print("carray1 populate time:", clock() - t1)
 f1.close()
 
 
@@ -43,9 +43,9 @@ c2 = f.create_carray(f2.root, 'cfield2',
                      tables.Int32Atom(), (L, M, N),
                      "scalar int32 carray", tables.Filters(complevel))
 
-t1 = time()
+t1 = clock()
 c2[:] = numpy.empty(shape=(L, 1, 1), dtype="int32")
-print("carray2 populate time:", time() - t1)
+print("carray2 populate time:", clock() - t1)
 f2.close()
 
 f0 = tables.open_file("chunkshape0.h5", mode="w")
@@ -54,9 +54,9 @@ e0 = f.create_earray(f0.root, 'efield0',
                      "scalar int32 carray", tables.Filters(complevel),
                      expectedrows=N)
 
-t1 = time()
+t1 = clock()
 e0.append(numpy.empty(shape=(N, L, M), dtype="int32"))
-print("earray0 populate time:", time() - t1)
+print("earray0 populate time:", clock() - t1)
 f0.close()
 
 f1 = tables.open_file("chunkshape1.h5", mode="w")
@@ -65,9 +65,9 @@ e1 = f.create_earray(f1.root, 'efield1',
                      "scalar int32 carray", tables.Filters(complevel),
                      expectedrows=N)
 
-t1 = time()
+t1 = clock()
 e1.append(numpy.empty(shape=(L, N, M), dtype="int32"))
-print("earray1 populate time:", time() - t1)
+print("earray1 populate time:", clock() - t1)
 f1.close()
 
 
@@ -77,9 +77,9 @@ e2 = f.create_earray(f2.root, 'efield2',
                      "scalar int32 carray", tables.Filters(complevel),
                      expectedrows=N)
 
-t1 = time()
+t1 = clock()
 e2.append(numpy.empty(shape=(L, M, N), dtype="int32"))
-print("earray2 populate time:", time() - t1)
+print("earray2 populate time:", clock() - t1)
 f2.close()
 
 # t1=time()

--- a/bench/collations.py
+++ b/bench/collations.py
@@ -1,6 +1,6 @@
 import numpy as np
 import tables
-from time import time
+from time import perf_counter as clock
 
 N = 1000 * 1000
 NCOLL = 200  # 200 collections maximum
@@ -21,7 +21,7 @@ def fill_bucket(lbucket):
     return c, e
 
 # Fill the table
-t1 = time()
+t1 = clock()
 f = tables.open_file("data.nobackup/collations.h5", "w")
 table = f.create_table("/", "Energies", Energies, expectedrows=N)
 # Fill the table with values
@@ -42,7 +42,7 @@ table = f.root.Energies
 #########################################################
 # First solution: load the table completely in memory
 #########################################################
-t1 = time()
+t1 = clock()
 t = table[:]  # convert to structured array
 coll1 = []
 collections = np.unique(t['collection'])
@@ -53,12 +53,12 @@ for c in collections:
     coll1.append(sener)
     print(c, ' : ', sener)
 del collections, energy_this_collection
-print("Time for first solution: %.3f" % (time() - t1))
+print(f"Time for first solution: {clock() - t1:.3f}s")
 
 #########################################################
 # Second solution: load all the collections in memory
 #########################################################
-t1 = time()
+t1 = clock()
 collections = {}
 for row in table:
     c = row['collection']
@@ -75,17 +75,17 @@ for c in sorted(collections):
     coll2.append(sener)
     print(c, ' : ', sener)
 del collections, energy_this_collection
-print("Time for second solution: %.3f" % (time() - t1))
+print(f"Time for second solution: {clock() - t1:.3f}s")
 
-t1 = time()
+t1 = clock()
 table.cols.collection.create_csindex()
 # table.cols.collection.reindex()
-print("Time for indexing: %.3f" % (time() - t1))
+print(f"Time for indexing: {clock() - t1:.3f}s")
 
 #########################################################
 # Third solution: load each collection separately
 #########################################################
-t1 = time()
+t1 = clock()
 coll3 = []
 for c in np.unique(table.col('collection')):
     energy_this_collection = table.read_where(
@@ -94,18 +94,18 @@ for c in np.unique(table.col('collection')):
     coll3.append(sener)
     print(c, ' : ', sener)
 del energy_this_collection
-print("Time for third solution: %.3f" % (time() - t1))
+print(f"Time for third solution: {clock() - t1:.3f}s")
 
 
-t1 = time()
+t1 = clock()
 table2 = table.copy('/', 'EnergySortedByCollation', overwrite=True,
                     sortby="collection", propindexes=True)
-print("Time for sorting: %.3f" % (time() - t1))
+print(f"Time for sorting: {clock() - t1:.3f}s")
 
 #####################################################################
 # Fourth solution: load each collection separately.  Sorted table.
 #####################################################################
-t1 = time()
+t1 = clock()
 coll4 = []
 for c in np.unique(table2.col('collection')):
     energy_this_collection = table2.read_where(
@@ -114,7 +114,7 @@ for c in np.unique(table2.col('collection')):
     coll4.append(sener)
     print(c, ' : ', sener)
     del energy_this_collection
-print("Time for fourth solution: %.3f" % (time() - t1))
+print(f"Time for fourth solution: {clock() - t1:.3f}s")
 
 
 # Finally, check that all solutions do match

--- a/bench/copy-bench.py
+++ b/bench/copy-bench.py
@@ -1,6 +1,6 @@
 import tables
 import sys
-import time
+from time import perf_counter as clock
 
 if len(sys.argv) != 3:
     print("usage: %s source_file dest_file", sys.argv[0])
@@ -10,7 +10,7 @@ filehsrc = tables.open_file(filesrc)
 filehdest = tables.open_file(filedest, 'w')
 ntables = 0
 tsize = 0
-t1 = time.time()
+t1 = clock()
 for group in filehsrc.walk_groups():
     if isinstance(group._v_parent, tables.File):
         groupdest = filehdest.root
@@ -24,7 +24,7 @@ for group in filehsrc.walk_groups():
         ntables += 1
         tsize += table.nrows * table.rowsize
 tsizeMB = tsize / (1024 * 1024)
-ttime = time.time() - t1
+ttime = clock() - t1
 print(f"Copied {ntables} tables for a total of {tsizeMB:.1f} MB"
       f" in {ttime:.3f} seconds ({tsizeMB / ttime:.1f} MB/s)")
 filehsrc.close()

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from time import time
+from time import perf_counter as clock
 import random
 import numpy
 import h5py
@@ -31,7 +31,7 @@ def show_stats(explain, tref):
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
-    tnow = time()
+    tnow = clock()
     print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 
@@ -70,7 +70,7 @@ if __name__ == '__main__':
         import cProfile as prof
 
     if profile:
-        tref = time()
+        tref = clock()
     if profile:
         show_stats("Abans de crear...", tref)
     f = h5py.File("/tmp/deep-tree.h5", 'w')

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -3,7 +3,7 @@
 
 import os
 import subprocess
-from time import time
+from time import perf_counter as clock
 import random
 #import numpy
 import tables
@@ -34,7 +34,7 @@ def show_stats(explain, tref):
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
-    tnow = time()
+    tnow = clock()
     print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         import cProfile as prof
 
     if profile:
-        tref = time()
+        tref = clock()
     if profile:
         show_stats("Abans de crear...", tref)
     f = tables.open_file("/tmp/PTdeep-tree.h5", 'w',
@@ -102,7 +102,7 @@ if __name__ == '__main__':
         show_stats("Despres de crear", tref)
 
     if profile:
-        tref = time()
+        tref = clock()
     if profile:
         show_stats("Abans d'obrir...", tref)
     f = tables.open_file("/tmp/PTdeep-tree.h5", 'r',

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -1,5 +1,5 @@
 import sys
-from time import time
+from time import perf_counter as clock
 
 import numpy as np
 import tables as tb
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         out = f.create_carray(f.root, 'out', tb.Float32Atom(),
                               shape=shape, filters=ofilters)
 
-    t0 = time()
+    t0 = clock()
     if iarrays and oarrays:
         #out = ne.evaluate("a*b+c")
         out = a * b + c
@@ -165,7 +165,7 @@ if __name__ == "__main__":
         ofile.close()
     else:
         evaluate("a*b+c", out)
-    print(f"Time for evaluate--> {time() - t0:.3f}")
+    print(f"Time for evaluate--> {clock() - t0:.3f}")
 
     # print "out-->", `out`
     # print `out[:]`

--- a/bench/expression.py
+++ b/bench/expression.py
@@ -1,4 +1,4 @@
-from time import time
+from time import perf_counter as clock
 import os.path
 
 import numpy as np
@@ -35,7 +35,7 @@ def tables(docompute, dowrite, complib, verbose):
         f = tb.open_file(ifilename, 'w')
 
         # Build input arrays
-        t0 = time()
+        t0 = clock()
         root = f.root
         a = f.create_carray(root, 'a', tb.Float32Atom(),
                             shape, filters=filters)
@@ -50,7 +50,7 @@ def tables(docompute, dowrite, complib, verbose):
             a[i] = row * (i + 1)
             b[i] = row * (i + 1) * 2
         f.close()
-        print(f"[tables.Expr] Time for creating inputs: {time() - t0:.3f}")
+        print(f"[tables.Expr] Time for creating inputs: {clock() - t0:.3f}")
 
     if docompute:
         f = tb.open_file(ifilename, 'r')
@@ -62,13 +62,13 @@ def tables(docompute, dowrite, complib, verbose):
         # The expression
         e = tb.Expr(expr)
         e.set_output(r1)
-        t0 = time()
+        t0 = clock()
         e.eval()
         if verbose:
             print("First ten values:", r1[0, :10])
         f.close()
         fr.close()
-        print(f"[tables.Expr] Time for computing & save: {time() - t0:.3f}")
+        print(f"[tables.Expr] Time for computing & save: {clock() - t0:.3f}")
 
 
 def memmap(docompute, dowrite, verbose):
@@ -77,7 +77,7 @@ def memmap(docompute, dowrite, verbose):
     bfilename = os.path.join(OUT_DIR, "memmap-b.bin")
     rfilename = os.path.join(OUT_DIR, "memmap-output.bin")
     if dowrite:
-        t0 = time()
+        t0 = clock()
         a = np.memmap(afilename, dtype='float32', mode='w+', shape=shape)
         b = np.memmap(bfilename, dtype='float32', mode='w+', shape=shape)
 
@@ -88,10 +88,10 @@ def memmap(docompute, dowrite, verbose):
             a[i] = row * (i + 1)
             b[i] = row * (i + 1) * 2
         del a, b  # flush data
-        print(f"[numpy.memmap] Time for creating inputs: {time() - t0:.3f}")
+        print(f"[numpy.memmap] Time for creating inputs: {clock() - t0:.3f}")
 
     if docompute:
-        t0 = time()
+        t0 = clock()
         # Reopen inputs in read-only mode
         a = np.memmap(afilename, dtype='float32', mode='r', shape=shape)
         b = np.memmap(bfilename, dtype='float32', mode='r', shape=shape)
@@ -104,7 +104,7 @@ def memmap(docompute, dowrite, verbose):
             print("First ten values:", r[0, :10])
         del a, b
         del r  # flush output data
-        print(f"[numpy.memmap] Time for compute & save: {time() - t0:.3f}")
+        print(f"[numpy.memmap] Time for compute & save: {clock() - t0:.3f}")
 
 
 def do_bench(what, documpute, dowrite, complib, verbose):

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -1,4 +1,4 @@
-from time import time
+from time import perf_counter as clock
 import subprocess
 import random
 import numpy
@@ -54,7 +54,7 @@ class DB:
         return int(line.split()[0])
 
     def print_mtime(self, t1, explain):
-        mtime = time() - t1
+        mtime = clock() - t1
         print(f"{explain}: {mtime:.6f}")
         print(f"Krows/s: {self.nrows / 1000 / mtime:.6f}")
 
@@ -118,7 +118,7 @@ class DB:
         self.con = self.open_db(remove=1)
         self.create_table(self.con)
         init_size = self.get_db_size()
-        t1 = time()
+        t1 = clock()
         self.fill_table(self.con)
         table_size = self.get_db_size()
         self.print_mtime(t1, 'Insert time')
@@ -135,7 +135,7 @@ class DB:
         else:
             idx_cols = ['col2', 'col4']
         for colname in idx_cols:
-            t1 = time()
+            t1 = clock()
             self.index_col(self.con, colname, kind, optlevel, verbose)
             self.print_mtime(t1, 'Index time (%s)' % colname)
 
@@ -163,9 +163,9 @@ class DB:
                 ltimes = []
                 random.seed(rseed)
                 for i in range(NI_NTIMES):
-                    t1 = time()
+                    t1 = clock()
                     results = self.do_query(self.con, colname, base, inkernel)
-                    ltimes.append(time() - t1)
+                    ltimes.append(clock() - t1)
                 if verbose:
                     print("Results len:", results)
                 self.print_qtime(colname, ltimes)
@@ -182,11 +182,11 @@ class DB:
                 # First, non-repeated queries
                 for i in range(niter):
                     base = rndbase[i]
-                    t1 = time()
+                    t1 = clock()
                     results = self.do_query(self.con, colname, base, inkernel)
                     #results, tprof = self.do_query(
                     #    self.con, colname, base, inkernel)
-                    ltimes.append(time() - t1)
+                    ltimes.append(clock() - t1)
                 if verbose:
                     print("Results len:", results)
                 self.print_qtime_idx(colname, ltimes, False, verbose)

--- a/bench/keysort.py
+++ b/bench/keysort.py
@@ -1,6 +1,6 @@
 from tables.indexesextension import keysort
 import numpy
-from time import time
+from time import perf_counter as clock
 
 N = 1000 * 1000
 rnd = numpy.random.randint(N, size=N)
@@ -14,18 +14,18 @@ for dtype1 in ('S6', 'b1',
         b = numpy.arange(N, dtype=dtype2)
         c = a.copy()
 
-        t1 = time()
+        t1 = clock()
         d = c.argsort()
         # c.sort()
         # e=c
         e = c[d]
         f = b[d]
-        tref = time() - t1
+        tref = clock() - t1
         print("normal sort time-->", tref)
 
-        t1 = time()
+        t1 = clock()
         keysort(a, b)
-        tks = time() - t1
+        tks = clock() - t1
         print("keysort time-->", tks, "    {:.2f}x".format(tref / tks))
         assert numpy.alltrue(a == e)
         #assert numpy.alltrue(b == d)

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -1,7 +1,7 @@
 """Benchmark to help choosing the best chunksize so as to optimize the access
 time in random lookups."""
 
-from time import time
+from time import perf_counter as clock
 import os
 import subprocess
 import numpy
@@ -50,7 +50,7 @@ class DB:
         return int(line.split()[0])
 
     def print_mtime(self, t1, explain):
-        mtime = time() - t1
+        mtime = clock() - t1
         print(f"{explain}: {mtime:.6f}")
         print(f"Krows/s: {self.nrows / 1000 / mtime:.6f}")
 
@@ -68,7 +68,7 @@ class DB:
         self.con = self.open_db(remove=1)
         self.create_array()
         init_size = self.get_db_size()
-        t1 = time()
+        t1 = clock()
         self.fill_array()
         array_size = self.get_db_size()
         self.print_mtime(t1, 'Insert time')
@@ -132,9 +132,9 @@ class DB:
         numpy.random.randint(self.nrows)
         ltimes = []
         for i in range(niter):
-            t1 = time()
+            t1 = clock()
             self.do_query(earray, numpy.random.randint(self.nrows))
-            ltimes.append(time() - t1)
+            ltimes.append(clock() - t1)
         self.print_qtime(ltimes)
         self.close_db()
 

--- a/bench/open_close-bench.py
+++ b/bench/open_close-bench.py
@@ -9,9 +9,9 @@ import sys
 import getopt
 import pstats
 import cProfile as prof
-import time
 import subprocess  # From Python 2.4 on
 import tables
+from time import perf_counter as clock
 
 filename = None
 niter = 1
@@ -36,7 +36,7 @@ def show_stats(explain, tref):
         elif line.startswith("VmLib:"):
             vmlib = int(line.split()[1])
     sout.close()
-    print("WallClock time:", time.time() - tref)
+    print("WallClock time:", clock() - tref)
     print("Memory usage: ******* %s *******" % explain)
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
@@ -47,7 +47,7 @@ def check_open_close():
     for i in range(niter):
         print(
             "------------------ open_close #%s -------------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         fileh.close()
         show_stats("After closing file", tref)
@@ -56,7 +56,7 @@ def check_open_close():
 def check_only_open():
     for i in range(niter):
         print("------------------ only_open #%s -------------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         show_stats("Before closing file", tref)
         fileh.close()
@@ -65,7 +65,7 @@ def check_only_open():
 def check_full_browse():
     for i in range(niter):
         print("------------------ full_browse #%s -----------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         for node in fileh:
             pass
@@ -76,7 +76,7 @@ def check_full_browse():
 def check_partial_browse():
     for i in range(niter):
         print("------------------ partial_browse #%s --------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         for node in fileh.root.ngroup0.ngroup1:
             pass
@@ -87,7 +87,7 @@ def check_partial_browse():
 def check_full_browse_attrs():
     for i in range(niter):
         print("------------------ full_browse_attrs #%s -----------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         for node in fileh:
             # Access to an attribute
@@ -99,7 +99,7 @@ def check_full_browse_attrs():
 def check_partial_browse_attrs():
     for i in range(niter):
         print("------------------ partial_browse_attrs #%s --------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         for node in fileh.root.ngroup0.ngroup1:
             # Access to an attribute
@@ -111,7 +111,7 @@ def check_partial_browse_attrs():
 def check_open_group():
     for i in range(niter):
         print("------------------ open_group #%s ------------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         group = fileh.root.ngroup0.ngroup1
         # Access to an attribute
@@ -123,7 +123,7 @@ def check_open_group():
 def check_open_leaf():
     for i in range(niter):
         print("------------------ open_leaf #%s -----------------------" % i)
-        tref = time.time()
+        tref = clock()
         fileh = tables.open_file(filename)
         leaf = fileh.root.ngroup0.ngroup1.array9
         # Access to an attribute
@@ -208,7 +208,7 @@ if __name__ == '__main__':
 
     filename = pargs[0]
 
-    tref = time.time()
+    tref = clock()
     if all_system_checks:
         args.remove('-S')  # We don't want -S in the options list again
         for opt in options:

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -9,7 +9,7 @@ import os
 import math
 import subprocess
 import tempfile
-from time import time
+from time import perf_counter as clock
 import numpy
 import tables
 
@@ -59,24 +59,24 @@ def bench(chunkshape, filters):
                         filters = filters,
                         chunkshape = chunkshape)
     # Fill the array
-    t1 = time()
+    t1 = clock()
     for i in range(N):
         # e.append([numpy.random.rand(M)])  # use this for less compressibility
         e.append([quantize(numpy.random.rand(M), 6)])
     # os.system("sync")
-    print(f"Creation time: {time() - t1:.3f}", end=' ')
+    print(f"Creation time: {clock() - t1:.3f}", end=' ')
     filesize = get_db_size(filename)
     filesize_bytes = os.stat(filename).st_size
     print("\t\tFile size: %d -- (%s)" % (filesize_bytes, filesize))
 
     # Read in sequential mode:
     e = f.root.earray
-    t1 = time()
+    t1 = clock()
     # Flush everything to disk and flush caches
     #os.system("sync; echo 1 > /proc/sys/vm/drop_caches")
     for row in e:
         t = row
-    print(f"Sequential read time: {time() - t1:.3f}", end=' ')
+    print(f"Sequential read time: {clock() - t1:.3f}", end=' ')
 
     # f.close()
     # return
@@ -93,11 +93,11 @@ def bench(chunkshape, filters):
         f.close()
         return
 
-    t1 = time()
+    t1 = clock()
     for i in i_index:
         for j in j_index:
             t = e[i, j]
-    print(f"\tRandom read time: {time() - t1:.3f}")
+    print(f"\tRandom read time: {clock() - t1:.3f}")
 
     f.close()
 

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -7,7 +7,7 @@
 #######################################################################
 
 import os
-from time import time
+from time import perf_counter as clock
 import numpy as np
 import tables as tb
 import numexpr as ne
@@ -155,7 +155,7 @@ if __name__ == '__main__':
     for what in ["numpy", "numexpr"]:
         # break
         print("Populating x using %s with %d points..." % (what, N))
-        t0 = time()
+        t0 = clock()
         if what == "numpy":
             populate_x_numpy()
             compute = compute_numpy
@@ -165,14 +165,14 @@ if __name__ == '__main__':
         elif what == "numpy.memmap":
             populate_x_memmap()
             compute = compute_memmap
-        print(f"*** Time elapsed populating: {time() - t0:.3f}")
+        print(f"*** Time elapsed populating: {clock() - t0:.3f}")
         print(f"Computing: {expr!r} using {what}")
-        t0 = time()
+        t0 = clock()
         compute()
-        print(f"**************** Time elapsed computing: {time() - t0:.3f}")
+        print(f"**************** Time elapsed computing: {clock() - t0:.3f}")
 
     for what in ["tables.Expr"]:
-        t0 = time()
+        t0 = clock()
         first = True    # Sentinel
         for clib in supported_clibs:
             # for clevel in (0, 1, 3, 6, 9):
@@ -182,11 +182,11 @@ if __name__ == '__main__':
                     continue
                 print("Populating x using %s with %d points..." % (what, N))
                 populate_x_tables(clib, clevel)
-                print(f"*** Time elapsed populating: {time() - t0:.3f}")
+                print(f"*** Time elapsed populating: {clock() - t0:.3f}")
                 print(f"Computing: {expr!r} using {what}")
-                t0 = time()
+                t0 = clock()
                 compute_tables(clib, clevel)
                 print(
                     f"**************** Time elapsed computing: "
-                    f"{time() - t0:.3f}")
+                    f"{clock() - t0:.3f}")
                 first = False

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -1,4 +1,4 @@
-from time import time
+from time import perf_counter as clock
 import numpy
 import random
 
@@ -105,7 +105,7 @@ def create_db(filename, nrows):
         cur.execute("create table ints(i integer, j double precision)")
     con.commit()
     con.set_isolation_level(2)
-    t1 = time()
+    t1 = clock()
     st = Stream32()
     cur.copy_from(st, "ints")
     # In case of postgres, the speeds of generator and loop are similar
@@ -113,7 +113,7 @@ def create_db(filename, nrows):
 #     for i in xrange(nrows):
 #         cur.execute("insert into ints values (%s,%s)", (i, float(i)))
     con.commit()
-    ctime = time() - t1
+    ctime = clock() - t1
     if verbose:
         print(f"insert time: {ctime:.5f}")
         print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
@@ -122,10 +122,10 @@ def create_db(filename, nrows):
 
 def index_db(filename):
     con, cur = open_db(filename)
-    t1 = time()
+    t1 = clock()
     cur.execute("create index ij on ints(j)")
     con.commit()
-    itime = time() - t1
+    itime = clock() - t1
     if verbose:
         print(f"index time: {itime:.5f}")
         print(f"Krows/s: {nrows / itime:.5f}")
@@ -135,7 +135,7 @@ def index_db(filename):
 
 def query_db(filename, rng):
     con, cur = open_db(filename)
-    t1 = time()
+    t1 = clock()
     ntimes = 10
     for i in range(ntimes):
         # between clause does not seem to take advantage of indexes
@@ -146,7 +146,7 @@ def query_db(filename, rng):
                     (rng[0] + i, rng[1] + i))
         results = cur.fetchall()
     con.commit()
-    qtime = (time() - t1) / ntimes
+    qtime = (clock() - t1) / ntimes
     if verbose:
         print(f"query time: {qtime:.5f}")
         print(f"Mrows/s: {nrows / 1000 / qtime:.5f}")

--- a/bench/pytables-search-bench.py
+++ b/bench/pytables-search-bench.py
@@ -1,5 +1,5 @@
 import os
-from time import time
+from time import perf_counter as clock
 import random
 import numpy as np
 import tables
@@ -30,7 +30,7 @@ def create_db(filename, nrows):
     table.indexFilters = filters
     step = 1000 * 100
     scale = 0.1
-    t1 = time()
+    t1 = clock()
     j = 0
     for i in range(0, nrows, step):
         stop = (j + 1) * step
@@ -45,7 +45,7 @@ def create_db(filename, nrows):
         table.append(recarr)
         j += 1
     table.flush()
-    ctime = time() - t1
+    ctime = clock() - t1
     if verbose:
         print(f"insert time: {ctime:.5f}")
         print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
@@ -54,15 +54,15 @@ def create_db(filename, nrows):
 
 
 def index_db(table):
-    t1 = time()
+    t1 = clock()
     table.cols.col2.create_index()
-    itime = time() - t1
+    itime = clock() - t1
     if verbose:
         print(f"index time (int): {itime:.5f}")
         print(f"Krows/s: {nrows / 1000 / itime:.5f}")
-    t1 = time()
+    t1 = clock()
     table.cols.col4.create_index()
-    itime = time() - t1
+    itime = clock() - t1
     if verbose:
         print(f"index time (float): {itime:.5f}")
         print(f"Krows/s: {nrows / 1000 / itime:.5f}")
@@ -74,27 +74,27 @@ def query_db(filename, rng):
     # Query for integer columns
     # Query for non-indexed column
     if not doqueryidx:
-        t1 = time()
+        t1 = clock()
         ntimes = 10
         for i in range(ntimes):
             results = [
                 r['col1'] for r in table.where(
                     rng[0] + i <= table.cols.col1 <= rng[1] + i)
             ]
-        qtime = (time() - t1) / ntimes
+        qtime = (clock() - t1) / ntimes
         if verbose:
             print(f"query time (int, not indexed): {qtime:.5f}")
             print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
             print(results)
     # Query for indexed column
-    t1 = time()
+    t1 = clock()
     ntimes = 10
     for i in range(ntimes):
         results = [
             r['col1'] for r in table.where(
                 rng[0] + i <= table.cols.col2 <= rng[1] + i)
         ]
-    qtime = (time() - t1) / ntimes
+    qtime = (clock() - t1) / ntimes
     if verbose:
         print(f"query time (int, indexed): {qtime:.5f}")
         print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
@@ -102,25 +102,25 @@ def query_db(filename, rng):
     # Query for floating columns
     # Query for non-indexed column
     if not doqueryidx:
-        t1 = time()
+        t1 = clock()
         ntimes = 10
         for i in range(ntimes):
             results = [
                 r['col3'] for r in table.where(
                     rng[0] + i <= table.cols.col3 <= rng[1] + i)
             ]
-        qtime = (time() - t1) / ntimes
+        qtime = (clock() - t1) / ntimes
         if verbose:
             print(f"query time (float, not indexed): {qtime:.5f}")
             print(f"Krows/s: {nrows / 1000 / qtime:.5f}")
             print(results)
     # Query for indexed column
-    t1 = time()
+    t1 = clock()
     ntimes = 10
     for i in range(ntimes):
         results = [r['col3'] for r in
                    table.where(rng[0] + i <= table.cols.col4 <= rng[1] + i)]
-    qtime = (time() - t1) / ntimes
+    qtime = (clock() - t1) / ntimes
     if verbose:
         print(f"query time (float, indexed): {qtime:.5f}")
         print(f"Krows/s: {nrows / 1000 / qtime:.5f}")

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import time
+from time import perf_counter as clock
 import numpy as np
 import chararray
 import recarray
@@ -29,11 +29,11 @@ print("recarray shape in test ==>", r2.shape)
 
 print("Assignment in recarray original")
 print("-------------------------------")
-t1 = time.perf_counter()
+t1 = clock()
 for row in range(reclen):
     #r1.field("b")[row] = "changed"
     r1.field("c")[row] = float(row ** 2)
-t2 = time.perf_counter()
+t2 = clock()
 origtime = t2 - t1
 print(f"Assign time: {origtime:.3f} Rows/s: {reclen / (origtime + delta):.0f}")
 # print "Field b on row 2 after re-assign:", r1.field("c")[2]
@@ -41,12 +41,12 @@ print()
 
 print("Assignment in recarray modified")
 print("-------------------------------")
-t1 = time.perf_counter()
+t1 = clock()
 for row in range(reclen):
     rec = r2._row(row)  # select the row to be changed
     # rec.b = "changed"      # change the "b" field
     rec.c = float(row ** 2)  # Change the "c" field
-t2 = time.perf_counter()
+t2 = clock()
 ttime = t2 - t1
 print(f"Assign time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
 print(f" Speed-up: {origtime / ttime:.3f}")
@@ -55,24 +55,24 @@ print()
 
 print("Selection in recarray original")
 print("------------------------------")
-t1 = time.perf_counter()
+t1 = clock()
 for row in range(reclen):
     rec = r1[row]
     if rec.field("a") < 3:
         print("This record pass the cut ==>", rec.field("c"), "(row", row, ")")
-t2 = time.perf_counter()
+t2 = clock()
 origtime = t2 - t1
 print(f"Select time: {origtime:.3f}, Rows/s: {reclen / (origtime + delta):.0f}")
 print()
 
 print("Selection in recarray modified")
 print("------------------------------")
-t1 = time.perf_counter()
+t1 = clock()
 for row in range(reclen):
     rec = r2._row(row)
     if rec.a < 3:
         print("This record pass the cut ==>", rec.c, "(row", row, ")")
-t2 = time.perf_counter()
+t2 = clock()
 ttime = t2 - t1
 print(f"Select time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
 print(f" Speed-up: {origtime / ttime:.3f}")
@@ -81,9 +81,9 @@ print()
 print("Printing in recarray original")
 print("------------------------------")
 f = open("test.out", "w")
-t1 = time.perf_counter()
+t1 = clock()
 f.write(str(r1))
-t2 = time.perf_counter()
+t2 = clock()
 origtime = t2 - t1
 f.close()
 os.unlink("test.out")
@@ -92,9 +92,9 @@ print()
 print("Printing in recarray modified")
 print("------------------------------")
 f = open("test2.out", "w")
-t1 = time.perf_counter()
+t1 = clock()
 f.write(str(r2))
-t2 = time.perf_counter()
+t2 = clock()
 ttime = t2 - t1
 f.close()
 os.unlink("test2.out")

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
-import sys
-import time
-import random
-import warnings
 import os
+import random
+import sys
+import warnings
+from time import perf_counter as clock
+from time import process_time as cpuclock
 
 import numpy
 
@@ -89,8 +90,8 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     table = fileh.create_table(fileh.root, 'table', Small, "test table",
                                None, nrows)
 
-    t1 = time.time()
-    cpu1 = time.perf_counter()
+    t1 = clock()
+    cpu1 = cpuclock()
     nrowsbuf = table.nrowsinbuf
     minimum = 0
     maximum = nrows
@@ -112,8 +113,8 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
         table.append([var3, var2, var1])
     table.flush()
     rowswritten += nrows
-    time1 = time.time() - t1
-    tcpu1 = time.perf_counter() - cpu1
+    time1 = clock() - t1
+    tcpu1 = cpuclock() - cpu1
     print(
         f"Time for filling: {time1:.3f} Krows/s: {nrows / 1000 / time1:.3f}",
         end=' ')
@@ -125,15 +126,15 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     table = fileh.root.table
     rowsize = table.rowsize
     if index:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         # Index all entries
         if not heavy:
             indexrows = table.cols.var1.create_index(filters=filters)
         for colname in ['var2', 'var3']:
             table.colinstances[colname].create_index(filters=filters)
-        time2 = time.time() - t1
-        tcpu2 = time.perf_counter() - cpu1
+        time2 = clock() - t1
+        tcpu2 = cpuclock() - cpu1
         print(
             f"Time for indexing: {time2:.3f} "
             f"iKrows/s: {indexrows / 1000 / time2:.3f}",
@@ -244,8 +245,8 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
         # The interval for look values at. This is aproximately equivalent to
         # the number of elements to select
         rnd = numpy.random.randint(table.nrows)
-        cpu1 = time.perf_counter()
-        t1 = time.time()
+        cpu1 = cpuclock()
+        t1 = clock()
         if atom == "string":
             val = str(rnd)[-4:]
             if indexmode in ["indexed", "inkernel"]:
@@ -265,7 +266,7 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
         elif atom == "float":
             val = rnd + dselect
             if indexmode in ["indexed", "inkernel"]:
-                t1 = time.time()
+                t1 = clock()
                 results = [p.nrow
                            for p in where('(rnd <= var3) & (var3 < val)')]
             else:
@@ -277,18 +278,18 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
         # print "selected values-->", results
         if i == 0:
             # First iteration
-            time1 = time.time() - t1
-            tcpu1 = time.perf_counter() - cpu1
+            time1 = clock() - t1
+            tcpu1 = cpuclock() - cpu1
         else:
             if indexmode == "indexed":
                 # if indexed, wait until the 5th iteration (in order to
                 # insure that the index is effectively cached) to take times
                 if i >= 5:
-                    time2 += time.time() - t1
-                    tcpu2 += time.perf_counter() - cpu1
+                    time2 += clock() - t1
+                    tcpu2 += cpuclock() - cpu1
             else:
-                time2 += time.time() - t1
-                tcpu2 += time.perf_counter() - cpu1
+                time2 += clock() - t1
+                tcpu2 += cpuclock() - cpu1
 
     if riter > 1:
         if indexmode == "indexed" and riter >= 5:

--- a/bench/searchsorted-bench.py
+++ b/bench/searchsorted-bench.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import time
+from time import perf_counter as clock
+from time import process_time as cpuclock
+
 from tables import *
 
 
@@ -293,14 +295,14 @@ if __name__ == "__main__":
             print("Compression library:", complib)
             if shuffle:
                 print("Suffling...")
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, nrows, filters,
                                     atom, recsize, index, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written:", rowsw, " Row size:", rowsz)
@@ -314,15 +316,15 @@ if __name__ == "__main__":
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
             psyco.bind(searchFile)
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if rng or item:
             (rowsr, uncomprB, niter) = searchFile(file, atom, verbose, item)
         else:
             for i in range(1):
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         tMrows = rowsr / 1000 / 1000

--- a/bench/searchsorted-bench2.py
+++ b/bench/searchsorted-bench2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import time
+from time import perf_counter as clock
+from time import process_time as cpuclock
+
 from tables import *
 
 
@@ -293,14 +295,14 @@ if __name__ == "__main__":
             print("Compression library:", complib)
             if shuffle:
                 print("Suffling...")
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, nrows, filters,
                                     atom, recsize, index, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written: {rowsw}  Row size: {rowsz}")
@@ -314,15 +316,15 @@ if __name__ == "__main__":
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
             psyco.bind(searchFile)
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if rng or item:
             (rowsr, uncomprB, niter) = searchFile(file, atom, verbose, item)
         else:
             for i in range(1):
                 (rowsr, rowsel, rowsz) = readFile(file, atom, niter, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         tMrows = rowsr / 1000 / 1000

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -143,7 +143,7 @@ def readFile(filename, recsize):
 # Add code to test here
 if __name__ == "__main__":
     import getopt
-    import time
+    from time import perf_counter as clock
 
     usage = """usage: %s [-f] [-s recsize] [-i iterations] file
             -s use [big] record, [medium] or [small]
@@ -177,16 +177,16 @@ if __name__ == "__main__":
     # Catch the hdf5 file passed as the last argument
     file = pargs[0]
 
-    t1 = time.perf_counter()
+    t1 = clock()
     psyco.bind(createFile)
     (rowsw, rowsz) = createFile(file, iterations, recsize)
-    t2 = time.perf_counter()
+    t2 = clock()
     tapprows = t2 - t1
 
-    t1 = time.perf_counter()
+    t1 = clock()
     psyco.bind(readFile)
     readFile(file, recsize)
-    t2 = time.perf_counter()
+    t2 = clock()
     treadrows = t2 - t1
 
     print(f"Rows written: {rowsw}  Row size: {rowsz}")

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -2,10 +2,12 @@
 
 import sqlite
 import random
-import time
 import sys
 import os
 import os.path
+from time import perf_counter as clock
+from time import process_time as cpuclock
+
 from tables import *
 import numpy as np
 
@@ -121,8 +123,8 @@ CREATE INDEX ivar3 ON small(var3);
         place_holders = ",".join(['%s'] * 3)
         # Insert rows
         SQL = "insert into small values(NULL, %s)" % place_holders
-        time1 = time.time()
-        cpu1 = time.perf_counter()
+        time1 = clock()
+        cpu1 = cpuclock()
         # This way of filling is to copy the PyTables benchmark
         nrowsbuf = 1000
         minimum = 0
@@ -147,8 +149,8 @@ CREATE INDEX ivar3 ON small(var3);
                 fields = (var1[n], var2[n], var3[n])
                 cursor.execute(SQL, fields)
             conn.commit()
-        t1 = time.time() - time1
-        tcpu1 = time.perf_counter() - cpu1
+        t1 = clock() - time1
+        tcpu1 = cpuclock() - cpu1
         rowsecf = nrows / t1
         size1 = os.stat(dbfile).st_size
         print(f"******** Results for writing nrows = {nrows} *********")
@@ -157,8 +159,8 @@ CREATE INDEX ivar3 ON small(var3);
 
     # Indexem
     if indexmode == "indexed":
-        time1 = time.time()
-        cpu1 = time.perf_counter()
+        time1 = clock()
+        cpu1 = cpuclock()
         if not heavy:
             cursor.execute("CREATE INDEX ivar1 ON small(var1)")
             conn.commit()
@@ -166,8 +168,8 @@ CREATE INDEX ivar3 ON small(var3);
         conn.commit()
         cursor.execute("CREATE INDEX ivar3 ON small(var3)")
         conn.commit()
-        t2 = time.time() - time1
-        tcpu2 = time.perf_counter() - cpu1
+        t2 = clock() - time1
+        tcpu2 = cpuclock() - cpu1
         rowseci = nrows / t2
         print(f"Index time: {t2:.5f}, IKRows/s: {nrows / 1000 / t2:.3f}")
         size2 = os.stat(dbfile).st_size - size1
@@ -279,8 +281,8 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
         rowsel = 0
         for i in range(riter):
             rnd = random.randrange(nrows)
-            time1 = time.time()
-            cpu1 = time.perf_counter()
+            time1 = clock()
+            cpu1 = cpuclock()
             if atom == "string":
                 #cursor.execute(SQL1, "1111")
                 cursor.execute(SQL1, str(rnd)[-4:])
@@ -294,19 +296,19 @@ def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
                 raise ValueError(
                     "atom must take a value in ['string','int','float']")
             if i == 0:
-                t1 = time.time() - time1
-                tcpu1 = time.perf_counter() - cpu1
+                t1 = clock() - time1
+                tcpu1 = cpuclock() - cpu1
             else:
                 if indexmode == "indexed":
                     # if indexed, wait until the 5th iteration to take
                     # times (so as to insure that the index is
                     # effectively cached)
                     if i >= 5:
-                        time2 += time.time() - time1
-                        cpu2 += time.perf_counter() - cpu1
+                        time2 += clock() - time1
+                        cpu2 += cpuclock() - cpu1
                 else:
-                    time2 += time.time() - time1
-                    time2 += time.perf_counter() - cpu1
+                    time2 += clock() - time1
+                    time2 += cpuclock() - cpu1
         if riter > 1:
             if indexmode == "indexed" and riter >= 5:
                 correction = 5

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -1,6 +1,6 @@
 import os
 import os.path
-from time import time
+from time import perf_counter as clock
 import numpy
 import random
 
@@ -53,11 +53,11 @@ def open_db(filename, remove=0):
 def create_db(filename, nrows):
     con, cur = open_db(filename, remove=1)
     cur.execute("create table ints(i integer, j real)")
-    t1 = time()
+    t1 = clock()
     # This is twice as fast as a plain loop
     cur.executemany("insert into ints(i,j) values (?,?)", int_generator(nrows))
     con.commit()
-    ctime = time() - t1
+    ctime = clock() - t1
     if verbose:
         print(f"insert time: {ctime:.5f}")
         print(f"Krows/s: {nrows / 1000 / ctime:.5f}")
@@ -66,10 +66,10 @@ def create_db(filename, nrows):
 
 def index_db(filename):
     con, cur = open_db(filename)
-    t1 = time()
+    t1 = clock()
     cur.execute("create index ij on ints(j)")
     con.commit()
-    itime = time() - t1
+    itime = clock() - t1
     if verbose:
         print(f"index time: {itime:.5f}")
         print(f"Krows/s: {nrows / itime:.5f}")
@@ -79,7 +79,7 @@ def index_db(filename):
 
 def query_db(filename, rng):
     con, cur = open_db(filename)
-    t1 = time()
+    t1 = clock()
     ntimes = 10
     for i in range(ntimes):
         # between clause does not seem to take advantage of indexes
@@ -90,7 +90,7 @@ def query_db(filename, rng):
                     (rng[0] + i, rng[1] + i))
         results = cur.fetchall()
     con.commit()
-    qtime = (time() - t1) / ntimes
+    qtime = (clock() - t1) / ntimes
     if verbose:
         print(f"query time: {qtime:.5f}")
         print(f"Mrows/s: {nrows / 1000 / qtime:.5f}")

--- a/bench/stress-test.py
+++ b/bench/stress-test.py
@@ -1,7 +1,7 @@
 import gc
 import sys
-import time
-#import types
+from time import perf_counter as clock
+from time import process_time as cpuclock
 import numpy
 from tables import Group  # , MetaIsDescription
 from tables import *
@@ -263,15 +263,15 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
     if complevel > 0:
         print("Compression library:", complib)
     if testwrite:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if usearray:
             (rowsw, rowsz) = createFileArr(file, ngroups, ntables, nrows)
         else:
             (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                         complevel, complib, recsize)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written: {rowsw}  Row size: {rowsz}")
@@ -282,15 +282,15 @@ def testMethod(file, usearray, testwrite, testread, complib, complevel,
         print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if usearray:
             (rowsr, rowsz, bufsz) = readFileArr(file,
                                                 ngroups, recsize, verbose)
         else:
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")

--- a/bench/stress-test2.py
+++ b/bench/stress-test2.py
@@ -1,7 +1,8 @@
 import gc
 import sys
-import time
 import random
+from time import perf_counter as clock
+from time import process_time as cpuclock
 from tables import *
 
 
@@ -41,7 +42,7 @@ def createFile(filename, ngroups, ntables, nrows, complevel, complib, recsize):
             row = table.row
             # Fill the table
             for i in range(nrows):
-                row['time'] = time.time()
+                row['time'] = clock()
                 row['random'] = random.random() * 40 + 100
                 row['ngroup'] = k
                 row['ntable'] = j
@@ -198,14 +199,14 @@ if __name__ == "__main__":
     if complevel > 0:
         print("Compression library:", complib)
     if testwrite:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                     complevel, complib, recsize)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written: {rowsw}  Row size: {rowsz}")
@@ -216,13 +217,13 @@ if __name__ == "__main__":
         print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
         (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")

--- a/bench/stress-test3.py
+++ b/bench/stress-test3.py
@@ -9,7 +9,8 @@ Issue "python stress-test3.py" without parameters for a help on usage.
 
 import gc
 import sys
-import time
+from time import perf_counter as clock
+from time import process_time as cpuclock
 from tables import *
 
 
@@ -243,8 +244,8 @@ if __name__ == "__main__":
     if complevel > 0:
         print("Compression library:", complib)
     if testwrite:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         if usearray:
@@ -252,8 +253,8 @@ if __name__ == "__main__":
         else:
             (rowsw, rowsz) = createFile(file, ngroups, ntables, nrows,
                                         complevel, complib, recsize)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written: {rowsw}  Row size: {rowsz}")
@@ -264,8 +265,8 @@ if __name__ == "__main__":
         print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
         if usearray:
@@ -273,8 +274,8 @@ if __name__ == "__main__":
                                                 ngroups, recsize, verbose)
         else:
             (rowsr, rowsz, bufsz) = readFile(file, ngroups, recsize, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         print(f"Rows read: {rowsw}  Row size: {rowsz}, Buf size: {bufsz}")

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -277,7 +277,8 @@ if __name__ == "__main__":
     except:
         psyco_imported = 0
 
-    import time
+    from time import perf_counter as clock
+    from time import process_time as cpuclock
 
     usage = """usage: %s [-v] [-p] [-P] [-R range] [-r] [-w] [-s recsize] [-f field] [-c level] [-l complib] [-i iterations] [-S] [-F] file
             -v verbose
@@ -370,8 +371,8 @@ if __name__ == "__main__":
             print("Compression library:", complib)
             if shuffle:
                 print("Suffling...")
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(createFile)
         if profile:
@@ -387,8 +388,8 @@ if __name__ == "__main__":
             stats.print_stats(20)
         else:
             (rowsw, rowsz) = createFile(file, iterations, filters, recsize)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         tapprows = t2 - t1
         cpuapprows = cpu2 - cpu1
         print(f"Rows written: {rowsw}  Row size: {rowsz}")
@@ -399,8 +400,8 @@ if __name__ == "__main__":
         print(f"Write KB/s : {rowsw * rowsz / (tapprows * 1024):.0f}")
 
     if testread:
-        t1 = time.time()
-        cpu1 = time.perf_counter()
+        t1 = clock()
+        cpu1 = cpuclock()
         if psyco_imported and usepsyco:
             psyco.bind(readFile)
             # psyco.bind(readField)
@@ -411,8 +412,8 @@ if __name__ == "__main__":
         else:
             for i in range(1):
                 (rowsr, rowsz) = readFile(file, recsize, verbose)
-        t2 = time.time()
-        cpu2 = time.perf_counter()
+        t2 = clock()
+        cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
         print(f"Rows read: {rowsw}  Row size: {rowsz}")

--- a/bench/table-copy.py
+++ b/bench/table-copy.py
@@ -1,4 +1,4 @@
-import time
+from time import perf_counter as clock
 
 import numpy as np
 import tables
@@ -8,9 +8,9 @@ N = 144_000
 
 
 def timed(func, *args, **kwargs):
-    start = time.time()
+    start = clock()
     res = func(*args, **kwargs)
-    print("%fs elapsed." % (time.time() - start))
+    print(f"{clock() - start:.3f}s elapsed.")
     return res
 
 

--- a/bench/undo_redo.py
+++ b/bench/undo_redo.py
@@ -7,7 +7,7 @@
 ###########################################################################
 
 import numpy
-from time import time
+from time import perf_counter as clock
 import tables
 
 verbose = 0
@@ -51,23 +51,23 @@ class BasicBenchmark:
             self.fileh.mark()
         # Unwind all marks sequentially
         for i in range(self.niter):
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.undo()
                 if verbose:
                     print("u", end=' ')
             if verbose:
                 print()
-            undo = time() - t1
+            undo = clock() - t1
             # Rewind all marks sequentially
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.redo()
                 if verbose:
                     print("r", end=' ')
             if verbose:
                 print()
-            redo = time() - t1
+            redo = clock() - t1
 
             print("Time for Undo, Redo (createNode):", undo, "s, ", redo, "s")
 
@@ -90,23 +90,23 @@ class BasicBenchmark:
             self.fileh.mark()
         # Unwind all marks sequentially
         for i in range(self.niter):
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.undo()
                 if verbose:
                     print("u", end=' ')
             if verbose:
                 print()
-            undo = time() - t1
+            undo = clock() - t1
             # Rewind all marks sequentially
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.redo()
                 if verbose:
                     print("r", end=' ')
             if verbose:
                 print()
-            redo = time() - t1
+            redo = clock() - t1
 
             print(("Time for Undo, Redo (copy_children):", undo, "s, ",
                   redo, "s"))
@@ -123,23 +123,23 @@ class BasicBenchmark:
             self.fileh.mark()
         # Unwind all marks sequentially
         for i in range(self.niter):
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.undo()
                 if verbose:
                     print("u", end=' ')
             if verbose:
                 print()
-            undo = time() - t1
+            undo = clock() - t1
             # Rewind all marks sequentially
-            t1 = time()
+            t1 = clock()
             for i in range(self.nobjects):
                 self.fileh.redo()
                 if verbose:
                     print("r", end=' ')
             if verbose:
                 print()
-            redo = time() - t1
+            redo = clock() - t1
 
             print("Time for Undo, Redo (set_attr):", undo, "s, ", redo, "s")
 

--- a/bench/widetree.py
+++ b/bench/widetree.py
@@ -4,6 +4,7 @@ import hotshot.stats
 import unittest
 import os
 import tempfile
+from time import perf_counter as clock
 
 from tables import *
 
@@ -24,7 +25,6 @@ class WideTreeTestCase(unittest.TestCase):
 
         """
 
-        import time
         maxchilds = 1000
         if verbose:
             print('\n', '-=' * 30)
@@ -50,11 +50,11 @@ class WideTreeTestCase(unittest.TestCase):
         # Close the file
         fileh.close()
 
-        t1 = time.time()
+        t1 = clock()
         # Open the previous HDF5 file in read-only mode
         fileh = open_file(file, mode="r")
         print("\nTime spent opening a file with %d groups + %d arrays: "
-              "%s s" % (maxchilds, maxchilds, time.time() - t1))
+              "%s s" % (maxchilds, maxchilds, clock() - t1))
         if verbose:
             print("\nChildren reading progress: ", end=' ')
         # Close the file
@@ -73,7 +73,6 @@ class WideTreeTestCase(unittest.TestCase):
 
         """
 
-        import time
         maxchilds = 1000
         if verbose:
             print('\n', '-=' * 30)
@@ -96,11 +95,11 @@ class WideTreeTestCase(unittest.TestCase):
         # Close the file
         fileh.close()
 
-        t1 = time.time()
+        t1 = clock()
         # Open the previous HDF5 file in read-only mode
         fileh = open_file(file, mode="r")
         print("\nTime spent opening a file with %d groups: %s s" %
-              (maxchilds, time.time() - t1))
+              (maxchilds, clock() - t1))
         # Close the file
         fileh.close()
         # Then, delete the file

--- a/contrib/make_hdf.py
+++ b/contrib/make_hdf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-
-import tables, cPickle, time
+from time import perf_counter as clock
+import tables, cPickle
 #################################################################################
 
 
@@ -180,15 +180,15 @@ class Hdf_dict(dict):
         table=fileh.root.cache0
         total=[]
         print 'reading'
-        begin=time.time()
+        begin=clock()
         for i in table.iterrows():
             total.append(i['col_0'])
         total=''.join(total)
         total=total.replace(chr(1), '\n')
-        print 'loaded cache len=', len(total), time.time()-begin
-        begin=time.time()
+        print 'loaded cache len=', len(total), clock()-begin
+        begin=clock()
         a=cPickle.loads(total)
-        print 'cache', time.time()-begin
+        print 'cache', clock()-begin
         return a
 
     def has_key(self, k):

--- a/examples/particles.py
+++ b/examples/particles.py
@@ -1,6 +1,6 @@
 """Beware! you need PyTables >= 2.3 to run this script!"""
 
-from time import time  # use clock for Win
+from time import perf_counter as clock
 import numpy as np
 import tables
 
@@ -22,7 +22,7 @@ class Particle(tables.IsDescription):
     mass = tables.Float64Col(pos=5)                 # mass of the particle
 
 # Create a new table for events
-t1 = time()
+t1 = clock()
 print(
     f"Creating a table with {NEVENTS * MAX_PARTICLES_PER_EVENT // 2} "
     f"entries aprox.. Wait please...")
@@ -46,12 +46,12 @@ for i in range(NEVENTS):
         # This injects the row values.
         particle.append()
 table.flush()
-print(f"Added {table.nrows} entries --- Time: {time() - t1:.3f} sec")
+print(f"Added {table.nrows} entries --- Time: {clock() - t1:.3f} sec")
 
-t1 = time()
+t1 = clock()
 print("Creating index...")
 table.cols.event_id.create_index(optlevel=0, _verbose=True)
-print(f"Index created --- Time: {time() - t1:.3f} sec")
+print(f"Index created --- Time: {clock() - t1:.3f} sec")
 # Add the number of events as an attribute
 table.attrs.nevents = NEVENTS
 
@@ -64,58 +64,58 @@ table = fileh.root.events.table
 
 print("Particles in event 34:", end=' ')
 nrows = 0
-t1 = time()
+t1 = clock()
 for row in table.where("event_id == 34"):
         nrows += 1
 print(nrows)
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 print("Root particles in event 34:", end=' ')
 nrows = 0
-t1 = time()
+t1 = clock()
 for row in table.where("event_id == 34"):
     if row['parent_id'] < 0:
         nrows += 1
 print(nrows)
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 print("Sum of masses of root particles in event 34:", end=' ')
 smass = 0.0
-t1 = time()
+t1 = clock()
 for row in table.where("event_id == 34"):
     if row['parent_id'] < 0:
         smass += row['mass']
 print(smass)
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 print(
     "Sum of masses of daughter particles for particle 3 in event 34:", end=' ')
 smass = 0.0
-t1 = time()
+t1 = clock()
 for row in table.where("event_id == 34"):
     if row['parent_id'] == 3:
         smass += row['mass']
 print(smass)
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 print("Sum of module of momentum for particle 3 in event 34:", end=' ')
 smomentum = 0.0
-t1 = time()
+t1 = clock()
 # for row in table.where("(event_id == 34) & ((parent_id) == 3)"):
 for row in table.where("event_id == 34"):
     if row['parent_id'] == 3:
         smomentum += np.sqrt(np.add.reduce(row['momentum'] ** 2))
 print(smomentum)
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 # This is the same than above, but using generator expressions
 # Python >= 2.4 needed here!
 print("Sum of module of momentum for particle 3 in event 34 (2):", end=' ')
-t1 = time()
+t1 = clock()
 print(sum(np.sqrt(np.add.reduce(row['momentum'] ** 2))
           for row in table.where("event_id == 34")
           if row['parent_id'] == 3))
-print(f"Done --- Time: {time() - t1:.3f} sec")
+print(f"Done --- Time: {clock() - t1:.3f} sec")
 
 
 fileh.close()

--- a/examples/read_array_out_arg.py
+++ b/examples/read_array_out_arg.py
@@ -6,7 +6,7 @@
 
 
 
-import time
+from time import perf_counter as clock
 
 import numpy as np
 import tables
@@ -23,10 +23,10 @@ def standard_read(array_size):
     N = 10
     with tables.open_file('test.h5', 'r') as fobj:
         array = fobj.get_node('/', 'test')
-        start = time.time()
+        start = clock()
         for i in range(N):
             output = array.read(0, array_size, 1)
-        end = time.time()
+        end = clock()
         assert(np.all(output == 1))
         print('standard read   \t {:5.5f}'.format((end - start) / N))
 
@@ -35,11 +35,11 @@ def pre_allocated_read(array_size):
     N = 10
     with tables.open_file('test.h5', 'r') as fobj:
         array = fobj.get_node('/', 'test')
-        start = time.time()
+        start = clock()
         output = np.empty(array_size, 'i8')
         for i in range(N):
             array.read(0, array_size, 1, out=output)
-        end = time.time()
+        end = clock()
         assert(np.all(output == 1))
         print('pre-allocated read\t {:5.5f}'.format((end - start) / N))
 

--- a/tables/index.py
+++ b/tables/index.py
@@ -19,7 +19,8 @@ import sys
 import tempfile
 import warnings
 
-from time import time, perf_counter
+from time import perf_counter as clock
+from time import process_time as cpuclock
 
 import numpy
 
@@ -551,7 +552,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Compute an initial indices arrays for data to be indexed."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering initial_append", tref)
         arr = xarr.pop()
@@ -630,7 +631,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Perform final operations in 32-bit indices."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering final_idx32", tref)
         # Do an upcast first in order to add the offset.
@@ -650,7 +651,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Append the array to the index objects."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering append", tref)
         if not update and self.temp_required:
@@ -715,7 +716,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Append the array to the last row index objects."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering appendLR", tref)
         # compute the elements in the last row sorted & bounds array
@@ -839,8 +840,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Bring an already optimized index into a complete sorted state."""
 
         if self.verbose:
-            t1 = time()
-            c1 = perf_counter()
+            t1 = clock()
+            c1 = cpuclock()
         ss = self.slicesize
         tmp = self.tmp
         ranges = tmp.ranges[:]
@@ -945,7 +946,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         # in verbose mode!).
         self.compute_overlaps(self.tmp, "do_complete_sort()", self.verbose)
         if self.verbose:
-            print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
+            print(f"time: {clock() - t1:.4f}. clock: {cpuclock() - c1:.4f}")
 
     def swap(self, what, mode=None):
         """Swap chunks or slices using a certain bounds reference."""
@@ -958,8 +959,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         thtover = 0.01    # minimum overlaping index for slices (a 1%)
 
         if self.verbose:
-            t1 = time()
-            c1 = perf_counter()
+            t1 = clock()
+            c1 = cpuclock()
         if what == "chunks":
             self.swap_chunks(mode)
         elif what == "slices":
@@ -972,7 +973,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             self.tmp, message, self.verbose)
         rmult = len(mult.nonzero()[0]) / len(mult)
         if self.verbose:
-            print(f"time: {time() - t1:.4f}. clock: {perf_counter() - c1:.4f}")
+            print(f"time: {clock() - t1:.4f}. clock: {cpuclock() - c1:.4f}")
         # Check that entropy is actually decreasing
         if what == "chunks" and self.last_tover > 0 and self.last_nover > 0:
             tover_var = (self.last_tover - tover) / self.last_tover
@@ -1815,7 +1816,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Do a binary search in this index for an item."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering search", tref)
 
@@ -1998,7 +1999,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Compute a map with the interesting chunks in index."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering get_chunkmap", tref)
         ss = self.slicesize

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -15,11 +15,11 @@ Pass the flag -h to this for help on usage.
 """
 
 import sys
-import time
 import os.path
 import argparse
 import warnings
-from time import process_time as cputime
+from time import perf_counter as clock
+from time import process_time as cpuclock
 
 from tables.file import open_file
 from tables.group import Group
@@ -493,8 +493,8 @@ def main():
     createsysattrs = args.createsysattrs
 
     # Some timing
-    t1 = time.time()
-    cpu1 = cputime()
+    t1 = clock()
+    cpu1 = cpuclock()
     # Copy the file
     if verbose:
         print("+=+" * 20)
@@ -546,8 +546,8 @@ def main():
         )
 
     # Gather some statistics
-    t2 = time.time()
-    cpu2 = cputime()
+    t2 = clock()
+    cpu2 = cpuclock()
     tcopy = t2 - t1
     cpucopy = cpu2 - cpu1
     if verbose:

--- a/tables/table.py
+++ b/tables/table.py
@@ -17,7 +17,7 @@ import sys
 import warnings
 
 from functools import reduce as _reduce
-from time import time
+from time import perf_counter as clock
 
 import numpy
 import numexpr
@@ -149,7 +149,7 @@ def restorecache(self):
 def _table__where_indexed(self, compiled, condition, condvars,
                           start, stop, step):
     if profile:
-        tref = time()
+        tref = clock()
     if profile:
         show_stats("Entering table_whereIndexed", tref)
     self._use_index = True
@@ -1487,7 +1487,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         """Low-level counterpart of `self.where()`."""
 
         if profile:
-            tref = time()
+            tref = clock()
         if profile:
             show_stats("Entering table._where", tref)
         # Adjust the slice to be used.

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -1,9 +1,9 @@
 import os
-import time
+from time import perf_counter as clock
 
 import tables
 
-tref = time.time()
+tref = clock()
 trel = tref
 
 
@@ -30,9 +30,9 @@ def show_mem(explain):
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
-    print("WallClock time:", time.time() - tref, end=' ')
-    print("  Delta time:", time.time() - trel)
-    trel = time.time()
+    print("WallClock time:", clock() - tref, end=' ')
+    print("  Delta time:", clock() - trel)
+    trel = clock()
 
 
 def write_group(filename, nchildren, niter):

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -13,11 +13,11 @@
 import os
 import re
 import sys
-import time
 import locale
 import platform
 import tempfile
 import warnings
+from time import perf_counter as clock
 from distutils.version import LooseVersion
 
 import unittest
@@ -350,7 +350,7 @@ class TempFileMixin:
 
 
 class ShowMemTime(PyTablesTestCase):
-    tref = time.time()
+    tref = clock()
     """Test for showing memory and time consumption."""
 
     def test00(self):
@@ -370,7 +370,7 @@ class ShowMemTime(PyTablesTestCase):
                 vmexe = int(line.split()[1])
             elif line.startswith("VmLib:"):
                 vmlib = int(line.split()[1])
-        print("\nWallClock time:", time.time() - self.tref)
+        print("\nWallClock time:", clock() - self.tref)
         print("Memory usage: ******* %s *******" % self._getName())
         print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
         print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -1,8 +1,8 @@
 import os
 import sys
-import time
 import tempfile
 import warnings
+from time import perf_counter as clock
 
 import tables
 from tables import Group, Leaf, Table, Array
@@ -770,14 +770,14 @@ class WideTreeTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print()
 
-        t1 = time.time()
+        t1 = clock()
         a = [1, 1]
 
         # Open the previous HDF5 file in read-only mode
         self._reopen()
         if common.verbose:
             print("\nTime spent opening a file with %d arrays: %s s" %
-                  (maxchildren, time.time()-t1))
+                  (maxchildren, clock()-t1))
             print("\nChildren reading progress: ", end=' ')
 
         # Get the metadata on the previosly saved arrays
@@ -829,13 +829,13 @@ class WideTreeTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print()
 
-        t1 = time.time()
+        t1 = clock()
 
         # Open the previous HDF5 file in read-only mode
         self._reopen()
         if common.verbose:
             print("\nTime spent opening a file with %d groups: %s s" %
-                  (maxchildren, time.time()-t1))
+                  (maxchildren, clock()-t1))
             print("\nChildren reading progress: ", end=' ')
 
         # Get the metadata on the previosly saved arrays

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -15,7 +15,7 @@ import os
 import sys
 import warnings
 import subprocess
-from time import time
+from time import perf_counter as clock
 
 import numpy
 
@@ -269,7 +269,7 @@ def show_stats(explain, tref, encoding=None):
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
     print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
-    tnow = time()
+    tnow = clock()
     print(f"WallClock time: {tnow - tref:.3f}")
     return tnow
 


### PR DESCRIPTION
Consistent import and usage of elapsed time measuring tools in the whole repository:
- `time.perf_counter() as clock()` for elapsed time
- `time.process_time() as cpuclock()` for CPU time

Both methods return `float` that are relative to some point within the process, so they should be used only for calculating deltas and not as UNIX timestamp. They are immune to system clock updates (such as NTP), and therefore the deltas are always positive.

There was previously a bug that used `time.perf_counter()` for CPU time. This has been fixed here.