### PR TITLE
Use lowercase "float64" as numpy dtype

### DIFF
--- a/bench/bsddb-table-bench.py
+++ b/bench/bsddb-table-bench.py
@@ -82,11 +82,11 @@ def createFile(filename, totalrows, recsize, verbose):
     # Get the record object associated with the new table
     if recsize == "big":
         isrec = Big()
-        arr = np.array(np.arange(32), type=np.Float64)
-        arr2 = np.array(np.arange(32), type=np.Float64)
+        arr = np.array(np.arange(32), type=np.float64)
+        arr2 = np.array(np.arange(32), type=np.float64)
     elif recsize == "medium":
         isrec = Medium()
-        arr = np.array(np.arange(2), type=np.Float64)
+        arr = np.array(np.arange(2), type=np.float64)
     else:
         isrec = Small()
     # print d
@@ -106,8 +106,8 @@ def createFile(filename, totalrows, recsize, verbose):
             #d['TDCcount'] = i % 256
             d['ADCcount'] = (i * 256) % (1 << 16)
             if recsize == "big":
-                #d.float1 = np.array([i]*32, np.Float64)
-                #d.float2 = np.array([i**2]*32, np.Float64)
+                #d.float1 = np.array([i]*32, np.float64)
+                #d.float2 = np.array([i**2]*32, np.float64)
                 arr[0] = 1.1
                 d['float1'] = arr
                 arr2[0] = 2.2

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -14,11 +14,11 @@ def flatten(l):
 
 
 def fill_arrays(start, stop):
-    col_i = numpy.arange(start, stop, type=numpy.Int32)
+    col_i = numpy.arange(start, stop, type=numpy.int32)
     if userandom:
         col_j = numpy.random.uniform(0, nrows, size=[stop - start])
     else:
-        col_j = numpy.array(col_i, type=numpy.Float64)
+        col_j = numpy.array(col_i, type=numpy.float64)
     return col_i, col_j
 
 # Generator for ensure pytables benchmark compatibility

--- a/bench/pytables-search-bench.py
+++ b/bench/pytables-search-bench.py
@@ -36,11 +36,11 @@ def create_db(filename, nrows):
         stop = (j + 1) * step
         if stop > nrows:
             stop = nrows
-        arr_f8 = np.arange(i, stop, type=np.Float64)
-        arr_i4 = np.arange(i, stop, type=np.Int32)
+        arr_f8 = np.arange(i, stop, type=np.float64)
+        arr_i4 = np.arange(i, stop, type=np.int32)
         if userandom:
             arr_f8 += np.random.normal(0, stop * scale, shape=[stop - i])
-            arr_i4 = np.array(arr_f8, type=np.Int32)
+            arr_i4 = np.array(arr_f8, type=np.int32)
         recarr = np.rec.fromarrays([arr_i4, arr_i4, arr_f8, arr_f8])
         table.append(recarr)
         j += 1

--- a/bench/recarray2-test.py
+++ b/bench/recarray2-test.py
@@ -21,7 +21,7 @@ delta = 0.000_001
 # Creation of recarrays objects for test
 x1 = np.array(np.arange(reclen))
 x2 = chararray.array(None, itemsize=7, shape=reclen)
-x3 = np.array(np.arange(reclen, reclen * 3, 2), np.Float64)
+x3 = np.array(np.arange(reclen, reclen * 3, 2), np.float64)
 r1 = recarray.fromarrays([x1, x2, x3], names='a,b,c')
 r2 = recarray2.fromarrays([x1, x2, x3], names='a,b,c')
 

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from tables import *
-import numpy as NA
+import numpy as np
 import struct
 import sys
 import shelve
@@ -44,8 +44,8 @@ class Medium(IsDescription):
 
 class Big(IsDescription):
     name = StringCol(itemsize=16)   # 16-character String
-    #float1 = Float64Col(shape=32, dflt=NA.arange(32))
-    #float2 = Float64Col(shape=32, dflt=NA.arange(32))
+    #float1 = Float64Col(shape=32, dflt=np.arange(32))
+    #float2 = Float64Col(shape=32, dflt=np.arange(32))
     float1 = Float64Col(shape=32, dflt=range(32))
     float2 = Float64Col(shape=32, dflt=[2.2] * 32)
     ADCcount = Int16Col()           # signed short integer
@@ -64,8 +64,8 @@ def createFile(filename, totalrows, recsize):
     # Get the record object associated with the new table
     if recsize == "big":
         d = Big()
-        arr = NA.array(NA.arange(32), type=NA.float64)
-        arr2 = NA.array(NA.arange(32), type=NA.float64)
+        arr = np.array(np.arange(32), type=np.float64)
+        arr2 = np.array(np.arange(32), type=np.float64)
     elif recsize == "medium":
         d = Medium()
     else:
@@ -86,15 +86,15 @@ def createFile(filename, totalrows, recsize):
                 #d.TDCcount = i % 256
                 d.ADCcount = (i * 256) % (1 << 16)
                 if recsize == "big":
-                    #d.float1 = NA.array([i]*32, NA.float64)
-                    #d.float2 = NA.array([i**2]*32, NA.float64)
+                    #d.float1 = np.array([i]*32, np.float64)
+                    #d.float2 = np.array([i**2]*32, np.float64)
                     arr[0] = 1.1
                     d.float1 = arr
                     arr2[0] = 2.2
                     d.float2 = arr2
                     pass
                 else:
-                    d.float1 = NA.array([i ** 2] * 2, NA.float64)
+                    d.float1 = np.array([i ** 2] * 2, np.float64)
                     #d.float1 = float(i)
                     #d.float2 = float(i)
                 d.grid_i = i

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -64,8 +64,8 @@ def createFile(filename, totalrows, recsize):
     # Get the record object associated with the new table
     if recsize == "big":
         d = Big()
-        arr = np.array(np.arange(32), type=np.float64)
-        arr2 = np.array(np.arange(32), type=np.float64)
+        arr = np.arange(32, dtype=np.float64)
+        arr2 = np.arange(32, dtype=np.float64)
     elif recsize == "medium":
         d = Medium()
     else:

--- a/bench/shelve-bench.py
+++ b/bench/shelve-bench.py
@@ -64,8 +64,8 @@ def createFile(filename, totalrows, recsize):
     # Get the record object associated with the new table
     if recsize == "big":
         d = Big()
-        arr = NA.array(NA.arange(32), type=NA.Float64)
-        arr2 = NA.array(NA.arange(32), type=NA.Float64)
+        arr = NA.array(NA.arange(32), type=NA.float64)
+        arr2 = NA.array(NA.arange(32), type=NA.float64)
     elif recsize == "medium":
         d = Medium()
     else:
@@ -86,15 +86,15 @@ def createFile(filename, totalrows, recsize):
                 #d.TDCcount = i % 256
                 d.ADCcount = (i * 256) % (1 << 16)
                 if recsize == "big":
-                    #d.float1 = NA.array([i]*32, NA.Float64)
-                    #d.float2 = NA.array([i**2]*32, NA.Float64)
+                    #d.float1 = NA.array([i]*32, NA.float64)
+                    #d.float2 = NA.array([i**2]*32, NA.float64)
                     arr[0] = 1.1
                     d.float1 = arr
                     arr2[0] = 2.2
                     d.float2 = arr2
                     pass
                 else:
-                    d.float1 = NA.array([i ** 2] * 2, NA.Float64)
+                    d.float1 = NA.array([i ** 2] * 2, NA.float64)
                     #d.float1 = float(i)
                     #d.float2 = float(i)
                 d.grid_i = i

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -137,10 +137,10 @@ CREATE INDEX ivar3 ON small(var3);
             if randomvalues:
                 var3 = np.random.uniform(minimum, maximum, shape=[j - i])
             else:
-                var3 = np.arange(i, j, type=np.Float64)
+                var3 = np.arange(i, j, type=np.float64)
                 if noise:
                     var3 += np.random.uniform(-3, 3, shape=[j - i])
-            var2 = np.array(var3, type=np.Int32)
+            var2 = np.array(var3, type=np.int32)
             var1 = np.array(None, shape=[j - i], dtype='s4')
             if not heavy:
                 for n in range(j - i):

--- a/doc/source/cookbook/custom_data_types.rst
+++ b/doc/source/cookbook/custom_data_types.rst
@@ -65,9 +65,8 @@ Submitted by Kevin R. Thornton.
 
 
     if __name__ == '__main__':
-        x = np.array(np.random.rand(100))
-        x=np.reshape(x,(50,2))
-        x.dtype=[('x',np.float),('y',np.float)]
+        x = np.random.rand(100).reshape(50,2)
+        x.dtype = [('x',float), ('y',float)]
         h5file = tables.open_file('tester.hdf5', 'w')
         mtab = h5file.createDerivedFromTable(h5file.root, 'random', x)
 

--- a/doc/source/usersguide/tutorials.rst
+++ b/doc/source/usersguide/tutorials.rst
@@ -1234,8 +1234,8 @@ can be passed to this method::
             particle['longi'] = 10 - i
 
             ########### Detectable errors start here. Play with them!
-            particle['pressure'] = np.array(i * np.arange(2 * 3)).reshape((2, 4))  # Incorrect
-            #particle['pressure'] = np.array(i * np.arange(2 * 3)).reshape((2, 3)) # Correct
+            particle['pressure'] = i * np.arange(2 * 4).reshape(2, 4)  # Incorrect
+            #particle['pressure'] = i * np.arange(2 * 3).reshape(2, 3) # Correct
             ########### End of errors
 
             particle['temperature'] = i ** 2     # Broadcasting

--- a/examples/array4.py
+++ b/examples/array4.py
@@ -8,7 +8,7 @@ fileh = tables.open_file(file, mode="w")
 # Get the root group
 group = fileh.root
 # Set the type codes to test
-dtypes = [np.int8, np.uint8, np.int16, np.int, np.float32, np.float]
+dtypes = [np.int8, np.uint8, np.int16, int, np.float32, float]
 i = 1
 for dtype in dtypes:
     # Create an array of dtype, with incrementally bigger ranges

--- a/examples/tutorial2.py
+++ b/examples/tutorial2.py
@@ -61,9 +61,8 @@ for tablename in ("TParticle1", "TParticle2", "TParticle3"):
         particle['lati'] = i
         particle['longi'] = 10 - i
         # Detectable errors start here. Play with them!
-        particle['pressure'] = np.array(
-            i * np.arange(2 * 3)).reshape((2, 4))  # Incorrect
-        # particle['pressure'] = array(i*arange(2*3)).reshape((2,3))  # Correct
+        particle['pressure'] = i * np.arange(2 * 4).reshape(2, 4) # Incorrect
+        # particle['pressure'] = i * arange(2 * 3).reshape(2, 3)  # Correct
         # End of errors
         particle['temperature'] = (i ** 2)     # Broadcasting
         # This injects the Record values

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -336,7 +336,7 @@ class Atom(metaclass=MetaAtom):
             Traceback (most recent call last):
             ...
             ValueError: unknown NumPy scalar type: 'S5'
-            >>> Atom.from_sctype('Float64')
+            >>> Atom.from_sctype('float64')
             Float64Atom(shape=(), dflt=0.0)
 
         """

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -1439,7 +1439,7 @@ cdef class Array(Leaf):
       chunkshapes = getshape(self.rank, self.dims_chunk)
 
     # object arrays should not be read directly into memory
-    if atom.dtype != numpy.object:
+    if atom.dtype != object:
       # Get the fill value
       dflts = numpy.zeros((), dtype=atom.dtype)
       fill_data = dflts.data

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -460,7 +460,6 @@ class TableReadTestCase(common.TempFileMixin, TestCase):
         for colname in table.colnames:
             numcol = table.read(field=colname)
             typecol = table.coltypes[colname]
-            #nctypecode = np.typeNA[numcol.dtype.char[0]]
             nctypecode = np.sctypeDict[numcol.dtype.char[0]]
             if typecol != "string":
                 if common.verbose:

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -179,7 +179,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.get_node("/vlarray1")
 
         # Get a numpy array of objects
-        rows = numpy.array(vlarray[:], dtype=numpy.object)
+        rows = numpy.array(vlarray[:], dtype=object)
 
         for slc in [0, numpy.array(1), 2, numpy.array([3]), [4]]:
             # Read the rows in slc

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -213,7 +213,7 @@ cdef str cstr_to_pystr(const char* cstring):
 import_array()
 
 # NaN-aware sorting with NaN as the greatest element
-# numpy.isNaN only takes floats, this should work for strings too
+# numpy.isnan only takes floats, this should work for strings too
 cpdef nan_aware_lt(a, b): return a < b or (b != b and a == a)
 cpdef nan_aware_le(a, b): return a <= b or b != b
 cpdef nan_aware_gt(a, b): return a > b or (a != a and b == b)


### PR DESCRIPTION
Float64 is gone with numpy 1.20, which causes doctests to fail
(https://bugzilla.redhat.com/show_bug.cgi?id=1914335).

>>> numpy.__version__
'1.19.4'
>>> [k for k in numpy.sctypeDict.keys() if str(k).lower().startswith('float')]
['float16', 'Float16', 'float32', 'Float32', 'float64', 'Float64', 'float128', 'Float128', 'float_', 'float']

>>> numpy.__version__
'1.20.0rc2'
>>> [k for k in numpy.sctypeDict.keys() if str(k).lower().startswith('float')]
['float16', 'float32', 'float64', 'float128', 'float_', 'float']