### PR TITLE
Use pathlib for dir/file operations

### DIFF
--- a/bench/blosc.py
+++ b/bench/blosc.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 from time import perf_counter as clock
 import numpy as np
 import tables as tb
@@ -50,7 +50,7 @@ def create_file(kind, prec, synth):
                 r[:] = col[:]
         f2.close()
         if clevel == 0:
-            size = 1.5 * os.stat(oname).st_size
+            size = 1.5 * Path(oname).stat().st_size
     f.close()
     return size
 
@@ -88,7 +88,7 @@ def create_synth(kind, prec):
 
         f2.close()
         if clevel == 0:
-            size = 1.5 * os.stat(oname).st_size
+            size = 1.5 * Path(oname).stat().st_size
     f.close()
     return size
 
@@ -131,7 +131,7 @@ def process_file(kind, prec, clevel, synth):
         expr.eval()
     f.close()
     f2.close()
-    size = os.stat(iname).st_size + os.stat(oname).st_size
+    size = Path(iname).stat().st_size + Path(oname).stat().st_size
     return size
 
 

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -1,5 +1,4 @@
-import os
-import subprocess
+from pathlib import Path
 from time import perf_counter as clock
 import random
 import numpy as np
@@ -10,10 +9,7 @@ random.seed(2)
 
 def show_stats(explain, tref):
     "Show the used memory (only works for Linux 2.6.x)."
-    # Build the command to obtain memory info
-    cmd = "cat /proc/%s/status" % os.getpid()
-    sout = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-    for line in sout:
+    for line in Path('/proc/self/status').read_text().splitlines():
         if line.startswith("VmSize:"):
             vmsize = int(line.split()[1])
         elif line.startswith("VmRSS:"):
@@ -26,7 +22,6 @@ def show_stats(explain, tref):
             vmexe = int(line.split()[1])
         elif line.startswith("VmLib:"):
             vmlib = int(line.split()[1])
-    sout.close()
     print("Memory usage: ******* %s *******" % explain)
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -1,8 +1,7 @@
 # Small benchmark for compare creation times with parameter
 # PYTABLES_SYS_ATTRS active or not.
 
-import os
-import subprocess
+from pathlib import Path
 from time import perf_counter as clock
 import random
 import tables as tb
@@ -12,10 +11,7 @@ random.seed(2)
 
 def show_stats(explain, tref):
     "Show the used memory (only works for Linux 2.6.x)."
-    # Build the command to obtain memory info
-    cmd = "cat /proc/%s/status" % os.getpid()
-    sout = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-    for line in sout:
+    for line in Path('/proc/self/status').read_text().splitlines():
         if line.startswith("VmSize:"):
             vmsize = int(line.split()[1])
         elif line.startswith("VmRSS:"):
@@ -28,7 +24,6 @@ def show_stats(explain, tref):
             vmexe = int(line.split()[1])
         elif line.startswith("VmLib:"):
             vmlib = int(line.split()[1])
-    sout.close()
     print("Memory usage: ******* %s *******" % explain)
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
     print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")

--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -163,9 +163,8 @@ if __name__ == "__main__":
         prof = Profile()
         prof.run('evaluate("a*b+c", out)')
         kcg = lsprofcalltree.KCacheGrind(prof)
-        ofile = open('evaluate.kcg', 'w')
-        kcg.output(ofile)
-        ofile.close()
+        with Path('evaluate.kcg').open('w') as ofile:
+            kcg.output(ofile)
     else:
         evaluate("a*b+c", out)
     print(f"Time for evaluate--> {clock() - t0:.3f}")

--- a/bench/expression.py
+++ b/bench/expression.py
@@ -1,10 +1,10 @@
-import os
+from pathlib import Path
 from time import perf_counter as clock
 
 import numpy as np
 import tables as tb
 
-OUT_DIR = "/scratch2/faltet/"   # the directory for data output
+OUT_DIR = Path("/scratch2/faltet/")   # the directory for data output
 
 shape = (1000, 1000 * 1000)   # shape for input arrays
 expr = "a*b+1"   # Expression to be computed
@@ -15,8 +15,8 @@ nrows, ncols = shape
 def tables(docompute, dowrite, complib, verbose):
 
     # Filenames
-    ifilename = os.path.join(OUT_DIR, "expression-inputs.h5")
-    ofilename = os.path.join(OUT_DIR, "expression-outputs.h5")
+    ifilename = OUT_DIR / "expression-inputs.h5"
+    ofilename = OUT_DIR / "expression-outputs.h5"
 
     # Filters
     shuffle = True
@@ -73,9 +73,9 @@ def tables(docompute, dowrite, complib, verbose):
 
 def memmap(docompute, dowrite, verbose):
 
-    afilename = os.path.join(OUT_DIR, "memmap-a.bin")
-    bfilename = os.path.join(OUT_DIR, "memmap-b.bin")
-    rfilename = os.path.join(OUT_DIR, "memmap-output.bin")
+    afilename = OUT_DIR / "memmap-a.bin"
+    bfilename = OUT_DIR / "memmap-b.bin"
+    rfilename = OUT_DIR / "memmap-output.bin"
     if dowrite:
         t0 = clock()
         a = np.memmap(afilename, dtype='float32', mode='w+', shape=shape)

--- a/bench/get-figures-ranges.py
+++ b/bench/get-figures-ranges.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from pylab import *
 
 linewidth = 2
@@ -8,11 +9,10 @@ markersize = 8
 
 
 def get_values(filename):
-    f = open(filename)
     sizes = []
     values = []
     isize = None
-    for line in f:
+    for line in Path(filename).read_text().splitlines():
         if line.startswith('range'):
             tmp = line.split(':')[1]
             tmp = tmp.strip()
@@ -68,8 +68,6 @@ def get_values(filename):
                 elif query_warm and 'warm' in line:
                     sizes.append(isize)
                     values.append(qtime)
-
-    f.close()
     return sizes, values
 
 

--- a/bench/get-figures.py
+++ b/bench/get-figures.py
@@ -8,10 +8,9 @@ markersize = 8
 
 
 def get_values(filename):
-    f = open(filename)
     sizes = []
     values = []
-    for line in f:
+    for line in Path(filename).read_text().splitlines():
         if line.startswith('Processing database:'):
             txtime = 0
             line = line.split(':')[1]
@@ -93,8 +92,6 @@ def get_values(filename):
                 qtime = float(tmp[:tmp.index('+-')])
                 sizes.append(isize)
                 values.append(qtime)
-
-    f.close()
     return sizes, values
 
 

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -1,6 +1,8 @@
-from time import perf_counter as clock
-import subprocess
 import random
+import subprocess
+from pathlib import Path
+from time import perf_counter as clock
+
 import numpy as np
 
 # Constants
@@ -414,9 +416,8 @@ if __name__ == "__main__":
                 'db.query_db(niter, dtype, onlyidxquery, onlynonidxquery, '
                 'avoidfscache, verbose, inkernel)')
             kcg = lsprofcalltree.KCacheGrind(prof)
-            ofile = open('indexed_search.kcg', 'w')
-            kcg.output(ofile)
-            ofile.close()
+            with Path('indexed_search.kcg').open('w') as ofile:
+                kcg.output(ofile)
         elif doprofile:
             import hotshot
             import hotshot.stats

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -1,9 +1,10 @@
 """Benchmark to help choosing the best chunksize so as to optimize the access
 time in random lookups."""
 
-from time import perf_counter as clock
-import os
 import subprocess
+from pathlib import Path
+from time import perf_counter as clock
+
 import numpy as np
 import tables as tb
 
@@ -59,8 +60,8 @@ class DB:
         print(f"Array size (MB): {array_size:.3f}")
 
     def open_db(self, remove=0):
-        if remove and os.path.exists(self.filename):
-            os.remove(self.filename)
+        if remove and Path(self.filename).is_file():
+            Path(self.filename).unlink()
         con = tb.open_file(self.filename, 'a')
         return con
 

--- a/bench/open_close-bench.py
+++ b/bench/open_close-bench.py
@@ -9,7 +9,7 @@ import sys
 import getopt
 import pstats
 import cProfile as prof
-import subprocess
+from pathlib import Path
 from time import perf_counter as clock
 
 import tables as tb
@@ -20,10 +20,7 @@ niter = 1
 
 def show_stats(explain, tref):
     "Show the used memory"
-    # Build the command to obtain memory info (only for Linux 2.6.x)
-    cmd = "cat /proc/%s/status" % os.getpid()
-    sout = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-    for line in sout:
+    for line in Path('/proc/self/status').read_text().splitlines():
         if line.startswith("VmSize:"):
             vmsize = int(line.split()[1])
         elif line.startswith("VmRSS:"):
@@ -36,7 +33,6 @@ def show_stats(explain, tref):
             vmexe = int(line.split()[1])
         elif line.startswith("VmLib:"):
             vmlib = int(line.split()[1])
-    sout.close()
     print("WallClock time:", clock() - tref)
     print("Memory usage: ******* %s *******" % explain)
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -5,10 +5,10 @@ Francesc Alted
 
 """
 
-import os
 import math
 import subprocess
 import tempfile
+from pathlib import Path
 from time import perf_counter as clock
 import numpy as np
 import tables as tb
@@ -66,7 +66,7 @@ def bench(chunkshape, filters):
     # os.system("sync")
     print(f"Creation time: {clock() - t1:.3f}", end=' ')
     filesize = get_db_size(filename)
-    filesize_bytes = os.stat(filename).st_size
+    filesize_bytes = Path(filename).stat().st_size
     print("\t\tFile size: %d -- (%s)" % (filesize_bytes, filesize))
 
     # Read in sequential mode:

--- a/bench/plot-bar.py
+++ b/bench/plot-bar.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # a stacked bar plot with errorbars
 
+from pathlib import Path
 from pylab import *
 
 checks = ['open_close', 'only_open',
@@ -15,15 +16,13 @@ ind = arange(len(checks))    # the x locations for the groups
 
 def get_values(filename):
     values = []
-    f = open(filename)
-    for line in f:
+    for line in Path(filename).read_text().splitlines():
         if show_memory:
             if line.startswith('VmData:'):
                 values.append(float(line.split()[1]) / 1024)
         else:
             if line.startswith('WallClock time:'):
                 values.append(float(line.split(':')[1]))
-    f.close()
     return values
 
 

--- a/bench/poly.py
+++ b/bench/poly.py
@@ -6,8 +6,9 @@
 # Date: 2010-02-24
 #######################################################################
 
-import os
+from pathlib import Path
 from time import perf_counter as clock
+
 import numpy as np
 import tables as tb
 import numexpr as ne
@@ -39,9 +40,9 @@ def print_filesize(filename, clib=None, clevel=0):
 
     # os.system("sync")    # make sure that all data has been flushed to disk
     if isinstance(filename, list):
-        filesize_bytes = sum(os.stat(fname).st_size for fname in filename)
+        filesize_bytes = sum(Path(fname).stat().st_size for fname in filename)
     else:
-        filesize_bytes = os.stat(filename).st_size
+        filesize_bytes = Path(filename).stat().st_size
     print(
         f"\t\tTotal file sizes: {filesize_bytes} -- "
         f"({filesize_bytes / MB:.1f} MB)", end=' ')

--- a/bench/pytables-search-bench.py
+++ b/bench/pytables-search-bench.py
@@ -1,6 +1,7 @@
-import os
-from time import perf_counter as clock
 import random
+from pathlib import Path
+from time import perf_counter as clock
+
 import numpy as np
 import tables as tb
 
@@ -10,8 +11,8 @@ np.random.seed((19, 20))
 
 
 def open_db(filename, remove=0):
-    if remove and os.path.exists(filename):
-        os.remove(filename)
+    if remove and Path(filename).is_file():
+        Path(filename).unlink()
     con = tb.open_file(filename, 'a')
     return con
 

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 from time import perf_counter as clock
 import numpy as np
 import chararray
@@ -80,24 +80,22 @@ print()
 
 print("Printing in recarray original")
 print("------------------------------")
-f = open("test.out", "w")
-t1 = clock()
-f.write(str(r1))
-t2 = clock()
-origtime = t2 - t1
-f.close()
-os.unlink("test.out")
+with Path("test.out").open("w") as f:
+    t1 = clock()
+    f.write(str(r1))
+    t2 = clock()
+    origtime = t2 - t1
+Path("test.out").unlink()
 print(f"Print time: {origtime:.3f} Rows/s: {reclen / (origtime + delta):.0f}")
 print()
 print("Printing in recarray modified")
 print("------------------------------")
-f = open("test2.out", "w")
-t1 = clock()
-f.write(str(r2))
-t2 = clock()
-ttime = t2 - t1
-f.close()
-os.unlink("test2.out")
+with Path("test2.out").open("w") as f:
+    t1 = clock()
+    f.write(str(r2))
+    t2 = clock()
+    ttime = t2 - t1
+Path("test2.out").unlink()
 print(f"Print time: {ttime:.3f} Rows/s: {reclen / (ttime + delta):.0f}", end=' ')
 print(f" Speed-up: {origtime / ttime:.3f}")
 print()

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-import os
 import random
 import sys
 import warnings
+from pathlib import Path
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
@@ -118,7 +118,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
         f"Time for filling: {time1:.3f} Krows/s: {nrows / 1000 / time1:.3f}",
         end=' ')
     fileh.close()
-    size1 = os.stat(filename).st_size
+    size1 = Path(filename).stat().st_size
     print(f", File size: {size1 / 1024 / 1024:.3f} MB")
     fileh = tb.open_file(filename, mode="a", title="Searchsorted Benchmark",
                       filters=filters)
@@ -152,7 +152,7 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
     # Close the file
     fileh.close()
 
-    size2 = os.stat(filename).st_size - size1
+    size2 = Path(filename).stat().st_size - size1
     if index:
         print(f", Index size: {size2 / 1024 / 1024:.3f} MB")
     return (rowswritten, indexrows, rowsize, time1, time2,
@@ -494,7 +494,7 @@ if __name__ == "__main__":
                          shuffle=shuffle, fletcher32=fletcher32)
 
     # Create the benchfile (if needed)
-    if not os.path.exists(bfile):
+    if not Path(bfile).exists():
         createNewBenchFile(bfile, verbose)
 
     if testwrite:

--- a/bench/split-file.py
+++ b/bench/split-file.py
@@ -7,12 +7,12 @@ Usage: python split-file.py prefix filename
 """
 
 import sys
+from pathlib import Path
 
 prefix = sys.argv[1]
 filename = sys.argv[2]
-f = open(filename)
 sf = None
-for line in f:
+for line in Path(filename).read_text().splitlines():
     if line.startswith('Processing database:'):
         if sf:
             sf.close()
@@ -37,4 +37,3 @@ for line in f:
         sf = file(sfilename, 'a')
     if sf:
         sf.write(line)
-f.close()

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
-import sqlite
-import random
-import sys
 import os
+import random
+import sqlite3
+import sys
+from pathlib import Path
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
@@ -116,7 +117,7 @@ CREATE INDEX ivar3 ON small(var3);
         instd.write(CREATESTD)
         instd.close()
 
-    conn = sqlite.connect(dbfile)
+    conn = sqlite3.connect(dbfile)
     cursor = conn.cursor()
     if indexmode == "standard":
         place_holders = ",".join(['%s'] * 3)
@@ -151,7 +152,7 @@ CREATE INDEX ivar3 ON small(var3);
         t1 = clock() - time1
         tcpu1 = cpuclock() - cpu1
         rowsecf = nrows / t1
-        size1 = os.stat(dbfile).st_size
+        size1 = Path(dbfile).stat().st_size
         print(f"******** Results for writing nrows = {nrows} *********")
         print(f"Insert time: {t1:.5f}, KRows/s: {nrows / 1000 / t1:.3f}")
         print(f", File size: {size1 / 1024 / 1024:.3f} MB")
@@ -171,7 +172,7 @@ CREATE INDEX ivar3 ON small(var3);
         tcpu2 = cpuclock() - cpu1
         rowseci = nrows / t2
         print(f"Index time: {t2:.5f}, IKRows/s: {nrows / 1000 / t2:.3f}")
-        size2 = os.stat(dbfile).st_size - size1
+        size2 = Path(dbfile).stat().st_size - size1
         print(f", Final size with index: {size2 / 1024 / 1024:.3f} MB")
 
     conn.close()
@@ -202,7 +203,7 @@ CREATE INDEX ivar3 ON small(var3);
 
 def readFile(dbfile, nrows, indexmode, heavy, dselect, bfile, riter):
     # Connect to the database.
-    conn = sqlite.connect(db=dbfile, mode=755)
+    conn = sqlite3.connect(db=dbfile, mode=755)
     # Obtain a cursor
     cursor = conn.cursor()
 
@@ -436,7 +437,7 @@ if __name__ == "__main__":
         nrows -= 1  # the worst case
 
     # Create the benchfile (if needed)
-    if not os.path.exists(bfile):
+    if not Path(bfile).exists():
         createNewBenchFile(bfile, verbose)
 
     if testwrite:

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from time import perf_counter as clock
 import numpy as np
 import random
@@ -42,8 +42,8 @@ def int_generator_slow(nrows):
 
 
 def open_db(filename, remove=0):
-    if remove and os.path.exists(filename):
-        os.remove(filename)
+    if remove and Path(filename).is_file():
+        Path(filename).unlink()
     con = sqlite.connect(filename)
     cur = con.cursor()
     return con, cur

--- a/bench/widetree.py
+++ b/bench/widetree.py
@@ -2,8 +2,8 @@ import hotshot
 import hotshot.stats
 
 import unittest
-import os
 import tempfile
+from pathlib import Path
 from time import perf_counter as clock
 
 import tables as tb
@@ -103,7 +103,7 @@ class WideTreeTestCase(unittest.TestCase):
         # Close the file
         fileh.close()
         # Then, delete the file
-        os.remove(file)
+        Path(file).unlink()
 
 #----------------------------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,6 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+from pathlib import Path
 
 
 # -- Project information -----------------------------------------------------
@@ -22,7 +23,7 @@ copyright = '2011–2021, PyTables maintainers'
 author = 'PyTables maintainers'
 
 # The short X.Y version
-VERSION = open('../../VERSION').read().strip()
+VERSION = (Path(__file__).parent.parent.parent / 'VERSION').read_text().strip()
 version = VERSION
 
 # The full version, including alpha/beta/rc tags

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -6,9 +6,9 @@ import sys
 import queue
 
 import multiprocessing
-import os
 import random
 import time
+from pathlib import Path
 
 import numpy as np
 import tables as tb
@@ -174,6 +174,6 @@ if __name__ == '__main__':
         print()
         print(f'contents of log file {output_file}')
         print(open(output_file).read())
-        os.remove(output_file)
+        Path(output_file).unlink()
 
-    os.remove('test.h5')
+    Path('test.h5').unlink()

--- a/examples/play-with-enums.py
+++ b/examples/play-with-enums.py
@@ -93,6 +93,6 @@ for (d1, d2) in earr:
     print("From %s to %s (%d days)." % (wdays(d1), wdays(d2), d2 - d1 + 1))
 
 COMMENT("Close the PyTables file and remove it.")
-import os
+from pathlib import Path
 h5f.close()
-os.remove('enum.h5')
+Path('enum.h5').unlink()

--- a/examples/simple_threading.py
+++ b/examples/simple_threading.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import math
-import os
 import queue
 import threading
+from pathlib import Path
 
 import numpy as np
 import tables as tb
@@ -58,7 +58,7 @@ def run(filename, path, inqueue, outqueue):
 
 def main():
     # generate the test data
-    if not os.path.exists(FILENAME):
+    if not Path(FILENAME).exists():
         create_test_file(FILENAME)
 
     threads = []

--- a/examples/split.py
+++ b/examples/split.py
@@ -5,16 +5,17 @@ the raw data file in a subdirectory.
 
 """
 
-import os
 import errno
+from pathlib import Path
+
 import numpy as np
 import tables as tb
 
 FNAME = "split"
 DRIVER = "H5FD_SPLIT"
-RAW_DIR = "raw"
+RAW_DIR = Path(__file__).with_name("raw")
 DRIVER_PROPS = {
-    "driver_split_raw_ext": os.path.join(RAW_DIR, "%s-r.h5")
+    "driver_split_raw_ext": str(RAW_DIR / "%s-r.h5")
 }
 DATA_SHAPE = (2, 10)
 
@@ -24,7 +25,7 @@ class FooBar(tb.IsDescription):
     data = tb.Float32Col(shape=DATA_SHAPE)
 
 try:
-    os.mkdir(RAW_DIR)
+    RAW_DIR.mkdir()
 except OSError as e:
     if e.errno == errno.EEXIST:
         pass

--- a/examples/threading_monkeypatch.py
+++ b/examples/threading_monkeypatch.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 import math
-import os
 import queue
 import functools
 import threading
+from pathlib import Path
 
 import numpy as np
 import tables as tb
@@ -92,7 +92,7 @@ def run(filename, path, inqueue, outqueue):
 
 def main():
     # generate the test data
-    if not os.path.exists(FILENAME):
+    if not Path(FILENAME).exists():
         create_test_file(FILENAME)
 
     threads = []

--- a/tables/file.py
+++ b/tables/file.py
@@ -19,11 +19,11 @@ nodes.
 """
 
 import datetime
-import os
 import sys
 import weakref
 import warnings
 from collections import defaultdict
+from pathlib import Path
 
 import numexpr as ne
 import numpy as np
@@ -1961,7 +1961,7 @@ class File(hdf5extension.File):
         self._check_open()
 
         # Check that we are not treading our own shoes
-        if os.path.abspath(self.filename) == os.path.abspath(dstfilename):
+        if Path(self.filename).resolve() == Path(dstfilename).resolve():
             raise OSError("You cannot copy a file over itself")
 
         # Compute default arguments.
@@ -1976,10 +1976,11 @@ class File(hdf5extension.File):
         copyuserattrs = kwargs.get('copyuserattrs', True)
         title = kwargs.pop('title', self.title)
 
-        if os.path.isfile(dstfilename) and not overwrite:
-            raise OSError(("file ``%s`` already exists; "
-                           "you may want to use the ``overwrite`` "
-                           "argument") % dstfilename)
+        if Path(dstfilename).is_file() and not overwrite:
+            raise OSError(
+                f"file ``{dstfilename}`` already exists; you may want to "
+                f"use the ``overwrite`` argument"
+            )
 
         # Create destination file, overwriting it.
         dstfileh = open_file(
@@ -2786,7 +2787,7 @@ class File(hdf5extension.File):
         # Print all the nodes (Group and Leaf objects) on object tree
         try:
             date = datetime.datetime.fromtimestamp(
-                os.stat(self.filename).st_mtime, datetime.timezone.utc
+                Path(self.filename).stat().st_mtime, datetime.timezone.utc
             ).isoformat(timespec='seconds')
         except OSError:
             # in-memory file

--- a/tables/index.py
+++ b/tables/index.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import warnings
 
+from pathlib import Path
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
@@ -1134,7 +1135,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             print("Deleting temporaries...")
         self.tmp = None
         self.tmpfile.close()
-        os.remove(self.tmpfilename)
+        Path(self.tmpfilename).unlink()
         self.tmpfilename = None
 
         # The optimization process has finished, and the index is ok now

--- a/tables/link.py
+++ b/tables/link.py
@@ -25,8 +25,10 @@ Misc variables:
 
 """
 
-import os
+from pathlib import Path
+
 import tables as tb
+
 from . import linkextension
 from .node import Node
 from .utils import lazyattr
@@ -373,11 +375,10 @@ class ExternalLink(linkextension.ExternalLink, Link):
 
         filename, target = self._get_filename_node()
 
-        if not os.path.isabs(filename):
+        if not Path(filename).is_absolute():
             # Resolve the external link with respect to the this
             # file's directory.  See #306.
-            base_directory = os.path.dirname(self._v_file.filename)
-            filename = os.path.join(base_directory, filename)
+            filename = str(Path(self._v_file.filename).with_name(filename))
 
         if self.extfile is None or not self.extfile.isopen:
             self.extfile = tb.open_file(filename, **kwargs)

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -12,10 +12,10 @@
 are PEP 8 compliant.
 
 """
-import os
 import re
 import sys
 import argparse
+from pathlib import Path
 
 old2newnames = dict([
     # from __init__.py
@@ -504,10 +504,9 @@ def main():
     parser.add_argument('filename', help='path to input file.')
     ns = parser.parse_args()
 
-    if not os.path.isfile(ns.filename):
+    if not Path(ns.filename).is_file():
         sys.exit(f'file {ns.filename!r} not found')
-    with open(ns.filename) as f:
-        src = f.read()
+    src = Path(ns.filename).read_text()
 
     subs, repl = make_subs(ns)
     targ = subs.sub(repl, src)
@@ -516,8 +515,7 @@ def main():
     if ns.output is None:
         sys.stdout.write(targ)
     else:
-        with open(ns.output, 'w') as f:
-            f.write(targ)
+        Path(ns.output).write_text(targ)
 
 if __name__ == '__main__':
     main()

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -15,9 +15,9 @@ Pass the flag -h to this for help on usage.
 """
 
 import argparse
-import os
 import sys
 import warnings
+from pathlib import Path
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
@@ -99,7 +99,7 @@ def copy_leaf(srcfile, dstfile, srcnode, dstnode, title,
     if dstleaf == "":
         dstleaf = srcnode.name
     # Check whether the destination group exists or not
-    if os.path.isfile(dstfile) and not overwritefile:
+    if Path(dstfile).is_file() and not overwritefile:
         dstfileh = tb.open_file(dstfile, 'a',
                                 pytables_sys_attrs=createsysattrs,
                                 allow_padding=allow_padding)
@@ -185,7 +185,7 @@ def copy_children(srcfile, dstfile, srcgroup, dstgroup, title,
 
     created_dstgroup = False
     # Check whether the destination group exists or not
-    if os.path.isfile(dstfile) and not overwritefile:
+    if Path(dstfile).is_file() and not overwritefile:
         dstfileh = tb.open_file(dstfile, 'a',
                                 pytables_sys_attrs=createsysattrs,
                                 allow_padding=allow_padding)

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -18,6 +18,7 @@ import os
 import argparse
 from collections import defaultdict, deque
 import warnings
+from pathlib import Path
 
 import numpy as np
 import tables as tb
@@ -342,7 +343,7 @@ def get_tree_str(f, where='/', max_depth=-1, print_class=True,
 
     if print_total:
         avg_ratio = total_on_disk / total_in_mem
-        fsize = os.stat(f.filename).st_size
+        fsize = Path(f.filename).stat().st_size
 
         out_str += '-' * 60 + '\n'
         out_str += 'Total branch leaves:    %i\n' % total_items
@@ -441,7 +442,7 @@ def bytes2human(use_si_units=False):
 
 
 def make_test_file(prefix='/tmp'):
-    f = tb.open_file(os.path.join(prefix, 'test_pttree.hdf5'), 'w')
+    f = tb.open_file(str(Path(prefix) / 'test_pttree.hdf5'), 'w')
 
     g1 = f.create_group('/', 'group1')
     g1a = f.create_group(g1, 'group1a')

--- a/tables/table.py
+++ b/tables/table.py
@@ -13,9 +13,9 @@
 import functools
 import math
 import operator
-import os
 import sys
 import warnings
+from pathlib import Path
 
 from time import perf_counter as clock
 
@@ -3573,11 +3573,12 @@ class Column:
         if filters is None:
             filters = default_index_filters
         if tmp_dir is None:
-            tmp_dir = os.path.dirname(self._table_file.filename)
+            tmp_dir = str(Path(self._table_file.filename).parent)
         else:
-            if not os.path.isdir(tmp_dir):
-                raise ValueError("Temporary directory '%s' does not exist" %
-                                 tmp_dir)
+            if not Path(tmp_dir).is_dir():
+                raise ValueError(
+                    f"Temporary directory '{tmp_dir}' does not exist"
+                )
         if (_blocksizes is not None and
                 (not isinstance(_blocksizes, tuple) or len(_blocksizes) != 4)):
             raise ValueError("_blocksizes must be a tuple with exactly 4 "

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from time import perf_counter as clock
 
 import tables as tb
@@ -10,21 +10,19 @@ trel = tref
 def show_mem(explain):
     global tref, trel
 
-    filename = "/proc/%s/status" % os.getpid()
-    with open(filename) as fd:
-        for line in fd:
-            if line.startswith("VmSize:"):
-                vmsize = int(line.split()[1])
-            elif line.startswith("VmRSS:"):
-                vmrss = int(line.split()[1])
-            elif line.startswith("VmData:"):
-                vmdata = int(line.split()[1])
-            elif line.startswith("VmStk:"):
-                vmstk = int(line.split()[1])
-            elif line.startswith("VmExe:"):
-                vmexe = int(line.split()[1])
-            elif line.startswith("VmLib:"):
-                vmlib = int(line.split()[1])
+    for line in Path(f"/proc/self/status").read_text().splitlines():
+        if line.startswith("VmSize:"):
+            vmsize = int(line.split()[1])
+        elif line.startswith("VmRSS:"):
+            vmrss = int(line.split()[1])
+        elif line.startswith("VmData:"):
+            vmdata = int(line.split()[1])
+        elif line.startswith("VmStk:"):
+            vmstk = int(line.split()[1])
+        elif line.startswith("VmExe:"):
+            vmexe = int(line.split()[1])
+        elif line.startswith("VmLib:"):
+            vmlib = int(line.split()[1])
 
     print("\nMemory usage: ******* %s *******" % explain)
     print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -10,12 +10,12 @@
 
 """Utilities for PyTables' test suites."""
 
-import os
 import re
 import sys
 import locale
 import platform
 import tempfile
+from pathlib import Path
 from time import perf_counter as clock
 from distutils.version import LooseVersion
 
@@ -331,7 +331,7 @@ class TempFileMixin:
 
         self.h5file.close()
         self.h5file = None
-        os.remove(self.h5fname)   # comment this for debugging purposes only
+        Path(self.h5fname).unlink()   # comment this for debugging purposes only
         super().tearDown()
 
     def _reopen(self, mode='r', **kwargs):
@@ -355,7 +355,7 @@ class ShowMemTime(PyTablesTestCase):
         """Showing memory and time consumption."""
 
         # Obtain memory info (only for Linux 2.6.x)
-        for line in open("/proc/self/status"):
+        for line in Path("/proc/self/status").read_text().splitlines():
             if line.startswith("VmSize:"):
                 vmsize = int(line.split()[1])
             elif line.startswith("VmRSS:"):

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -1,6 +1,6 @@
-import os
 import sys
 import tempfile
+from pathlib import Path
 
 import numpy as np
 import tables as tb
@@ -95,7 +95,7 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertTrue(common.allequal(a, b))
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def write_read_out_arg(self, testarray):
         a = testarray
@@ -148,7 +148,7 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertTrue(common.allequal(a, b))
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def write_read_atom_shape_args(self, testarray):
         a = testarray
@@ -242,7 +242,7 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertTrue(common.allequal(a, b))
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def setup00_char(self):
         """Data integrity during recovery (character objects)"""
@@ -290,7 +290,7 @@ class BasicTestCase(common.PyTablesTestCase):
                     self.assertIn(type(b), [list, np.ndarray])
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def test00b_char_out_arg(self):
         """Data integrity during recovery (string objects)"""
@@ -315,7 +315,7 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertIsInstance(b, np.ndarray)
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def test00b_char_atom_shape_args(self):
         """Data integrity during recovery (string objects)"""
@@ -354,7 +354,7 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertIsInstance(b, np.ndarray)
         finally:
             # Then, delete the file
-            os.remove(filename)
+            Path(filename).unlink()
 
     def setup01_char_nc(self):
         """Data integrity during recovery (non-contiguous character objects)"""
@@ -2391,7 +2391,7 @@ class CopyNativeHDF5MDAtom(common.PyTablesTestCase):
     def tearDown(self):
         self.h5file.close()
         self.copyh.close()
-        os.remove(self.copy)
+        Path(self.copy).unlink()
         super().tearDown()
 
     def test01_copy(self):

--- a/tables/tests/test_backcompat.py
+++ b/tables/tests/test_backcompat.py
@@ -1,7 +1,7 @@
-import os
 import shutil
 import tempfile
 import warnings
+from pathlib import Path
 
 import numpy as np
 
@@ -191,7 +191,7 @@ class OldFlavorsTestCase01(common.PyTablesTestCase):
                 self.assertEqual(h5file.root.vlarray1copy.flavor, 'numeric')
                 self.assertEqual(h5file.root.vlarray2copy.flavor, 'python')
         finally:
-            os.remove(tmpfile)
+            Path(tmpfile).unlink()
 
 
 class OldFlavorsTestCase02(common.PyTablesTestCase):

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
@@ -1132,7 +1132,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         self.create_array(complevel)
         self.array[:] = 1
         self.h5file.flush()
-        file_size = os.stat(self.h5fname).st_size
+        file_size = Path(self.h5fname).stat().st_size
         self.assertTrue(
             abs(self.array.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertTrue(self.array.size_on_disk < self.array.size_in_memory)
@@ -1144,7 +1144,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         self.create_array(complevel)
         self.array[:] = np.random.randint(0, 1e6, self.array_size)
         self.h5file.flush()
-        file_size = os.stat(self.h5fname).st_size
+        file_size = Path(self.h5fname).stat().st_size
         self.assertTrue(
             abs(self.array.size_on_disk - file_size) <= self.hdf_overhead)
 

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
@@ -1262,7 +1262,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         complevel = 1
         self.create_array(complevel)
         self.array.append([tuple(range(10))] * self.chunkshape[0] * 10)
-        file_size = os.stat(self.h5fname).st_size
+        file_size = Path(self.h5fname).stat().st_size
         self.assertTrue(
             abs(self.array.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertEqual(self.array.size_in_memory, 10 * 1000 * 10 * 4)

--- a/tables/tests/test_hdf5compat.py
+++ b/tables/tests/test_hdf5compat.py
@@ -10,9 +10,9 @@
 
 """Test module for compatibility with plain HDF files."""
 
-import os
 import shutil
 import tempfile
+from pathlib import Path
 
 import numpy as np
 
@@ -266,7 +266,7 @@ class ContiguousCompoundAppendTestCase(common.TestFileMixin, common.PyTablesTest
         self.assertRaises(tb.HDF5ExtError, tbl.row.append)
         # Remove the file copy
         self.h5file.close()  # Close the handler first
-        os.remove(h5fname_copy)
+        Path(h5fname_copy).unlink()
 
 
 class ExtendibleTestCase(common.TestFileMixin, common.PyTablesTestCase):

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -1,6 +1,6 @@
-import os
 import copy
 import tempfile
+from pathlib import Path
 
 import numpy as np
 
@@ -669,7 +669,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             distance = tb.FloatCol(pos=1)
 
         # Delete the old temporal file
-        os.remove(self.h5fname)
+        Path(self.h5fname).unlink()
 
         self.h5fname = tempfile.mktemp(".h5")
         self.h5file = tb.open_file(self.h5fname, mode='w')

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -1,6 +1,6 @@
-import os
 import random
 import tempfile
+from pathlib import Path
 
 import numpy as np
 
@@ -3168,8 +3168,8 @@ class LastRowReuseBuffers(common.PyTablesTestCase):
     def tearDown(self):
         if self.h5file is not None:
             self.h5file.close()
-        if os.path.exists(self.h5fname):
-            os.remove(self.h5fname)
+        if Path(self.h5fname).is_file():
+            Path(self.h5fname).unlink()
         super().tearDown()
 
     def test00_lrucache(self):
@@ -3372,8 +3372,8 @@ class SideEffectNumPyQuicksort(common.PyTablesTestCase):
         self.assertEqual(len(npvals), len(indexed))
 
         h5.close()
-        if os.path.exists(tmp_file):
-            os.remove(tmp_file)
+        if Path(tmp_file).is_file():
+            Path(tmp_file).unlink()
 
 
 # -----------------------------

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -10,9 +10,9 @@
 
 """Test module for diferent kind of links under PyTables."""
 
-import os
 import re
 import tempfile
+from pathlib import Path
 
 import tables as tb
 from tables.tests import common
@@ -300,7 +300,7 @@ class SoftLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if common.verbose:
             print("Copied link:", lgroup1_, 'in:', lgroup1_._v_file.filename)
         h5f.close()
-        os.remove(fname)
+        Path(fname).unlink()
 
     def test11_direct_attribute_access(self):
         """Check direct get/set attributes via link-->target.attribute"""
@@ -384,7 +384,7 @@ class ExternalLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
         #    for handler in open_files.get_handlers_by_name(self.extfname):
         #        handler.close()
 
-        os.remove(extfname)   # comment this for debugging purposes only
+        Path(extfname).unlink()   # comment this for debugging purposes only
 
     def _createFile(self):
         self.h5file.create_array('/', 'arr1', [1, 2])
@@ -581,8 +581,8 @@ class ExternalLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
                     print("Copied link:", lgroup1_, 'in:',
                           lgroup1_._v_file.filename)
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
 
 def suite():

--- a/tables/tests/test_lists.py
+++ b/tables/tests/test_lists.py
@@ -1,5 +1,5 @@
-import os
 import tempfile
+from pathlib import Path
 
 import tables as tb
 from tables.tests import common
@@ -50,8 +50,8 @@ class BasicTestCase(common.PyTablesTestCase):
     def tearDown(self):
         if self.h5file is not None:
             self.h5file.close()
-        if os.path.exists(self.h5fname):
-            os.remove(self.h5fname)
+        if Path(self.h5fname).is_file():
+            Path(self.h5fname).unlink()
         super().tearDown()
 
     def test00_char(self):
@@ -126,8 +126,8 @@ class ExceptionTestCase(common.PyTablesTestCase):
     def tearDown(self):
         if self.h5file is not None:
             self.h5file.close()
-        if os.path.exists(self.h5fname):
-            os.remove(self.h5fname)
+        if Path(self.h5fname).is_file():
+            Path(self.h5fname).unlink()
         super().tearDown()
 
     def test00_char(self):

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -1,6 +1,6 @@
-import os
 import sys
 import tempfile
+from pathlib import Path
 
 import numpy as np
 
@@ -92,8 +92,8 @@ class BasicTestCase(common.PyTablesTestCase):
                 self.assertTrue(common.allequal(a, b, "numpy"))
         finally:
             # Then, delete the file
-            if os.path.exists(self.h5fname):
-                os.remove(self.h5fname)
+            if Path(self.h5fname).is_file():
+                Path(self.h5fname).unlink()
 
     def test00_char(self):
         """Data integrity during recovery (character objects)"""

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1,9 +1,9 @@
 import itertools
-import os
 import sys
 import tempfile
 import struct
 import platform
+from pathlib import Path
 
 import numpy as np
 
@@ -1908,7 +1908,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         complevel = 1
         self.create_table(complevel)
         self.table.append([tuple(range(10))] * self.chunkshape[0] * 10)
-        file_size = os.stat(self.h5fname).st_size
+        file_size = Path(self.h5fname).stat().st_size
         self.assertTrue(
             abs(self.table.size_on_disk - file_size) <= self.hdf_overhead)
         self.assertEqual(self.table.size_in_memory, 10 * 1000 * 10 * 4)
@@ -5610,8 +5610,8 @@ class WhereAppendTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 tbl2 = h5file2.root.test
                 tbl1.append_where(tbl2, 'id > 1')
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
     def test06_wholeTable(self):
         """Append whole table."""

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -5,6 +5,7 @@
 import hashlib
 import sys
 import time
+from pathlib import Path
 
 import tables as tb
 from tables.tests import common
@@ -143,12 +144,8 @@ class BitForBitTestCase(TrackTimesMixin, common.TempFileMixin, common.PyTablesTe
 
     def _get_digest(self, filename):
         md5 = hashlib.md5()
-        fd = open(filename, 'rb')
-
-        for data in fd:
+        for data in Path(filename).read_bytes():
             md5.update(data)
-
-        fd.close()
 
         hexdigest = md5.hexdigest()
 

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -1,7 +1,7 @@
-import os
 import sys
 import tempfile
 import warnings
+from pathlib import Path
 from time import perf_counter as clock
 
 import tables as tb
@@ -661,8 +661,8 @@ class DeepTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             self._check_tree(h5fname2)
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
     def test01b_copyDeepTree(self):
         """Copy of a large depth object tree with small node cache."""
@@ -681,8 +681,8 @@ class DeepTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             self._check_tree(h5fname2)
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
     def test01c_copyDeepTree(self):
         """Copy of a large depth object tree with no node cache."""
@@ -701,8 +701,8 @@ class DeepTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             self._check_tree(h5fname2)
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
     @common.unittest.skipUnless(common.heavy, 'only in heavy mode')
     def test01d_copyDeepTree(self):
@@ -723,8 +723,8 @@ class DeepTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             self._check_tree(h5fname2)
         finally:
-            if os.path.exists(h5fname2):
-                os.remove(h5fname2)
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
 
 class WideTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):


### PR DESCRIPTION
Replace all `os.path`/`open` calls with `pathlib.Path`. The changes are mostly local. A possibility of more global `Path` objects has to be investigated later.