### PR TITLE
Run `apt-get update` before installing ubuntu packages

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,6 +13,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install APT packages
       run: |
+        sudo apt-get update
         sudo apt install libblosc-dev libbz2-dev libhdf5-dev liblz4-dev liblzo2-dev libsnappy-dev libzstd-dev zlib1g-dev
         sudo apt install python3-all-dev cython3 python3-setuptools python3-six python3-numpy python3-numexpr
         sudo apt install python3-numpydoc python3-sphinx python3-sphinx-rtd-theme python3-ipython


### PR DESCRIPTION
There was a failed run in #862:

```
 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 9598 kB in 0s (33.5 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The version on the server at that time was `http://security.ubuntu.com/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.2_amd64.deb`

This will update the packages index before the installation.