### PR TITLE
[WIP/draft] Modernize setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,60 +2,57 @@
 
 """Setup script for the tables package"""
 
-import os
-import sys
 import ctypes
+import distutils.spawn
+import glob
+import os
+import platform
+import subprocess
+import sys
 import tempfile
 import textwrap
-import subprocess
-from os.path import exists, expanduser
-import glob
-import platform
-
-# Using ``setuptools`` enables lots of goodies
-from setuptools import setup, find_packages
-import pkg_resources
-
+from distutils.ccompiler import new_compiler
 from distutils.core import Extension
 from distutils.dep_util import newer
 from distutils.util import convert_path
-from distutils.ccompiler import new_compiler
 from distutils.version import LooseVersion
-import distutils.spawn
+from os.path import exists, expanduser
 
+import pkg_resources
+# Using ``setuptools`` enables lots of goodies
+from setuptools import find_packages, setup
 # We need to avoid importing numpy until we can be sure it's installed
 # This approach is based on this SO answer http://stackoverflow.com/a/21621689
 # This is also what pandas does.
 from setuptools.command.build_ext import build_ext
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # `cpuinfo.py` uses multiprocessing to check CPUID flags. On Windows, the
     # entire setup script needs to be protected as a result
     # For guessing the capabilities of the CPU for C-Blosc
     try:
         import cpuinfo
+
         cpu_info = cpuinfo.get_cpu_info()
-        cpu_flags = cpu_info['flags']
+        cpu_flags = cpu_info["flags"]
     except Exception as e:
-        print('cpuinfo failed, assuming no CPU features:', e)
+        print("cpuinfo failed, assuming no CPU features:", e)
         cpu_flags = []
 
     # The name for the pkg-config utility
-    PKG_CONFIG = 'pkg-config'
-
+    PKG_CONFIG = "pkg-config"
 
     # Fetch the requisites
-    with open('requirements.txt') as f:
+    with open("requirements.txt") as f:
         requirements = f.read().splitlines()
-
 
     class BuildExtensions(build_ext):
         """Subclass setuptools build_ext command
 
         BuildExtensions does two things
         1) it makes sure numpy is available
-        2) it injects numpy's core/include directory in the include_dirs parameter
-        of all extensions
+        2) it injects numpy's core/include directory in the include_dirs
+           parameter of all extensions
         3) it runs the original build_ext command
         """
 
@@ -63,37 +60,38 @@ if __name__ == '__main__':
             # According to
             # https://pip.pypa.io/en/stable/reference/pip_install.html#installation-order
             # at this point we can be sure pip has already installed numpy
-            numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
+            numpy_incl = pkg_resources.resource_filename(
+                "numpy", "core/include"
+            )
 
             for ext in self.extensions:
-                if (hasattr(ext, 'include_dirs') and
-                        numpy_incl not in ext.include_dirs):
+                if (
+                    hasattr(ext, "include_dirs")
+                    and numpy_incl not in ext.include_dirs
+                ):
                     ext.include_dirs.append(numpy_incl)
 
             build_ext.run(self)
 
-
-    cmdclass = {'build_ext': BuildExtensions}
+    cmdclass = {"build_ext": BuildExtensions}
     setuptools_kwargs = {}
-
 
     # Some functions for showing errors and warnings.
     def _print_admonition(kind, head, body):
-        tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
+        tw = textwrap.TextWrapper(
+            initial_indent="   ", subsequent_indent="   "
+        )
 
         print(f".. {kind.upper()}:: {head}")
         for line in tw.wrap(body):
             print(line)
 
-
-    def exit_with_error(head, body=''):
-        _print_admonition('error', head, body)
+    def exit_with_error(head, body=""):
+        _print_admonition("error", head, body)
         sys.exit(1)
 
-
-    def print_warning(head, body=''):
-        _print_admonition('warning', head, body)
-
+    def print_warning(head, body=""):
+        _print_admonition("warning", head, body)
 
     # The minimum required versions
     min_python_version = (3, 6)
@@ -103,32 +101,32 @@ if __name__ == '__main__':
     print("* Using Python %s" % sys.version.splitlines()[0])
 
     # Minimum required versions for numpy, numexpr and HDF5
-    with open(os.path.join('tables', 'req_versions.py')) as fd:
+    with open(os.path.join("tables", "req_versions.py")) as fd:
         _min_versions = {}
         exec(fd.read(), _min_versions)
 
-        min_hdf5_version = _min_versions['min_hdf5_version']
-        min_blosc_version = _min_versions['min_blosc_version']
-        min_blosc_bitshuffle_version = _min_versions['min_blosc_bitshuffle_version']
+        min_hdf5_version = _min_versions["min_hdf5_version"]
+        min_blosc_version = _min_versions["min_blosc_version"]
+        min_blosc_bitshuffle_version = _min_versions[
+            "min_blosc_bitshuffle_version"
+        ]
 
-
-    with open('VERSION') as fd:
+    with open("VERSION") as fd:
         VERSION = fd.read().strip()
 
     # ----------------------------------------------------------------------
 
-    debug = '--debug' in sys.argv
+    debug = "--debug" in sys.argv
 
     # Global variables
     lib_dirs = []
-    inc_dirs = [os.path.join('hdf5-blosc', 'src')]
+    inc_dirs = [os.path.join("hdf5-blosc", "src")]
     optional_libs = []
-    data_files = []    # list of data files to add to packages (mainly for DLL's)
+    data_files = []  # list of data files to add to packages (mainly for DLL's)
 
     default_header_dirs = None
     default_library_dirs = None
     default_runtime_dirs = None
-
 
     def add_from_path(envname, dirs):
         try:
@@ -136,15 +134,13 @@ if __name__ == '__main__':
         except KeyError:
             pass
 
-
     def add_from_flags(envname, flag_key, dirs):
         for flag in os.environ.get(envname, "").split():
             if flag.startswith(flag_key):
-                dirs.append(flag[len(flag_key):])
+                dirs.append(flag[len(flag_key) :])
 
-
-    if os.name == 'posix':
-        prefixes = ('/usr/local', '/sw', '/opt', '/opt/local', '/usr', '/')
+    if os.name == "posix":
+        prefixes = ("/usr/local", "/sw", "/opt", "/opt/local", "/usr", "/")
 
         default_header_dirs = []
         add_from_path("CPATH", default_header_dirs)
@@ -152,36 +148,38 @@ if __name__ == '__main__':
         add_from_flags("CPPFLAGS", "-I", default_header_dirs)
         add_from_flags("CFLAGS", "-I", default_header_dirs)
         default_header_dirs.extend(
-            os.path.join(_tree, 'include') for _tree in prefixes
+            os.path.join(_tree, "include") for _tree in prefixes
         )
 
         default_library_dirs = []
         add_from_flags("LDFLAGS", "-L", default_library_dirs)
         default_library_dirs.extend(
-            os.path.join(_tree, _arch) for _tree in prefixes
-            for _arch in ('lib64', 'lib'))
+            os.path.join(_tree, _arch)
+            for _tree in prefixes
+            for _arch in ("lib64", "lib")
+        )
         default_runtime_dirs = default_library_dirs
 
-    elif os.name == 'nt':
+    elif os.name == "nt":
         default_header_dirs = []  # no default, must be given explicitly
         default_library_dirs = []  # no default, must be given explicitly
         default_runtime_dirs = [  # look for DLL files in ``%PATH%``
-            _path for _path in os.environ['PATH'].split(';')]
+            _path for _path in os.environ["PATH"].split(";")
+        ]
         # Add the \Windows\system to the runtime list (necessary for Vista)
-        default_runtime_dirs.append('\\windows\\system')
+        default_runtime_dirs.append("\\windows\\system")
         # Add the \path_to_python\DLLs and tables package to the list
         default_runtime_dirs.extend(
-            [os.path.join(sys.prefix, 'Lib\\site-packages\\tables')])
-
+            [os.path.join(sys.prefix, "Lib\\site-packages\\tables")]
+        )
 
     # Gcc 4.0.1 on Mac OS X 10.4 does not seem to include the default
     # header and library paths.  See ticket #18.
-    if sys.platform.lower().startswith('darwin'):
+    if sys.platform.lower().startswith("darwin"):
         inc_dirs.extend(default_header_dirs)
         lib_dirs.extend(default_library_dirs)
 
-
-    def _find_file_path(name, locations, prefixes=('',), suffixes=('',)):
+    def _find_file_path(name, locations, prefixes=("",), suffixes=("",)):
         for prefix in prefixes:
             for suffix in suffixes:
                 for location in locations:
@@ -190,7 +188,6 @@ if __name__ == '__main__':
                         return path
         return None
 
-
     class BasePackage:
         _library_prefixes = []
         _library_suffixes = []
@@ -198,8 +195,9 @@ if __name__ == '__main__':
         _runtime_suffixes = []
         _component_dirs = []
 
-        def __init__(self, name, tag, header_name, library_name,
-                    target_function=None):
+        def __init__(
+            self, name, tag, header_name, library_name, target_function=None
+        ):
             self.name = name
             self.tag = tag
             self.header_name = header_name
@@ -208,12 +206,17 @@ if __name__ == '__main__':
             self.target_function = target_function
 
         def find_header_path(self, locations=default_header_dirs):
-            return _find_file_path(self.header_name, locations, suffixes=['.h'])
+            return _find_file_path(
+                self.header_name, locations, suffixes=[".h"]
+            )
 
         def find_library_path(self, locations=default_library_dirs):
             return _find_file_path(
-                self.library_name, locations,
-                self._library_prefixes, self._library_suffixes)
+                self.library_name,
+                locations,
+                self._library_prefixes,
+                self._library_suffixes,
+            )
 
         def find_runtime_path(self, locations=default_runtime_dirs):
             """
@@ -221,7 +224,8 @@ if __name__ == '__main__':
             returns None otherwise
             """
             # An explicit path can not be provided for runtime libraries.
-            # (The argument is accepted for compatibility with previous methods.)
+            # (The argument is accepted for compatibility with previous
+            # methods.)
 
             # dlopen() won't tell us where the file is, just whether
             # success occurred, so this returns True instead of a filename
@@ -248,8 +252,16 @@ if __name__ == '__main__':
         def find_directories(self, location, use_pkgconfig=False):
             dirdata = [
                 (self.header_name, self.find_header_path, default_header_dirs),
-                (self.library_name, self.find_library_path, default_library_dirs),
-                (self.runtime_name, self.find_runtime_path, default_runtime_dirs),
+                (
+                    self.library_name,
+                    self.find_library_path,
+                    default_library_dirs,
+                ),
+                (
+                    self.runtime_name,
+                    self.find_runtime_path,
+                    default_runtime_dirs,
+                ),
             ]
 
             locations = []
@@ -268,24 +280,30 @@ if __name__ == '__main__':
 
             if use_pkgconfig:
                 # header
-                pkgconfig_header_dirs = self._pkg_config('--cflags')
+                pkgconfig_header_dirs = self._pkg_config("--cflags")
                 pkgconfig_header_dirs = [
-                    d.lstrip('-I') for d in pkgconfig_header_dirs
-                    if d.startswith('-I')
+                    d.lstrip("-I")
+                    for d in pkgconfig_header_dirs
+                    if d.startswith("-I")
                 ]
                 if pkgconfig_header_dirs:
-                    print('* pkg-config header dirs for %s:' % self.name,
-                        ', '.join(pkgconfig_header_dirs))
+                    print(
+                        "* pkg-config header dirs for %s:" % self.name,
+                        ", ".join(pkgconfig_header_dirs),
+                    )
 
                 # library
-                pkgconfig_library_dirs = self._pkg_config('--libs-only-L')
+                pkgconfig_library_dirs = self._pkg_config("--libs-only-L")
                 pkgconfig_library_dirs = [
-                    d.lstrip('-L') for d in pkgconfig_library_dirs
-                    if d.startswith('-L')
+                    d.lstrip("-L")
+                    for d in pkgconfig_library_dirs
+                    if d.startswith("-L")
                 ]
                 if pkgconfig_library_dirs:
-                    print('* pkg-config library dirs for %s:' % self.name,
-                        ', '.join(pkgconfig_library_dirs))
+                    print(
+                        "* pkg-config library dirs for %s:" % self.name,
+                        ", ".join(pkgconfig_library_dirs),
+                    )
 
                 # runtime
                 pkgconfig_runtime_dirs = pkgconfig_library_dirs
@@ -300,7 +318,9 @@ if __name__ == '__main__':
 
             directories = [None, None, None]  # headers, libraries, runtime
             for idx, (name, find_path, default_dirs) in enumerate(dirdata):
-                path = find_path(pkgconfig_dirs[idx] or locations or default_dirs)
+                path = find_path(
+                    pkgconfig_dirs[idx] or locations or default_dirs
+                )
                 if path:
                     if path is True:
                         directories[idx] = True
@@ -318,37 +338,40 @@ if __name__ == '__main__':
                     # then, the directory will be returned as '\stuff' (!!)
                     # F. Alted 2006-02-16
                     if idx == 0:
-                        directories[idx] = os.path.dirname(path[:path.rfind(name)])
+                        directories[idx] = os.path.dirname(
+                            path[: path.rfind(name)]
+                        )
                     else:
                         directories[idx] = os.path.dirname(path)
 
             return tuple(directories)
 
-
     class PosixPackage(BasePackage):
-        _library_prefixes = ['lib']
-        _library_suffixes = ['.so', '.dylib', '.a']
+        _library_prefixes = ["lib"]
+        _library_suffixes = [".so", ".dylib", ".a"]
         _runtime_prefixes = _library_prefixes
-        _runtime_suffixes = ['.so', '.dylib']
-        _component_dirs = ['include', 'lib', 'lib64']
-
+        _runtime_suffixes = [".so", ".dylib"]
+        _component_dirs = ["include", "lib", "lib64"]
 
     class WindowsPackage(BasePackage):
-        _library_prefixes = ['']
-        _library_suffixes = ['.lib']
-        _runtime_prefixes = ['']
-        _runtime_suffixes = ['.dll']
+        _library_prefixes = [""]
+        _library_suffixes = [".lib"]
+        _runtime_prefixes = [""]
+        _runtime_suffixes = [".dll"]
 
         # lookup in '.' seems necessary for LZO2
-        _component_dirs = ['include', 'lib', 'dll', 'bin', '.']
+        _component_dirs = ["include", "lib", "dll", "bin", "."]
 
         def find_runtime_path(self, locations=default_runtime_dirs):
             # An explicit path can not be provided for runtime libraries.
-            # (The argument is accepted for compatibility with previous methods.)
+            # (The argument is accepted for compatibility with previous
+            # methods.)
             return _find_file_path(
-                self.runtime_name, default_runtime_dirs,
-                self._runtime_prefixes, self._runtime_suffixes)
-
+                self.runtime_name,
+                default_runtime_dirs,
+                self._runtime_prefixes,
+                self._runtime_suffixes,
+            )
 
     # Get the HDF5 version provided the 'H5public.h' header
     def get_hdf5_version(headername):
@@ -357,21 +380,23 @@ if __name__ == '__main__':
         release_version = -1
         with open(headername) as fd:
             for line in fd:
-                if 'H5_VERS_MAJOR' in line:
+                if "H5_VERS_MAJOR" in line:
                     major_version = int(line.split()[2])
-                if 'H5_VERS_MINOR' in line:
+                if "H5_VERS_MINOR" in line:
                     minor_version = int(line.split()[2])
-                if 'H5_VERS_RELEASE' in line:
+                if "H5_VERS_RELEASE" in line:
                     release_version = int(line.split()[2])
-                if (major_version != -1 and minor_version != -1 and
-                        release_version != -1):
+                if (
+                    major_version != -1
+                    and minor_version != -1
+                    and release_version != -1
+                ):
                     break
-        if (major_version == -1 or minor_version == -1 or
-                release_version == -1):
+        if major_version == -1 or minor_version == -1 or release_version == -1:
             exit_with_error("Unable to detect HDF5 library version!")
-        return LooseVersion("{}.{}.{}".format(major_version, minor_version,
-                                        release_version))
-
+        return LooseVersion(
+            "{}.{}.{}".format(major_version, minor_version, release_version)
+        )
 
     # Get the Blosc version provided the 'blosc.h' header
     def get_blosc_version(headername):
@@ -379,160 +404,165 @@ if __name__ == '__main__':
         minor_version = -1
         release_version = -1
         for line in open(headername):
-            if 'BLOSC_VERSION_MAJOR' in line:
+            if "BLOSC_VERSION_MAJOR" in line:
                 major_version = int(line.split()[2])
-            if 'BLOSC_VERSION_MINOR' in line:
+            if "BLOSC_VERSION_MINOR" in line:
                 minor_version = int(line.split()[2])
-            if 'BLOSC_VERSION_RELEASE' in line:
+            if "BLOSC_VERSION_RELEASE" in line:
                 release_version = int(line.split()[2])
-            if (major_version != -1 and minor_version != -1 and
-                    release_version != -1):
+            if (
+                major_version != -1
+                and minor_version != -1
+                and release_version != -1
+            ):
                 break
-        if (major_version == -1 or minor_version == -1 or
-                release_version == -1):
+        if major_version == -1 or minor_version == -1 or release_version == -1:
             exit_with_error("Unable to detect Blosc library version!")
         return f"{major_version}.{minor_version}.{release_version}"
 
-
     _cp = convert_path
-    if os.name == 'posix':
+    if os.name == "posix":
         _Package = PosixPackage
         _platdep = {  # package tag -> platform-dependent components
-            'HDF5': ['hdf5'],
-            'LZO2': ['lzo2'],
-            'LZO': ['lzo'],
-            'BZ2': ['bz2'],
-            'BLOSC': ['blosc'],
+            "HDF5": ["hdf5"],
+            "LZO2": ["lzo2"],
+            "LZO": ["lzo"],
+            "BZ2": ["bz2"],
+            "BLOSC": ["blosc"],
         }
 
-    elif os.name == 'nt':
+    elif os.name == "nt":
         _Package = WindowsPackage
         _platdep = {  # package tag -> platform-dependent components
-            'HDF5': ['hdf5', 'hdf5'],
-            'LZO2': ['lzo2', 'lzo2'],
-            'LZO': ['liblzo', 'lzo1'],
-            'BZ2': ['bzip2', 'bzip2'],
-            'BLOSC': ['blosc', 'blosc'],
+            "HDF5": ["hdf5", "hdf5"],
+            "LZO2": ["lzo2", "lzo2"],
+            "LZO": ["liblzo", "lzo1"],
+            "BZ2": ["bzip2", "bzip2"],
+            "BLOSC": ["blosc", "blosc"],
         }
 
         # Copy the next DLL's to binaries by default.
         dll_files = [
-                    # '\\windows\\system\\zlib1.dll',
-                    # '\\windows\\system\\szip.dll',
-                    ]
+            # '\\windows\\system\\zlib1.dll',
+            # '\\windows\\system\\szip.dll',
+        ]
 
-        if os.environ.get('HDF5_USE_PREFIX', None):
+        if os.environ.get("HDF5_USE_PREFIX", None):
             # This is used on CI systems to link against HDF5 library
-            # The vendored `hdf5.dll` in a wheel is renamed to: `pytables_hdf5.dll`
-            # This should prevent DLL Hell.
-            print('* HDF5_USE_PREFIX: Trying to build against pytables_hdf5.dll')
-            _platdep['HDF5'] = ['pytables_hdf5', 'pytables_hdf5']
+            # The vendored `hdf5.dll` in a wheel is renamed to:
+            # `pytables_hdf5.dll` This should prevent DLL Hell.
+            print(
+                "* HDF5_USE_PREFIX: Trying to build against pytables_hdf5.dll"
+            )
+            _platdep["HDF5"] = ["pytables_hdf5", "pytables_hdf5"]
 
         if debug:
-            _platdep['HDF5'] = ['hdf5_D', 'hdf5_D']
+            _platdep["HDF5"] = ["hdf5_D", "hdf5_D"]
 
     else:
         _Package = None
         _platdep = {}
-        exit_with_error('Unsupported OS: %s' % os.name)
+        exit_with_error("Unsupported OS: %s" % os.name)
 
-
-    hdf5_package = _Package("HDF5", 'HDF5', 'H5public', *_platdep['HDF5'])
-    hdf5_package.target_function = 'H5close'
-    lzo2_package = _Package("LZO 2", 'LZO2', _cp('lzo/lzo1x'), *_platdep['LZO2'])
-    lzo2_package.target_function = 'lzo_version_date'
-    lzo1_package = _Package("LZO 1", 'LZO', 'lzo1x', *_platdep['LZO'])
-    lzo1_package.target_function = 'lzo_version_date'
-    bzip2_package = _Package("bzip2", 'BZ2', 'bzlib', *_platdep['BZ2'])
-    bzip2_package.target_function = 'BZ2_bzlibVersion'
-    blosc_package = _Package("blosc", 'BLOSC', 'blosc', *_platdep['BLOSC'])
-    blosc_package.target_function = 'blosc_list_compressors'  # Blosc >= 1.3
-
+    hdf5_package = _Package("HDF5", "HDF5", "H5public", *_platdep["HDF5"])
+    hdf5_package.target_function = "H5close"
+    lzo2_package = _Package(
+        "LZO 2", "LZO2", _cp("lzo/lzo1x"), *_platdep["LZO2"]
+    )
+    lzo2_package.target_function = "lzo_version_date"
+    lzo1_package = _Package("LZO 1", "LZO", "lzo1x", *_platdep["LZO"])
+    lzo1_package.target_function = "lzo_version_date"
+    bzip2_package = _Package("bzip2", "BZ2", "bzlib", *_platdep["BZ2"])
+    bzip2_package.target_function = "BZ2_bzlibVersion"
+    blosc_package = _Package("blosc", "BLOSC", "blosc", *_platdep["BLOSC"])
+    blosc_package.target_function = "blosc_list_compressors"  # Blosc >= 1.3
 
     # -----------------------------------------------------------------
 
-    def_macros = [('NDEBUG', 1)]
+    def_macros = [("NDEBUG", 1)]
     # Define macros for Windows platform
-    if os.name == 'nt':
-        def_macros.append(('WIN32', 1))
-        def_macros.append(('_HDF5USEDLL_', 1))
-        def_macros.append(('H5_BUILT_AS_DYNAMIC_LIB', 1))
+    if os.name == "nt":
+        def_macros.append(("WIN32", 1))
+        def_macros.append(("_HDF5USEDLL_", 1))
+        def_macros.append(("H5_BUILT_AS_DYNAMIC_LIB", 1))
 
     # Allow setting the HDF5 dir and additional link flags either in
     # the environment or on the command line.
     # First check the environment...
-    HDF5_DIR = os.environ.get('HDF5_DIR', '')
-    LZO_DIR = os.environ.get('LZO_DIR', '')
-    BZIP2_DIR = os.environ.get('BZIP2_DIR', '')
-    BLOSC_DIR = os.environ.get('BLOSC_DIR', '')
-    LFLAGS = os.environ.get('LFLAGS', '').split()
+    HDF5_DIR = os.environ.get("HDF5_DIR", "")
+    LZO_DIR = os.environ.get("LZO_DIR", "")
+    BZIP2_DIR = os.environ.get("BZIP2_DIR", "")
+    BLOSC_DIR = os.environ.get("BLOSC_DIR", "")
+    LFLAGS = os.environ.get("LFLAGS", "").split()
     # in GCC-style compilers, -w in extra flags will get rid of copious
     # 'uninitialized variable' Cython warnings. However, this shouldn't be
     # the default as it will suppress *all* the warnings, which definitely
     # is not a good idea.
-    CFLAGS = os.environ.get('CFLAGS', '').split()
-    LIBS = os.environ.get('LIBS', '').split()
-    CONDA_PREFIX = os.environ.get('CONDA_PREFIX', '')
+    CFLAGS = os.environ.get("CFLAGS", "").split()
+    LIBS = os.environ.get("LIBS", "").split()
+    CONDA_PREFIX = os.environ.get("CONDA_PREFIX", "")
     # We start using pkg-config since some distributions are putting HDF5
     # (and possibly other libraries) in exotic locations.  See issue #442.
     if distutils.spawn.find_executable(PKG_CONFIG):
-        USE_PKGCONFIG = os.environ.get('USE_PKGCONFIG', 'TRUE')
+        USE_PKGCONFIG = os.environ.get("USE_PKGCONFIG", "TRUE")
     else:
-        USE_PKGCONFIG = 'FALSE'
+        USE_PKGCONFIG = "FALSE"
 
     # ...then the command line.
     # Handle --hdf5=[PATH] --lzo=[PATH] --bzip2=[PATH] --blosc=[PATH]
     # --lflags=[FLAGS] --cflags=[FLAGS] and --debug
     args = sys.argv[:]
     for arg in args:
-        if arg.find('--hdf5=') == 0:
-            HDF5_DIR = expanduser(arg.split('=')[1])
+        if arg.find("--hdf5=") == 0:
+            HDF5_DIR = expanduser(arg.split("=")[1])
             sys.argv.remove(arg)
-        elif arg.find('--lzo=') == 0:
-            LZO_DIR = expanduser(arg.split('=')[1])
+        elif arg.find("--lzo=") == 0:
+            LZO_DIR = expanduser(arg.split("=")[1])
             sys.argv.remove(arg)
-        elif arg.find('--bzip2=') == 0:
-            BZIP2_DIR = expanduser(arg.split('=')[1])
+        elif arg.find("--bzip2=") == 0:
+            BZIP2_DIR = expanduser(arg.split("=")[1])
             sys.argv.remove(arg)
-        elif arg.find('--blosc=') == 0:
-            BLOSC_DIR = expanduser(arg.split('=')[1])
+        elif arg.find("--blosc=") == 0:
+            BLOSC_DIR = expanduser(arg.split("=")[1])
             sys.argv.remove(arg)
-        elif arg.find('--lflags=') == 0:
-            LFLAGS = arg.split('=')[1].split()
+        elif arg.find("--lflags=") == 0:
+            LFLAGS = arg.split("=")[1].split()
             sys.argv.remove(arg)
-        elif arg.find('--cflags=') == 0:
-            CFLAGS = arg.split('=')[1].split()
+        elif arg.find("--cflags=") == 0:
+            CFLAGS = arg.split("=")[1].split()
             sys.argv.remove(arg)
-        elif arg.find('--debug') == 0:
+        elif arg.find("--debug") == 0:
             # For debugging (mainly compression filters)
-            if os.name != 'nt':  # to prevent including dlfcn.h by utils.c!!!
-                def_macros = [('DEBUG', 1)]
+            if os.name != "nt":  # to prevent including dlfcn.h by utils.c!!!
+                def_macros = [("DEBUG", 1)]
             # Don't delete this argument. It maybe useful for distutils
             # when adding more flags later on
             # sys.argv.remove(arg)
-        elif arg.find('--use-pkgconfig') == 0:
-            USE_PKGCONFIG = arg.split('=')[1]
-            CONDA_PREFIX = ''
+        elif arg.find("--use-pkgconfig") == 0:
+            USE_PKGCONFIG = arg.split("=")[1]
+            CONDA_PREFIX = ""
             sys.argv.remove(arg)
-        elif arg.find('--no-conda') == 0:
-            CONDA_PREFIX = ''
+        elif arg.find("--no-conda") == 0:
+            CONDA_PREFIX = ""
             sys.argv.remove(arg)
 
-    USE_PKGCONFIG = True if USE_PKGCONFIG.upper() == 'TRUE' else False
-    print('* USE_PKGCONFIG:', USE_PKGCONFIG)
-
+    USE_PKGCONFIG = True if USE_PKGCONFIG.upper() == "TRUE" else False
+    print("* USE_PKGCONFIG:", USE_PKGCONFIG)
 
     # For windows, search for the hdf5 dll in the path and use it if found.
     # This is much more convenient than having to manually set an environment
     # variable to rebuild pytables
-    if not HDF5_DIR and os.name == 'nt':
+    if not HDF5_DIR and os.name == "nt":
         import ctypes.util
+
         if not debug:
-            libdir = (ctypes.util.find_library('hdf5.dll') or
-                    ctypes.util.find_library('hdf5dll.dll'))
+            libdir = ctypes.util.find_library(
+                "hdf5.dll"
+            ) or ctypes.util.find_library("hdf5dll.dll")
         else:
-            libdir = (ctypes.util.find_library('hdf5_D.dll') or
-                    ctypes.util.find_library('hdf5ddll.dll'))
+            libdir = ctypes.util.find_library(
+                "hdf5_D.dll"
+            ) or ctypes.util.find_library("hdf5ddll.dll")
         # Like 'C:\\Program Files\\HDF Group\\HDF5\\1.8.8\\bin\\hdf5dll.dll'
         if libdir:
             # Strip off the filename
@@ -541,11 +571,10 @@ if __name__ == '__main__':
             HDF5_DIR = os.path.dirname(libdir)
             print("* Found HDF5 using system PATH ('%s')" % libdir)
 
-
     if CONDA_PREFIX:
-        print('* Found conda env: ``%s``' % CONDA_PREFIX)
-        if os.name == 'nt':
-            CONDA_PREFIX += '\\Library'
+        print("* Found conda env: ``%s``" % CONDA_PREFIX)
+        if os.name == "nt":
+            CONDA_PREFIX += "\\Library"
 
     # The next flag for the C compiler is needed for finding the C headers for
     # the Cython extensions
@@ -553,32 +582,34 @@ if __name__ == '__main__':
 
     # Force the 1.8.x HDF5 API even if the library as been compiled to use the
     # 1.6.x API by default
-    CFLAGS.extend([
-        "-DH5_USE_18_API",
-        "-DH5Acreate_vers=2",
-        "-DH5Aiterate_vers=2",
-        "-DH5Dcreate_vers=2",
-        "-DH5Dopen_vers=2",
-        "-DH5Eclear_vers=2",
-        "-DH5Eprint_vers=2",
-        "-DH5Epush_vers=2",
-        "-DH5Eset_auto_vers=2",
-        "-DH5Eget_auto_vers=2",
-        "-DH5Ewalk_vers=2",
-        "-DH5E_auto_t_vers=2",
-        "-DH5Gcreate_vers=2",
-        "-DH5Gopen_vers=2",
-        "-DH5Pget_filter_vers=2",
-        "-DH5Pget_filter_by_id_vers=2",
-        # "-DH5Pinsert_vers=2",
-        # "-DH5Pregister_vers=2",
-        # "-DH5Rget_obj_type_vers=2",
-        "-DH5Tarray_create_vers=2",
-        # "-DH5Tcommit_vers=2",
-        "-DH5Tget_array_dims_vers=2",
-        # "-DH5Topen_vers=2",
-        "-DH5Z_class_t_vers=2",
-    ])
+    CFLAGS.extend(
+        [
+            "-DH5_USE_18_API",
+            "-DH5Acreate_vers=2",
+            "-DH5Aiterate_vers=2",
+            "-DH5Dcreate_vers=2",
+            "-DH5Dopen_vers=2",
+            "-DH5Eclear_vers=2",
+            "-DH5Eprint_vers=2",
+            "-DH5Epush_vers=2",
+            "-DH5Eset_auto_vers=2",
+            "-DH5Eget_auto_vers=2",
+            "-DH5Ewalk_vers=2",
+            "-DH5E_auto_t_vers=2",
+            "-DH5Gcreate_vers=2",
+            "-DH5Gopen_vers=2",
+            "-DH5Pget_filter_vers=2",
+            "-DH5Pget_filter_by_id_vers=2",
+            # "-DH5Pinsert_vers=2",
+            # "-DH5Pregister_vers=2",
+            # "-DH5Rget_obj_type_vers=2",
+            "-DH5Tarray_create_vers=2",
+            # "-DH5Tcommit_vers=2",
+            "-DH5Tget_array_dims_vers=2",
+            # "-DH5Topen_vers=2",
+            "-DH5Z_class_t_vers=2",
+        ]
+    )
     # H5Oget_info_by_name seems to have performance issues (see gh-402), so we
     # need to use teh deprecated H5Gget_objinfo function
     # CFLAGS.append("-DH5_NO_DEPRECATED_SYMBOLS")
@@ -589,75 +620,95 @@ if __name__ == '__main__':
     # Try to locate the compulsory and optional libraries.
     lzo2_enabled = False
     compiler = new_compiler()
-    for (package, location) in [(hdf5_package, HDF5_DIR),
-                                (lzo2_package, LZO_DIR),
-                                (lzo1_package, LZO_DIR),
-                                (bzip2_package, BZIP2_DIR),
-                                (blosc_package, BLOSC_DIR)]:
+    for (package, location) in [
+        (hdf5_package, HDF5_DIR),
+        (lzo2_package, LZO_DIR),
+        (lzo1_package, LZO_DIR),
+        (bzip2_package, BZIP2_DIR),
+        (blosc_package, BLOSC_DIR),
+    ]:
 
-        if package.tag == 'LZO' and lzo2_enabled:
-            print("* Skipping detection of %s since %s has already been found."
-                % (lzo1_package.name, lzo2_package.name))
+        if package.tag == "LZO" and lzo2_enabled:
+            print(
+                "* Skipping detection of %s since %s has already been found."
+                % (lzo1_package.name, lzo2_package.name)
+            )
             continue  # do not use LZO 1 if LZO 2 is available
 
         # if a package location is not specified, try to find it in conda env
         if not location and CONDA_PREFIX:
             location = CONDA_PREFIX
 
-        # looking for lzo/lzo1x.h but pkgconfig already returns '/usr/include/lzo'
-        use_pkgconfig = USE_PKGCONFIG if package.tag != 'LZO2' else False
+        # looking for lzo/lzo1x.h but pkgconfig already returns
+        # '/usr/include/lzo'
+        use_pkgconfig = USE_PKGCONFIG if package.tag != "LZO2" else False
 
         (hdrdir, libdir, rundir) = package.find_directories(
-            location, use_pkgconfig=use_pkgconfig)
+            location, use_pkgconfig=use_pkgconfig
+        )
 
         # check if HDF5 library uses old DLL naming scheme
-        if hdrdir and package.tag == 'HDF5':
+        if hdrdir and package.tag == "HDF5":
             hdf5_header = os.path.join(hdrdir, "H5public.h")
             hdf5_version = get_hdf5_version(hdf5_header)
             if hdf5_version < min_hdf5_version:
                 exit_with_error(
                     "Unsupported HDF5 version! HDF5 v%s+ required. "
-                    "Found version v%s" % (min_hdf5_version, hdf5_version))
+                    "Found version v%s" % (min_hdf5_version, hdf5_version)
+                )
 
-            if os.name == 'nt' and hdf5_version < "1.8.10":
+            if os.name == "nt" and hdf5_version < "1.8.10":
                 # Change in DLL naming happened in 1.8.10
-                hdf5_old_dll_name = 'hdf5dll' if not debug else 'hdf5ddll'
+                hdf5_old_dll_name = "hdf5dll" if not debug else "hdf5ddll"
                 package.library_name = hdf5_old_dll_name
                 package.runtime_name = hdf5_old_dll_name
-                _platdep['HDF5'] = [hdf5_old_dll_name, hdf5_old_dll_name]
+                _platdep["HDF5"] = [hdf5_old_dll_name, hdf5_old_dll_name]
                 _, libdir, rundir = package.find_directories(
-                    location, use_pkgconfig=USE_PKGCONFIG)
+                    location, use_pkgconfig=USE_PKGCONFIG
+                )
 
         # check if the library is in the standard compiler paths
         if not libdir and package.target_function:
-            libdir = compiler.has_function(package.target_function,
-                                        libraries=(package.library_name,))
+            libdir = compiler.has_function(
+                package.target_function, libraries=(package.library_name,)
+            )
 
         if not (hdrdir and libdir):
-            if package.tag in ['HDF5']:  # these are compulsory!
+            if package.tag in ["HDF5"]:  # these are compulsory!
                 pname, ptag = package.name, package.tag
                 exit_with_error(
                     "Could not find a local %s installation." % pname,
-                    "You may need to explicitly state "
-                    "where your local %(name)s headers and library can be found "
-                    "by setting the ``%(tag)s_DIR`` environment variable "
-                    "or by using the ``--%(ltag)s`` command-line option."
-                    % dict(name=pname, tag=ptag, ltag=ptag.lower()))
-            if package.tag == 'BLOSC':  # this is optional, but comes with sources
-                print("* Could not find %s headers and library; "
-                    "using internal sources." % package.name)
+                    "You may need to explicitly state where your local "
+                    "%(name)s headers and library can be found by setting "
+                    "the ``%(tag)s_DIR`` environment variable or by using "
+                    "the ``--%(ltag)s`` command-line option."
+                    % dict(name=pname, tag=ptag, ltag=ptag.lower()),
+                )
+            if (
+                package.tag == "BLOSC"
+            ):  # this is optional, but comes with sources
+                print(
+                    "* Could not find %s headers and library; "
+                    "using internal sources." % package.name
+                )
             else:
-                print("* Could not find %s headers and library; "
-                    "disabling support for it." % package.name)
+                print(
+                    "* Could not find %s headers and library; "
+                    "disabling support for it." % package.name
+                )
 
             continue  # look for the next library
 
         if libdir in ("", True):
-            print("* Found %s headers at ``%s``, the library is located in the "
-                "standard system search dirs." % (package.name, hdrdir))
+            print(
+                "* Found %s headers at ``%s``, the library is located in the "
+                "standard system search dirs." % (package.name, hdrdir)
+            )
         else:
-            print("* Found %s headers at ``%s``, library at ``%s``."
-                % (package.name, hdrdir, libdir))
+            print(
+                "* Found %s headers at ``%s``, library at ``%s``."
+                % (package.name, hdrdir, libdir)
+            )
 
         if hdrdir not in default_header_dirs:
             inc_dirs.append(hdrdir)  # save header directory if needed
@@ -669,65 +720,72 @@ if __name__ == '__main__':
             else:
                 lib_dirs.append(libdir)
 
-        if package.tag not in ['HDF5']:
+        if package.tag not in ["HDF5"]:
             # Keep record of the optional libraries found.
             optional_libs.append(package.tag)
-            def_macros.append(('HAVE_%s_LIB' % package.tag, 1))
+            def_macros.append(("HAVE_%s_LIB" % package.tag, 1))
 
-        if hdrdir and package.tag == 'BLOSC':
+        if hdrdir and package.tag == "BLOSC":
             blosc_header = os.path.join(hdrdir, "blosc.h")
             blosc_version = get_blosc_version(blosc_header)
             if blosc_version < min_blosc_version:
                 optional_libs.pop()  # Remove Blosc from the discovered libs
                 print_warning(
                     "Unsupported Blosc version installed! Blosc %s+ required. "
-                    "Found version %s.  Using internal Blosc sources." % (
-                        min_blosc_version, blosc_version))
+                    "Found version %s.  Using internal Blosc sources."
+                    % (min_blosc_version, blosc_version)
+                )
             if blosc_version < min_blosc_bitshuffle_version:
                 print_warning(
-                    "This Blosc version does not support the BitShuffle filter. "
-                    "Minimum desirable version is %s.  Found version: %s" % (
-                        min_blosc_bitshuffle_version, blosc_version))
+                    "This Blosc version does not support the BitShuffle "
+                    "filter. Minimum desirable version is %s. "
+                    "Found version: %s"
+                    % (min_blosc_bitshuffle_version, blosc_version)
+                )
 
         if not rundir:
             loc = {
-                'posix': "the default library paths.",
-                'nt': "any of the directories in %%PATH%%.",
+                "posix": "the default library paths.",
+                "nt": "any of the directories in %%PATH%%.",
             }[os.name]
 
-            if "bdist_wheel" in sys.argv and os.name == 'nt':
+            if "bdist_wheel" in sys.argv and os.name == "nt":
                 exit_with_error(
                     "Could not find the %s runtime." % package.name,
                     "The %(name)s shared library was *not* found in %(loc)s "
                     "Cannot build wheel without the runtime."
-                    % dict(name=package.name, loc=loc)
+                    % dict(name=package.name, loc=loc),
                 )
             else:
                 print_warning(
                     "Could not find the %s runtime." % package.name,
                     "The %(name)s shared library was *not* found in %(loc)s "
-                    "In case of runtime problems, please remember to install it."
-                    % dict(name=package.name, loc=loc)
+                    "In case of runtime problems, please remember to install "
+                    "it."
+                    % dict(name=package.name, loc=loc),
                 )
 
         if os.name == "nt":
-            # LZO DLLs cannot be copied to the binary package for license reasons
-            if package.tag not in ['LZO', 'LZO2']:
-                dll_file = _platdep[package.tag][1] + '.dll'
+            # LZO DLLs cannot be copied to the binary package for license
+            # reasons
+            if package.tag not in ["LZO", "LZO2"]:
+                dll_file = _platdep[package.tag][1] + ".dll"
                 # If DLL is not in rundir, do nothing.  This can be useful
                 # for BZIP2, that can be linked either statically (.LIB)
                 # or dinamically (.DLL)
                 if rundir is not None:
                     dll_files.append(os.path.join(rundir, dll_file))
 
-        if os.name == 'nt' and package.tag in ['HDF5']:
+        if os.name == "nt" and package.tag in ["HDF5"]:
             # hdf5.dll usually depends on zlib.dll
-            z_lib_path = ctypes.util.find_library('zlib.dll')
+            z_lib_path = ctypes.util.find_library("zlib.dll")
             if z_lib_path:
-                print('* Adding zlib.dll (hdf5 dependency): ``%s``' % z_lib_path)
+                print(
+                    "* Adding zlib.dll (hdf5 dependency): ``%s``" % z_lib_path
+                )
                 dll_files.append(z_lib_path)
 
-        if package.tag == 'LZO2':
+        if package.tag == "LZO2":
             lzo2_enabled = True
 
     if lzo2_enabled:
@@ -738,135 +796,140 @@ if __name__ == '__main__':
     # ------------------------------------------------------------------------------
 
     cython_extnames = [
-        'utilsextension',
-        'hdf5extension',
-        'tableextension',
-        'linkextension',
-        '_comp_lzo',
-        '_comp_bzip2',
-        'lrucacheextension',
-        'indexesextension',
+        "utilsextension",
+        "hdf5extension",
+        "tableextension",
+        "linkextension",
+        "_comp_lzo",
+        "_comp_bzip2",
+        "lrucacheextension",
+        "indexesextension",
     ]
 
-
     def get_cython_extfiles(extnames):
-        extdir = 'tables'
+        extdir = "tables"
         extfiles = {}
 
         for extname in extnames:
             extfile = os.path.join(extdir, extname)
-            extpfile = '%s.pyx' % extfile
-            extcfile = '%s.c' % extfile
+            extpfile = "%s.pyx" % extfile
+            extcfile = "%s.c" % extfile
 
             if not exists(extcfile) or newer(extpfile, extcfile):
                 # This is the only place where Cython is needed, but every
                 # developer should have it installed, so it should not be
                 # a hard requisite
                 from Cython.Build import cythonize
-                cythonize(extpfile, language_level = "2")
+
+                cythonize(extpfile, language_level="2")
             extfiles[extname] = extcfile
 
         return extfiles
 
-
     cython_extfiles = get_cython_extfiles(cython_extnames)
 
     # Update the version.h file if this file is newer
-    if newer('VERSION', 'src/version.h'):
-        with open('src/version.h', 'w') as fd:
+    if newer("VERSION", "src/version.h"):
+        with open("src/version.h", "w") as fd:
             fd.write('#define PYTABLES_VERSION "%s"\n' % VERSION)
 
     # --------------------------------------------------------------------
 
     # Package information for ``setuptools``
     # PyTables contains data files for tests.
-    setuptools_kwargs['zip_safe'] = False
+    setuptools_kwargs["zip_safe"] = False
 
-    setuptools_kwargs['install_requires'] = requirements
+    setuptools_kwargs["install_requires"] = requirements
 
     # Detect packages automatically.
-    setuptools_kwargs['packages'] = find_packages(exclude=['*.bench'])
+    setuptools_kwargs["packages"] = find_packages(exclude=["*.bench"])
 
     # Entry points for automatic creation of scripts.
-    setuptools_kwargs['entry_points'] = {
-        'console_scripts': [
-            'ptdump = tables.scripts.ptdump:main',
-            'ptrepack = tables.scripts.ptrepack:main',
-            'pt2to3 = tables.scripts.pt2to3:main',
-            'pttree = tables.scripts.pttree:main',
+    setuptools_kwargs["entry_points"] = {
+        "console_scripts": [
+            "ptdump = tables.scripts.ptdump:main",
+            "ptrepack = tables.scripts.ptrepack:main",
+            "pt2to3 = tables.scripts.pt2to3:main",
+            "pttree = tables.scripts.pttree:main",
         ],
     }
 
     # Test suites.
-    setuptools_kwargs['test_suite'] = 'tables.tests.test_all.suite'
-    setuptools_kwargs['scripts'] = []
+    setuptools_kwargs["test_suite"] = "tables.tests.test_all.suite"
+    setuptools_kwargs["scripts"] = []
 
     # Copy additional data for packages that need it.
-    setuptools_kwargs['package_data'] = {
-        'tables.tests': ['*.h5', '*.mat'],
-        'tables.nodes.tests': ['*.dat', '*.xbm', '*.h5'],
+    setuptools_kwargs["package_data"] = {
+        "tables.tests": ["*.h5", "*.mat"],
+        "tables.nodes.tests": ["*.dat", "*.xbm", "*.h5"],
     }
-
 
     # Having the Python version included in the package name makes managing a
     # system with multiple versions of Python much easier.
 
-    def find_name(base='tables'):
+    def find_name(base="tables"):
         """If "--name-with-python-version" is on the command line then
         append "-pyX.Y" to the base name"""
         name = base
-        if '--name-with-python-version' in sys.argv:
-            name += '-py%i.%i' % (sys.version_info[0], sys.version_info[1])
-            sys.argv.remove('--name-with-python-version')
+        if "--name-with-python-version" in sys.argv:
+            name += "-py%i.%i" % (sys.version_info[0], sys.version_info[1])
+            sys.argv.remove("--name-with-python-version")
         return name
-
 
     name = find_name()
 
     if os.name == "nt":
         # Add DLL's to the final package for windows
-        data_files.extend([
-            ('Lib/site-packages/%s' % name, dll_files),
-        ])
+        data_files.extend(
+            [
+                ("Lib/site-packages/%s" % name, dll_files),
+            ]
+        )
 
     ADDLIBS = [hdf5_package.library_name]
 
     # List of Blosc file dependencies
     blosc_sources = ["hdf5-blosc/src/blosc_filter.c"]
-    if 'BLOSC' not in optional_libs:
-        if not os.environ.get('PYTABLES_NO_EMBEDDED_LIBS', None) is None:
+    if "BLOSC" not in optional_libs:
+        if not os.environ.get("PYTABLES_NO_EMBEDDED_LIBS", None) is None:
             exit_with_error(
                 "Unable to find the blosc library. "
                 "The embedded copy of the blosc sources can't be used because "
                 "the PYTABLES_NO_EMBEDDED_LIBS environment variable has been "
-                "specified).")
+                "specified)."
+            )
 
         # Compiling everything from sources
         # Blosc + BloscLZ sources
-        blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                          if 'avx2' not in f and 'sse2' not in f]
+        blosc_sources += [
+            f
+            for f in glob.glob("c-blosc/blosc/*.c")
+            if "avx2" not in f and "sse2" not in f
+        ]
         # LZ4 sources
-        blosc_sources += glob.glob('c-blosc/internal-complibs/lz4*/*.c')
+        blosc_sources += glob.glob("c-blosc/internal-complibs/lz4*/*.c")
         # Snappy sources
-        # Starting from C-Blosc 1.19.0, snappy sources are not distributed anymore
+        # Starting from C-Blosc 1.19.0, snappy sources are not distributed
+        # anymore
         # blosc_sources += glob.glob('c-blosc/internal-complibs/snappy*/*.cc')
         # Zlib sources
-        blosc_sources += glob.glob('c-blosc/internal-complibs/zlib*/*.c')
+        blosc_sources += glob.glob("c-blosc/internal-complibs/zlib*/*.c")
         # Zstd sources
-        blosc_sources += glob.glob('c-blosc/internal-complibs/zstd*/*/*.c')
+        blosc_sources += glob.glob("c-blosc/internal-complibs/zstd*/*/*.c")
         # Finally, add all the include dirs...
-        inc_dirs += [os.path.join('c-blosc', 'blosc')]
-        inc_dirs += glob.glob('c-blosc/internal-complibs/*')
-        inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*/common')
-        inc_dirs += glob.glob('c-blosc/internal-complibs/zstd*')
+        inc_dirs += [os.path.join("c-blosc", "blosc")]
+        inc_dirs += glob.glob("c-blosc/internal-complibs/*")
+        inc_dirs += glob.glob("c-blosc/internal-complibs/zstd*/common")
+        inc_dirs += glob.glob("c-blosc/internal-complibs/zstd*")
         # ...and the macros for all the compressors supported
-        def_macros += [('HAVE_LZ4', 1), ('HAVE_ZLIB', 1), ('HAVE_ZSTD', 1)]
+        def_macros += [("HAVE_LZ4", 1), ("HAVE_ZLIB", 1), ("HAVE_ZSTD", 1)]
 
         # Add extra flags for optimizing shuffle in include Blosc
         def compiler_has_flags(compiler, flags):
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.c',
-                                            delete=False) as fd:
-                fd.write('int main() {return 0;}')
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".c", delete=False
+            ) as fd:
+                fd.write("int main() {return 0;}")
 
             try:
                 compiler.compile([fd.name], extra_preargs=flags)
@@ -878,149 +941,170 @@ if __name__ == '__main__':
                 os.remove(fd.name)
 
         # SSE2
-        if 'sse2' in cpu_flags:
-            print('SSE2 detected and enabled')
-            CFLAGS.append('-DSHUFFLE_SSE2_ENABLED')
-            if os.name == 'nt':
+        if "sse2" in cpu_flags:
+            print("SSE2 detected and enabled")
+            CFLAGS.append("-DSHUFFLE_SSE2_ENABLED")
+            if os.name == "nt":
                 # Windows always should have support for SSE2
                 # (present in all x86/amd64 architectures since 2003)
-                def_macros += [('__SSE2__', 1)]
+                def_macros += [("__SSE2__", 1)]
             else:
                 # On UNIX, both gcc and clang understand -msse2
-                CFLAGS.append('-msse2')
-            blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                              if 'sse2' in f]
+                CFLAGS.append("-msse2")
+            blosc_sources += [
+                f for f in glob.glob("c-blosc/blosc/*.c") if "sse2" in f
+            ]
         # AVX2
-        if 'avx2' in cpu_flags and 'DISABLE_AVX2' not in os.environ:
-            print('AVX2 detected and enabled')
-            if os.name == 'nt':
-                if LooseVersion(platform.python_version()) >= LooseVersion('3.5.0'):
-                    # MSVC2010 for Python 3.4 does not have sufficient AVX2 support
-                    def_macros += [('__AVX2__', 1)]
-                    CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
-                    blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                                      if 'avx2' in f]
+        if "avx2" in cpu_flags and "DISABLE_AVX2" not in os.environ:
+            print("AVX2 detected and enabled")
+            if os.name == "nt":
+                if LooseVersion(platform.python_version()) >= LooseVersion(
+                    "3.5.0"
+                ):
+                    # MSVC2010 for Python 3.4 does not have sufficient AVX2
+                    # support
+                    def_macros += [("__AVX2__", 1)]
+                    CFLAGS.append("-DSHUFFLE_AVX2_ENABLED")
+                    blosc_sources += [
+                        f
+                        for f in glob.glob("c-blosc/blosc/*.c")
+                        if "avx2" in f
+                    ]
             elif compiler_has_flags(compiler, ["-mavx2"]):
-                CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
-                CFLAGS.append('-mavx2')
-                blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
-                                  if 'avx2' in f]
+                CFLAGS.append("-DSHUFFLE_AVX2_ENABLED")
+                CFLAGS.append("-mavx2")
+                blosc_sources += [
+                    f for f in glob.glob("c-blosc/blosc/*.c") if "avx2" in f
+                ]
     else:
-        ADDLIBS += ['blosc']
-
+        ADDLIBS += ["blosc"]
 
     utilsExtension_libs = LIBS + ADDLIBS
     hdf5Extension_libs = LIBS + ADDLIBS
     tableExtension_libs = LIBS + ADDLIBS
     linkExtension_libs = LIBS + ADDLIBS
     indexesExtension_libs = LIBS + ADDLIBS
-    lrucacheExtension_libs = []    # Doesn't need external libraries
+    lrucacheExtension_libs = []  # Doesn't need external libraries
 
     # Compressor modules only need other libraries if they are enabled.
     _comp_lzo_libs = LIBS[:]
     _comp_bzip2_libs = LIBS[:]
-    for (package, complibs) in [(lzo_package, _comp_lzo_libs),
-                                (bzip2_package, _comp_bzip2_libs)]:
+    for (package, complibs) in [
+        (lzo_package, _comp_lzo_libs),
+        (bzip2_package, _comp_bzip2_libs),
+    ]:
 
         if package.tag in optional_libs:
             complibs.extend([hdf5_package.library_name, package.library_name])
 
-
     extensions = [
-        Extension("tables.utilsextension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['utilsextension'],
-                        "src/utils.c",
-                        "src/H5ARRAY.c",
-                        "src/H5ATTR.c",
-                        ] + blosc_sources,
-                library_dirs=lib_dirs,
-                libraries=utilsExtension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables.hdf5extension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['hdf5extension'],
-                        "src/utils.c",
-                        "src/typeconv.c",
-                        "src/H5ARRAY.c",
-                        "src/H5ARRAY-opt.c",
-                        "src/H5VLARRAY.c",
-                        "src/H5ATTR.c",
-                        ] + blosc_sources,
-                library_dirs=lib_dirs,
-                libraries=hdf5Extension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables.tableextension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['tableextension'],
-                        "src/utils.c",
-                        "src/typeconv.c",
-                        "src/H5TB-opt.c",
-                        "src/H5ATTR.c",
-                        ] + blosc_sources,
-                library_dirs=lib_dirs,
-                libraries=tableExtension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables._comp_lzo",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['_comp_lzo'],
-                        "src/H5Zlzo.c"],
-                library_dirs=lib_dirs,
-                libraries=_comp_lzo_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables._comp_bzip2",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['_comp_bzip2'],
-                        "src/H5Zbzip2.c"],
-                library_dirs=lib_dirs,
-                libraries=_comp_bzip2_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables.linkextension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['linkextension']],
-                library_dirs=lib_dirs,
-                libraries=tableExtension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables.lrucacheextension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['lrucacheextension']],
-                library_dirs=lib_dirs,
-                libraries=lrucacheExtension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
-        Extension("tables.indexesextension",
-                include_dirs=inc_dirs,
-                define_macros=def_macros,
-                sources=[cython_extfiles['indexesextension'],
-                        "src/H5ARRAY-opt.c",
-                        "src/idx-opt.c"],
-                library_dirs=lib_dirs,
-                libraries=indexesExtension_libs,
-                extra_link_args=LFLAGS,
-                extra_compile_args=CFLAGS),
-
+        Extension(
+            "tables.utilsextension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[
+                cython_extfiles["utilsextension"],
+                "src/utils.c",
+                "src/H5ARRAY.c",
+                "src/H5ATTR.c",
+            ]
+            + blosc_sources,
+            library_dirs=lib_dirs,
+            libraries=utilsExtension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables.hdf5extension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[
+                cython_extfiles["hdf5extension"],
+                "src/utils.c",
+                "src/typeconv.c",
+                "src/H5ARRAY.c",
+                "src/H5ARRAY-opt.c",
+                "src/H5VLARRAY.c",
+                "src/H5ATTR.c",
+            ]
+            + blosc_sources,
+            library_dirs=lib_dirs,
+            libraries=hdf5Extension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables.tableextension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[
+                cython_extfiles["tableextension"],
+                "src/utils.c",
+                "src/typeconv.c",
+                "src/H5TB-opt.c",
+                "src/H5ATTR.c",
+            ]
+            + blosc_sources,
+            library_dirs=lib_dirs,
+            libraries=tableExtension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables._comp_lzo",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[cython_extfiles["_comp_lzo"], "src/H5Zlzo.c"],
+            library_dirs=lib_dirs,
+            libraries=_comp_lzo_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables._comp_bzip2",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[cython_extfiles["_comp_bzip2"], "src/H5Zbzip2.c"],
+            library_dirs=lib_dirs,
+            libraries=_comp_bzip2_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables.linkextension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[cython_extfiles["linkextension"]],
+            library_dirs=lib_dirs,
+            libraries=tableExtension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables.lrucacheextension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[cython_extfiles["lrucacheextension"]],
+            library_dirs=lib_dirs,
+            libraries=lrucacheExtension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
+        Extension(
+            "tables.indexesextension",
+            include_dirs=inc_dirs,
+            define_macros=def_macros,
+            sources=[
+                cython_extfiles["indexesextension"],
+                "src/H5ARRAY-opt.c",
+                "src/idx-opt.c",
+            ],
+            library_dirs=lib_dirs,
+            libraries=indexesExtension_libs,
+            extra_link_args=LFLAGS,
+            extra_compile_args=CFLAGS,
+        ),
     ]
-
 
     classifiers = """\
 Development Status :: 5 - Production/Stable
@@ -1043,7 +1127,7 @@ Topic :: Software Development :: Libraries :: Python Modules
     setup(
         name=name,
         version=VERSION,
-        description='Hierarchical datasets for Python',
+        description="Hierarchical datasets for Python",
         long_description="""\
 PyTables is a package for managing hierarchical datasets and
 designed to efficently cope with extremely large amounts of
@@ -1054,26 +1138,25 @@ makes of it a fast, yet extremely easy to use tool for
 interactively save and retrieve large amounts of data.
 """,
         classifiers=[c for c in classifiers.split("\n") if c],
-        author=('Francesc Alted, Ivan Vilata,'
-                'Antonio Valentino, Anthony Scopatz et al.'),
-        author_email='pytables@pytables.org',
-        maintainer='PyTables maintainers',
-        maintainer_email='pytables@pytables.org',
-        url='http://www.pytables.org/',
-        license='BSD 2-Clause',
-        python_requires='>=3.6',
-        platforms=['any'],
+        author=(
+            "Francesc Alted, Ivan Vilata,"
+            "Antonio Valentino, Anthony Scopatz et al."
+        ),
+        author_email="pytables@pytables.org",
+        maintainer="PyTables maintainers",
+        maintainer_email="pytables@pytables.org",
+        url="http://www.pytables.org/",
+        license="BSD 2-Clause",
+        python_requires=">=3.6",
+        platforms=["any"],
         ext_modules=extensions,
         cmdclass=cmdclass,
         data_files=data_files,
         extra_require={
-            'doc': [
-                'sphinx >= 1.1',
-                'sphinx_rtd_theme',
-                'numpydoc',
-                'ipython']},
-        **setuptools_kwargs
+            "doc": ["sphinx >= 1.1", "sphinx_rtd_theme", "numpydoc", "ipython"]
+        },
+        **setuptools_kwargs,
     )
 
-elif __name__ == '__mp_main__':
+elif __name__ == "__mp_main__":
     pass


### PR DESCRIPTION
This is an attempt to modernize `setup.py` (f-strings, pathlib, formatting, …), but it does a little bit more, a bugfix and cleanup of old code. It has not been completely tested, so **PLEASE DO NOT MERGE.**

During the editing I changed quite a lot of stuff, then reformatted with `black`, so the diff was huge. Then I took the `setup.py` from the `master`, applied `black -l 79 setup.py && isort setup.py`, reformatted some comments, and rebased my changes on that, so after the first commit the file's functionality didn't change and the diff in the second commit is what I'd like to discuss with you.

1. `pathlib.Path` for file/directory manipulation. I have a relatively good feeling about the`posix` part, but little idea about the `nt` part. Anyway, there's the project's `ROOT` Path object where all project's files are based on. The `glob`bing and file reading is more compact. The main reason is to distinguish between strings and directory/file names. There were too many string hacks and now it should be clearer where we are working with file system. 
2. f-strings because the earlier `pyupgrade --py36-plus` didn't change everything, so I am updating anything I touch
3. fix typo `extras_required` in the `setup()` call
4. and entered a few `TODO`s where I was not sure what to do

I am not sure how `setup.py` should generally work, but this one prints quite a lot. So even for `python setup.py --version` where one would expect a single like with the version, it always prints some *debugging* info, such as directories with headers.

I am looking forward to your feedback!