### PR TITLE
Use `import numpy as np` everywhere

### DIFF
--- a/bench/LRUcache-node-bench.py
+++ b/bench/LRUcache-node-bench.py
@@ -1,5 +1,5 @@
 import sys
-import numpy
+import numpy as np
 import tables
 from time import perf_counter as clock
 #import psyco
@@ -29,8 +29,7 @@ f = tables.open_file(filename)
 def iternodes():
 #     for a in f.root.NodeContainer:
 #         pass
-    indices = numpy.random.randn(nodespergroup * niter) * \
-        30 + nodespergroup / 2
+    indices = np.random.randn(nodespergroup * niter) * 30 + nodespergroup / 2
     indices = indices.astype('i4').clip(0, nodespergroup - 1)
     g = f.get_node("/", "NodeContainer")
     for i in indices:

--- a/bench/cacheout.py
+++ b/bench/cacheout.py
@@ -1,7 +1,7 @@
 # Program to clean out the filesystem cache
-import numpy
+import numpy as np
 
-a = numpy.arange(1000 * 100 * 125, dtype='f8')  # 100 MB of RAM
+a = np.arange(1000 * 100 * 125, dtype='f8')  # 100 MB of RAM
 b = a * 3  # Another 100 MB
 # delete the reference to the booked memory
 del a

--- a/bench/chunkshape-bench.py
+++ b/bench/chunkshape-bench.py
@@ -3,7 +3,7 @@
 # You need at least PyTables 2.1 to run this!
 # F. Alted
 
-import numpy
+import numpy as np
 import tables
 from time import perf_counter as clock
 
@@ -19,7 +19,7 @@ print("Chunkshape for original array:", a.chunkshape)
 
 # Fill the EArray
 t1 = clock()
-zeros = numpy.zeros((dim1, 1), dtype="float64")
+zeros = np.zeros((dim1, 1), dtype="float64")
 for i in range(dim2):
     a.append(zeros)
 tcre = clock() - t1

--- a/bench/chunkshape-testing.py
+++ b/bench/chunkshape-testing.py
@@ -2,7 +2,7 @@
 
 """Simple benchmark for testing chunkshapes and nrowsinbuf."""
 
-import numpy
+import numpy as np
 import tables
 from time import perf_counter as clock
 
@@ -11,7 +11,7 @@ N = 2000
 M = 30
 complevel = 1
 
-recarray = numpy.empty(shape=2, dtype='(2,2,2)i4,(2,3,3)f8,i4,i8')
+recarray = np.empty(shape=2, dtype='(2,2,2)i4,(2,3,3)f8,i4,i8')
 
 f = tables.open_file("chunkshape.h5", mode="w")
 
@@ -33,7 +33,7 @@ c1 = f.create_carray(f1.root, 'cfield1',
                      "scalar int32 carray", tables.Filters(complevel=0))
 
 t1 = clock()
-c1[:] = numpy.empty(shape=(L, 1, 1), dtype="int32")
+c1[:] = np.empty(shape=(L, 1, 1), dtype="int32")
 print("carray1 populate time:", clock() - t1)
 f1.close()
 
@@ -44,7 +44,7 @@ c2 = f.create_carray(f2.root, 'cfield2',
                      "scalar int32 carray", tables.Filters(complevel))
 
 t1 = clock()
-c2[:] = numpy.empty(shape=(L, 1, 1), dtype="int32")
+c2[:] = np.empty(shape=(L, 1, 1), dtype="int32")
 print("carray2 populate time:", clock() - t1)
 f2.close()
 
@@ -55,7 +55,7 @@ e0 = f.create_earray(f0.root, 'efield0',
                      expectedrows=N)
 
 t1 = clock()
-e0.append(numpy.empty(shape=(N, L, M), dtype="int32"))
+e0.append(np.empty(shape=(N, L, M), dtype="int32"))
 print("earray0 populate time:", clock() - t1)
 f0.close()
 
@@ -66,7 +66,7 @@ e1 = f.create_earray(f1.root, 'efield1',
                      expectedrows=N)
 
 t1 = clock()
-e1.append(numpy.empty(shape=(L, N, M), dtype="int32"))
+e1.append(np.empty(shape=(L, N, M), dtype="int32"))
 print("earray1 populate time:", clock() - t1)
 f1.close()
 
@@ -78,7 +78,7 @@ e2 = f.create_earray(f2.root, 'efield2',
                      expectedrows=N)
 
 t1 = clock()
-e2.append(numpy.empty(shape=(L, M, N), dtype="int32"))
+e2.append(np.empty(shape=(L, M, N), dtype="int32"))
 print("earray2 populate time:", clock() - t1)
 f2.close()
 

--- a/bench/create-large-number-objects.py
+++ b/bench/create-large-number-objects.py
@@ -1,7 +1,7 @@
 "This creates an HDF5 file with a potentially large number of objects"
 
 import sys
-import numpy
+import numpy as np
 import tables
 
 filename = sys.argv[1]
@@ -21,7 +21,7 @@ nlevels, ngroups, ndatasets = (3, 10, 100)
 #nlevels, ngroups, ndatasets = (30, 10, 10)
 
 # Create an Array to save on disk
-a = numpy.array([-1, 2, 4], numpy.int16)
+a = np.array([-1, 2, 4], np.int16)
 
 group = fileh.root
 group2 = fileh.root

--- a/bench/deep-tree-h5py.py
+++ b/bench/deep-tree-h5py.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from time import perf_counter as clock
 import random
-import numpy
+import numpy as np
 import h5py
 
 random.seed(2)
@@ -38,7 +38,7 @@ def show_stats(explain, tref):
 
 def populate(f, nlevels):
     g = f
-    arr = numpy.zeros((10,), "f4")
+    arr = np.zeros((10,), "f4")
     for i in range(nlevels):
         g["DS1"] = arr
         g["DS2"] = arr

--- a/bench/deep-tree.py
+++ b/bench/deep-tree.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 from time import perf_counter as clock
 import random
-#import numpy
 import tables
 
 random.seed(2)

--- a/bench/indexed_search.py
+++ b/bench/indexed_search.py
@@ -1,7 +1,7 @@
 from time import perf_counter as clock
 import subprocess
 import random
-import numpy
+import numpy as np
 
 # Constants
 
@@ -80,7 +80,7 @@ class DB:
             r = "[REP] "
         else:
             r = "[NOREP] "
-        ltimes = numpy.array(ltimes)
+        ltimes = np.array(ltimes)
         ntimes = len(ltimes)
         qtime1 = ltimes[0]  # First measured time
         ctimes = ltimes[1:COLDCACHE]
@@ -90,7 +90,7 @@ class DB:
         if verbose:
             print("Times for cold cache:\n", ctimes)
             # print "Times for warm cache:\n", wtimes
-            hist1, hist2 = numpy.histogram(wtimes)
+            hist1, hist2 = np.histogram(wtimes)
             print(f"Histogram for warm cache: {hist1}\n{hist2}")
         print(f"{r}1st query time for {colname}: {qtime1:.{prec}f}")
         print(f"{r}Query time for {colname} (cold cache): "
@@ -106,12 +106,11 @@ class DB:
         print(f"Full size (MB): {table_size + indexes_size:.3f}")
 
     def fill_arrays(self, start, stop):
-        arr_f8 = numpy.arange(start, stop, dtype='float64')
-        arr_i4 = numpy.arange(start, stop, dtype='int32')
+        arr_f8 = np.arange(start, stop, dtype='float64')
+        arr_i4 = np.arange(start, stop, dtype='int32')
         if self.userandom:
-            arr_f8 += numpy.random.normal(0, stop * self.scale,
-                                          size=stop - start)
-            arr_i4 = numpy.array(arr_f8, dtype='int32')
+            arr_f8 += np.random.normal(0, stop * self.scale, size=stop - start)
+            arr_i4 = np.array(arr_f8, dtype='int32')
         return arr_i4, arr_f8
 
     def create_db(self, dtype, kind, optlevel, verbose):
@@ -152,12 +151,12 @@ class DB:
             reg_cols = ['col1', 'col3']
             idx_cols = ['col2', 'col4']
         if avoidfscache:
-            rseed = int(numpy.random.randint(self.nrows))
+            rseed = int(np.random.randint(self.nrows))
         else:
             rseed = 19
         # Query for non-indexed columns
-        numpy.random.seed(rseed)
-        base = numpy.random.randint(self.nrows)
+        np.random.seed(rseed)
+        base = np.random.randint(self.nrows)
         if not onlyidxquery:
             for colname in reg_cols:
                 ltimes = []
@@ -177,8 +176,8 @@ class DB:
         if not onlynonidxquery:
             for colname in idx_cols:
                 ltimes = []
-                numpy.random.seed(rseed)
-                rndbase = numpy.random.randint(self.nrows, size=niter)
+                np.random.seed(rseed)
+                rndbase = np.random.randint(self.nrows, size=niter)
                 # First, non-repeated queries
                 for i in range(niter):
                     base = rndbase[i]
@@ -374,7 +373,7 @@ if __name__ == "__main__":
 
     if not avoidfscache:
         # in order to always generate the same random sequence
-        numpy.random.seed(20)
+        np.random.seed(20)
 
     if verbose:
         if userandom:

--- a/bench/keysort.py
+++ b/bench/keysort.py
@@ -1,17 +1,17 @@
 from tables.indexesextension import keysort
-import numpy
+import numpy as np
 from time import perf_counter as clock
 
 N = 1000 * 1000
-rnd = numpy.random.randint(N, size=N)
+rnd = np.random.randint(N, size=N)
 
 for dtype1 in ('S6', 'b1',
                'i1', 'i2', 'i4', 'i8',
                'u1', 'u2', 'u4', 'u8', 'f4', 'f8'):
     for dtype2 in ('u4', 'i8'):
         print("dtype array1, array2-->", dtype1, dtype2)
-        a = numpy.array(rnd, dtype1)
-        b = numpy.arange(N, dtype=dtype2)
+        a = np.array(rnd, dtype1)
+        b = np.arange(N, dtype=dtype2)
         c = a.copy()
 
         t1 = clock()
@@ -27,6 +27,6 @@ for dtype1 in ('S6', 'b1',
         keysort(a, b)
         tks = clock() - t1
         print("keysort time-->", tks, "    {:.2f}x".format(tref / tks))
-        assert numpy.alltrue(a == e)
+        assert np.alltrue(a == e)
         #assert numpy.alltrue(b == d)
-        assert numpy.alltrue(f == d)
+        assert np.alltrue(f == d)

--- a/bench/lookup_bench.py
+++ b/bench/lookup_bench.py
@@ -4,7 +4,7 @@ time in random lookups."""
 from time import perf_counter as clock
 import os
 import subprocess
-import numpy
+import numpy as np
 import tables
 
 # Constants
@@ -100,16 +100,16 @@ class DB:
         earray.flush()
 
     def get_array(self, start, stop):
-        arr = numpy.arange(start, stop, dtype='float')
+        arr = np.arange(start, stop, dtype='float')
         if self.userandom:
-            arr += numpy.random.normal(0, stop * self.scale, size=stop - start)
+            arr += np.random.normal(0, stop * self.scale, size=stop - start)
         arr = arr.astype(self.dtype)
         return arr
 
     def print_qtime(self, ltimes):
-        ltimes = numpy.array(ltimes)
+        ltimes = np.array(ltimes)
         print("Raw query times:\n", ltimes)
-        print("Histogram times:\n", numpy.histogram(ltimes[1:]))
+        print("Histogram times:\n", np.histogram(ltimes[1:]))
         ntimes = len(ltimes)
         qtime1 = ltimes[0]  # First measured time
         if ntimes > 5:
@@ -125,15 +125,15 @@ class DB:
         self.con = self.open_db()
         earray = self.con.root.earray
         if avoidfscache:
-            rseed = int(numpy.random.randint(self.nrows))
+            rseed = int(np.random.randint(self.nrows))
         else:
             rseed = 19
-        numpy.random.seed(rseed)
-        numpy.random.randint(self.nrows)
+        np.random.seed(rseed)
+        np.random.randint(self.nrows)
         ltimes = []
         for i in range(niter):
             t1 = clock()
-            self.do_query(earray, numpy.random.randint(self.nrows))
+            self.do_query(earray, np.random.randint(self.nrows))
             ltimes.append(clock() - t1)
         self.print_qtime(ltimes)
         self.close_db()
@@ -219,7 +219,7 @@ if __name__ == "__main__":
 
     if not avoidfscache:
         # in order to always generate the same random sequence
-        numpy.random.seed(20)
+        np.random.seed(20)
 
     if verbose:
         if userandom:

--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -10,7 +10,7 @@ import math
 import subprocess
 import tempfile
 from time import perf_counter as clock
-import numpy
+import numpy as np
 import tables
 
 # Size of dataset
@@ -39,7 +39,7 @@ def quantize(data, least_significant_digit):
         exp = math.ceil(exp)
     bits = math.ceil(math.log(10 ** -exp, 2))
     scale = 2 ** bits
-    return numpy.around(scale * data) / scale
+    return np.around(scale * data) / scale
 
 
 def get_db_size(filename):
@@ -50,7 +50,7 @@ def get_db_size(filename):
 
 
 def bench(chunkshape, filters):
-    numpy.random.seed(1)   # to have reproductible results
+    np.random.seed(1)   # to have reproductible results
     filename = tempfile.mktemp(suffix='.h5')
     print("Doing test on the file system represented by:", filename)
 
@@ -62,7 +62,7 @@ def bench(chunkshape, filters):
     t1 = clock()
     for i in range(N):
         # e.append([numpy.random.rand(M)])  # use this for less compressibility
-        e.append([quantize(numpy.random.rand(M), 6)])
+        e.append([quantize(np.random.rand(M), 6)])
     # os.system("sync")
     print(f"Creation time: {clock() - t1:.3f}", end=' ')
     filesize = get_db_size(filename)
@@ -82,8 +82,8 @@ def bench(chunkshape, filters):
     # return
 
     # Read in random mode:
-    i_index = numpy.random.randint(0, N, 128)
-    j_index = numpy.random.randint(0, M, 256)
+    i_index = np.random.randint(0, N, 128)
+    j_index = np.random.randint(0, M, 256)
     # Flush everything to disk and flush caches
     #os.system("sync; echo 1 > /proc/sys/vm/drop_caches")
 

--- a/bench/postgres-search-bench.py
+++ b/bench/postgres-search-bench.py
@@ -1,5 +1,5 @@
 from time import perf_counter as clock
-import numpy
+import numpy as np
 import random
 
 DSN = "dbname=test port = 5435"
@@ -14,11 +14,11 @@ def flatten(l):
 
 
 def fill_arrays(start, stop):
-    col_i = numpy.arange(start, stop, type=numpy.int32)
+    col_i = np.arange(start, stop, type=np.int32)
     if userandom:
-        col_j = numpy.random.uniform(0, nrows, size=[stop - start])
+        col_j = np.random.uniform(0, nrows, size=[stop - start])
     else:
-        col_j = numpy.array(col_i, type=numpy.float64)
+        col_j = np.array(col_i, type=np.float64)
     return col_i, col_j
 
 # Generator for ensure pytables benchmark compatibility

--- a/bench/search-bench.py
+++ b/bench/search-bench.py
@@ -7,14 +7,14 @@ import warnings
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
-import numpy
+import numpy as np
 
 from tables import *
 
 # Initialize the random generator always with the same integer
 # in order to have reproductible results
 random.seed(19)
-numpy.random.seed(19)
+np.random.seed(19)
 
 randomvalues = 0
 worst = 0
@@ -101,13 +101,13 @@ def createFile(filename, nrows, filters, index, heavy, noise, verbose):
         else:
             j = i + nrowsbuf
         if randomvalues:
-            var3 = numpy.random.uniform(minimum, maximum, size=j - i)
+            var3 = np.random.uniform(minimum, maximum, size=j - i)
         else:
-            var3 = numpy.arange(i, j, dtype=numpy.float64)
+            var3 = np.arange(i, j, dtype=np.float64)
             if noise > 0:
-                var3 += numpy.random.uniform(-noise, noise, size=j - i)
-        var2 = numpy.array(var3, dtype=numpy.int32)
-        var1 = numpy.empty(shape=[j - i], dtype="S4")
+                var3 += np.random.uniform(-noise, noise, size=j - i)
+        var2 = np.array(var3, dtype=np.int32)
+        var1 = np.empty(shape=[j - i], dtype="S4")
         if not heavy:
             var1[:] = var2
         table.append([var3, var2, var1])
@@ -240,11 +240,11 @@ def readFile(filename, atom, riter, indexmode, dselect, verbose):
     # Initialize the random generator always with the same integer
     # in order to have reproductible results on each read iteration
     random.seed(19)
-    numpy.random.seed(19)
+    np.random.seed(19)
     for i in range(riter):
         # The interval for look values at. This is aproximately equivalent to
         # the number of elements to select
-        rnd = numpy.random.randint(table.nrows)
+        rnd = np.random.randint(table.nrows)
         cpu1 = cpuclock()
         t1 = clock()
         if atom == "string":

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -1,7 +1,7 @@
 import os
 import os.path
 from time import perf_counter as clock
-import numpy
+import numpy as np
 import random
 
 # in order to always generate the same random sequence
@@ -9,11 +9,11 @@ random.seed(19)
 
 
 def fill_arrays(start, stop):
-    col_i = numpy.arange(start, stop, dtype=numpy.int32)
+    col_i = np.arange(start, stop, dtype=np.int32)
     if userandom:
-        col_j = numpy.random.uniform(0, nrows, stop - start)
+        col_j = np.random.uniform(0, nrows, stop - start)
     else:
-        col_j = numpy.array(col_i, dtype=numpy.float64)
+        col_j = np.array(col_i, dtype=np.float64)
     return col_i, col_j
 
 # Generator for ensure pytables benchmark compatibility

--- a/bench/stress-test.py
+++ b/bench/stress-test.py
@@ -2,7 +2,7 @@ import gc
 import sys
 from time import perf_counter as clock
 from time import process_time as cpuclock
-import numpy
+import numpy as np
 from tables import Group  # , MetaIsDescription
 from tables import *
 
@@ -34,7 +34,7 @@ def createFileArr(filename, ngroups, ntables, nrows):
     fileh.close()
 
     # Now, create the arrays
-    arr = numpy.arange(nrows)
+    arr = np.arange(nrows)
     for k in range(ngroups):
         fileh = open_file(filename, mode="a", root_uep='group%04d' % k)
         for j in range(ntables):

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import numpy as NP
+import numpy as np
 from tables import *
 
 # This class is accessible only for the examples
@@ -16,7 +16,7 @@ class Small(IsDescription):
 
 class Medium(IsDescription):
     name = StringCol(itemsize=16, pos=0)    # 16-character String
-    float1 = Float64Col(shape=2, dflt=NP.arange(2), pos=1)
+    float1 = Float64Col(shape=2, dflt=np.arange(2), pos=1)
     #float1 = Float64Col(dflt=2.3)
     #float2 = Float64Col(dflt=2.3)
     # zADCcount    = Int16Col()               # signed short integer
@@ -32,7 +32,7 @@ class Medium(IsDescription):
 
 class Big(IsDescription):
     name = StringCol(itemsize=16)           # 16-character String
-    float1 = Float64Col(shape=32, dflt=NP.arange(32))
+    float1 = Float64Col(shape=32, dflt=np.arange(32))
     float2 = Float64Col(shape=32, dflt=2.2)
     TDCcount = Int8Col()                    # signed short integer
     #ADCcount    = Int32Col()
@@ -361,7 +361,7 @@ if __name__ == "__main__":
     file = pargs[0]
 
     if verbose:
-        print("numpy version:", NP.__version__)
+        print("numpy version:", np.__version__)
         if psyco_imported and usepsyco:
             print("Using psyco version:", psyco.version_info)
 

--- a/bench/undo_redo.py
+++ b/bench/undo_redo.py
@@ -6,7 +6,7 @@
 # 2005-03-09
 ###########################################################################
 
-import numpy
+import numpy as np
 from time import perf_counter as clock
 import tables
 
@@ -24,9 +24,9 @@ class BasicBenchmark:
         self.niter = niter
 
         # Initialize the arrays
-        self.a1 = numpy.arange(0, 1 * self.vecsize)
-        self.a2 = numpy.arange(1 * self.vecsize, 2 * self.vecsize)
-        self.a3 = numpy.arange(2 * self.vecsize, 3 * self.vecsize)
+        self.a1 = np.arange(0, 1 * self.vecsize)
+        self.a2 = np.arange(1 * self.vecsize, 2 * self.vecsize)
+        self.a3 = np.arange(2 * self.vecsize, 3 * self.vecsize)
 
     def setUp(self):
 

--- a/examples/carray1.py
+++ b/examples/carray1.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import tables
 
 fileName = 'carray1.h5'
@@ -9,7 +9,7 @@ filters = tables.Filters(complevel=5, complib='zlib')
 h5f = tables.open_file(fileName, 'w')
 ca = h5f.create_carray(h5f.root, 'carray', atom, shape, filters=filters)
 # Fill a hyperslab in ``ca``.
-ca[10:60, 20:70] = numpy.ones((50, 50))
+ca[10:60, 20:70] = np.ones((50, 50))
 h5f.close()
 
 # Re-open and read another hyperslab

--- a/examples/earray1.py
+++ b/examples/earray1.py
@@ -1,12 +1,12 @@
 import tables
-import numpy
+import numpy as np
 
 fileh = tables.open_file('earray1.h5', mode='w')
 a = tables.StringAtom(itemsize=8)
 # Use ``a`` as the object type for the enlargeable array.
 array_c = fileh.create_earray(fileh.root, 'array_c', a, (0,), "Chars")
-array_c.append(numpy.array(['a' * 2, 'b' * 4], dtype='S8'))
-array_c.append(numpy.array(['a' * 6, 'b' * 8, 'c' * 10], dtype='S8'))
+array_c.append(np.array(['a' * 2, 'b' * 4], dtype='S8'))
+array_c.append(np.array(['a' * 6, 'b' * 8, 'c' * 10], dtype='S8'))
 
 # Read the string ``EArray`` we have created on disk.
 for s in array_c:

--- a/examples/multiprocess_access_queues.py
+++ b/examples/multiprocess_access_queues.py
@@ -10,7 +10,7 @@ import os
 import random
 import time
 
-import numpy
+import numpy as np
 import tables
 
 
@@ -112,7 +112,7 @@ class DataProcessor(multiprocessing.Process):
 
         # modify a random row to equal 11 * (self.proc_num + 1)
         row_num = random.randrange(self.array_size)
-        new_data = (numpy.zeros((1, self.array_size), 'i8') +
+        new_data = (np.zeros((1, self.array_size), 'i8') +
                     11 * (self.proc_num + 1))
         self.write_queue.put((row_num, new_data))
 

--- a/examples/nested-tut.py
+++ b/examples/nested-tut.py
@@ -8,7 +8,7 @@ with ptdump or any HDF5 generic utility.
 
 """
 
-import numpy
+import numpy as np
 
 import tables
 
@@ -115,10 +115,10 @@ print(repr(table.description.info1._v_nested_names))
 print()
 print("**** now some for nested records, take that ****")
 print(repr(table.description._v_nested_descr))
-print(repr(numpy.rec.array(None, shape=0,
-                           dtype=table.description._v_nested_descr)))
-print(repr(numpy.rec.array(None, shape=0,
-                           dtype=table.description.info2._v_nested_descr)))
+print(repr(np.rec.array(None, shape=0,
+                        dtype=table.description._v_nested_descr)))
+print(repr(np.rec.array(None, shape=0,
+                        dtype=table.description.info2._v_nested_descr)))
 print()
 print("**** and some iteration over descriptions, too ****")
 for coldescr in table.description._f_walk():

--- a/examples/split.py
+++ b/examples/split.py
@@ -7,7 +7,7 @@ the raw data file in a subdirectory.
 
 import os
 import errno
-import numpy
+import numpy as np
 import tables
 
 FNAME = "split"
@@ -33,6 +33,6 @@ with tables.open_file(FNAME, mode="w", driver=DRIVER, **DRIVER_PROPS) as f:
     table = f.create_table(group, "bar", FooBar, "bar desc")
     for i in range(5):
         table.row["tag"] = "t%d" % i
-        table.row["data"] = numpy.random.random_sample(DATA_SHAPE)
+        table.row["data"] = np.random.random_sample(DATA_SHAPE)
         table.row.append()
     table.flush()

--- a/examples/vlarray3.py
+++ b/examples/vlarray3.py
@@ -3,13 +3,13 @@
 """Example that shows how to easily save a variable number of atoms with a
 VLArray."""
 
-import numpy
+import numpy as np
 import tables
 
 N = 100
 shape = (3, 3)
 
-numpy.random.seed(10)  # For reproductible results
+np.random.seed(10)  # For reproductible results
 f = tables.open_file("vlarray3.h5", mode="w")
 vlarray = f.create_vlarray(f.root, 'vlarray1',
                            tables.Float64Atom(shape=shape),
@@ -18,8 +18,8 @@ vlarray = f.create_vlarray(f.root, 'vlarray1',
 k = 0
 for i in range(N):
     l = []
-    for j in range(numpy.random.randint(N)):
-        l.append(numpy.random.randn(*shape))
+    for j in range(np.random.randint(N)):
+        l.append(np.random.randn(*shape))
         k += 1
     vlarray.append(l)
 

--- a/examples/vlarray4.py
+++ b/examples/vlarray4.py
@@ -3,13 +3,13 @@
 """Example that shows how to easily save a variable number of atoms with a
 VLArray."""
 
-import numpy
+import numpy as np
 import tables
 
 N = 100
 shape = (3, 3)
 
-numpy.random.seed(10)  # For reproductible results
+np.random.seed(10)  # For reproductible results
 f = tables.open_file("vlarray4.h5", mode="w")
 vlarray = f.create_vlarray(f.root, 'vlarray1',
                            tables.Float64Atom(shape=shape),
@@ -18,8 +18,8 @@ vlarray = f.create_vlarray(f.root, 'vlarray1',
 k = 0
 for i in range(N):
     l = []
-    for j in range(numpy.random.randint(N)):
-        l.append(numpy.random.randn(*shape))
+    for j in range(np.random.randint(N)):
+        l.append(np.random.randn(*shape))
         k += 1
     vlarray.append(l)
 

--- a/tables/array.py
+++ b/tables/array.py
@@ -12,7 +12,7 @@
 
 import operator
 import sys
-import numpy
+import numpy as np
 
 from . import hdf5extension
 from .filters import Filters
@@ -371,10 +371,10 @@ class Array(hdf5extension.Array, Leaf):
 
         maxlen = len(self.shape)
         shape = (maxlen,)
-        startl = numpy.empty(shape=shape, dtype=SizeType)
-        stopl = numpy.empty(shape=shape, dtype=SizeType)
-        stepl = numpy.empty(shape=shape, dtype=SizeType)
-        stop_None = numpy.zeros(shape=shape, dtype=SizeType)
+        startl = np.empty(shape=shape, dtype=SizeType)
+        stopl = np.empty(shape=shape, dtype=SizeType)
+        stepl = np.empty(shape=shape, dtype=SizeType)
+        stop_None = np.zeros(shape=shape, dtype=SizeType)
         if not isinstance(keys, tuple):
             keys = (keys,)
         nkeys = len(keys)
@@ -573,24 +573,22 @@ class Array(hdf5extension.Array, Leaf):
                     else:
                         list_seen = True
                 else:
-                    if (not isinstance(exp[0], (int, numpy.integer)) or
-                        (isinstance(exp[0], numpy.ndarray) and not
-                            numpy.issubdtype(exp[0].dtype, numpy.integer))):
+                    if (not isinstance(exp[0], (int, np.integer)) or
+                        (isinstance(exp[0], np.ndarray) and not
+                            np.issubdtype(exp[0].dtype, np.integer))):
                         raise TypeError("Only integer coordinates allowed.")
 
-                nexp = numpy.asarray(exp, dtype="i8")
+                nexp = np.asarray(exp, dtype="i8")
                 # Convert negative values
-                nexp = numpy.where(nexp < 0, length + nexp, nexp)
+                nexp = np.where(nexp < 0, length + nexp, nexp)
                 # Check whether the list is ordered or not
                 # (only one unordered list is allowed)
-                if not len(nexp) == len(numpy.unique(nexp)):
+                if len(nexp) != len(np.unique(nexp)):
                     raise IndexError(
                         "Selection lists cannot have repeated values")
                 neworder = nexp.argsort()
                 if (neworder.shape != (len(exp),) or
-                        numpy.sum(
-                            numpy.abs(
-                                neworder - numpy.arange(len(exp)))) != 0):
+                        np.sum(np.abs(neworder - np.arange(len(exp)))) != 0):
                     if reorder is not None:
                         raise IndexError(
                             "Only one selection list can be unordered")
@@ -716,7 +714,7 @@ class Array(hdf5extension.Array, Leaf):
         # truncate data if least_significant_digit filter is set
         # TODO: add the least_significant_digit attribute to the array on disk
         if (self.filters.least_significant_digit is not None and
-                not numpy.issubdtype(nparr.dtype, numpy.signedinteger)):
+                not np.issubdtype(nparr.dtype, np.signedinteger)):
             nparr = quantize(nparr, self.filters.least_significant_digit)
 
         try:
@@ -741,7 +739,7 @@ class Array(hdf5extension.Array, Leaf):
 
         if nparr.shape != (slice_shape + self.atom.dtype.shape):
             # Create an array compliant with the specified shape
-            narr = numpy.empty(shape=slice_shape, dtype=self.atom.dtype)
+            narr = np.empty(shape=slice_shape, dtype=self.atom.dtype)
 
             # Assign the value to it. It will raise a ValueError exception
             # if the objects cannot be broadcast to a single shape.
@@ -753,7 +751,7 @@ class Array(hdf5extension.Array, Leaf):
     def _read_slice(self, startl, stopl, stepl, shape):
         """Read a slice based on `startl`, `stopl` and `stepl`."""
 
-        nparr = numpy.empty(dtype=self.atom.dtype, shape=shape)
+        nparr = np.empty(dtype=self.atom.dtype, shape=shape)
         # Protection against reading empty arrays
         if 0 not in shape:
             # Arrays that have non-zero dimensionality
@@ -766,7 +764,7 @@ class Array(hdf5extension.Array, Leaf):
     def _read_coords(self, coords):
         """Read a set of points defined by `coords`."""
 
-        nparr = numpy.empty(dtype=self.atom.dtype, shape=len(coords))
+        nparr = np.empty(dtype=self.atom.dtype, shape=len(coords))
         if len(coords) > 0:
             self._g_read_coords(coords, nparr)
         # For zero-shaped arrays, return the scalar
@@ -782,7 +780,7 @@ class Array(hdf5extension.Array, Leaf):
         """
 
         # Create the container for the slice
-        nparr = numpy.empty(dtype=self.atom.dtype, shape=shape)
+        nparr = np.empty(dtype=self.atom.dtype, shape=shape)
         # Arrays that have non-zero dimensionality
         self._g_read_selection(selection, nparr)
         # For zero-shaped arrays, return the scalar
@@ -838,7 +836,7 @@ class Array(hdf5extension.Array, Leaf):
         if shape:
             shape[self.maindim] = nrowstoread
         if out is None:
-            arr = numpy.empty(dtype=self.atom.dtype, shape=shape)
+            arr = np.empty(dtype=self.atom.dtype, shape=shape)
         else:
             bytes_required = self.rowsize * nrowstoread
             # if buffer is too small, it will segfault
@@ -916,7 +914,7 @@ class Array(hdf5extension.Array, Leaf):
         # For details, see #275 of trac.
         object_ = Array(group, name, arr, title=title, _log=_log,
                         _atom=self.atom)
-        nbytes = numpy.prod(self.shape, dtype=SizeType) * self.atom.size
+        nbytes = np.prod(self.shape, dtype=SizeType) * self.atom.size
 
         return (object_, nbytes)
 

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -13,7 +13,7 @@
 
 import sys
 
-import numpy
+import numpy as np
 
 from .atom import Atom
 from .array import Array
@@ -91,7 +91,7 @@ class CArray(Array):
     See below a small example of the use of the `CArray` class.
     The code is available in ``examples/carray1.py``::
 
-        import numpy
+        import numpy as np
         import tables
 
         fileName = 'carray1.h5'
@@ -290,7 +290,7 @@ class CArray(Array):
             object[start3:stop3] = self.__getitem__(tuple(slices))
         # Activate the conversion again (default)
         self._v_convert = True
-        nbytes = numpy.prod(self.shape, dtype=SizeType) * self.atom.size
+        nbytes = np.prod(self.shape, dtype=SizeType) * self.atom.size
 
         return (object, nbytes)
 

--- a/tables/description.py
+++ b/tables/description.py
@@ -16,7 +16,7 @@ import sys
 import copy
 import warnings
 
-import numpy
+import numpy as np
 
 from . import atom
 from .path import check_name_validity
@@ -617,9 +617,9 @@ class Description:
             itemsize = newdict.get('_v_itemsize', None)
             if itemsize is not None:
               dtype_fields['itemsize'] = itemsize
-            dtype = numpy.dtype(dtype_fields)
+            dtype = np.dtype(dtype_fields)
         else:
-            dtype = numpy.dtype(nestedDType)
+            dtype = np.dtype(nestedDType)
         newdict['_v_dtype'] = dtype
         newdict['_v_itemsize'] = dtype.itemsize
         newdict['_v_offsets'] = [dtype.fields[name][1] for name in dtype.names]

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -10,7 +10,7 @@
 
 """Here is defined the EArray class."""
 
-import numpy
+import numpy as np
 
 from .utils import convert_to_np_atom2, SizeType
 from .carray import CArray
@@ -107,7 +107,7 @@ class EArray(CArray):
     code is available in ``examples/earray1.py``::
 
         import tables
-        import numpy
+        import numpy as np
 
         fileh = tables.open_file('earray1.h5', mode='w')
         a = tables.StringAtom(itemsize=8)
@@ -162,7 +162,7 @@ class EArray(CArray):
         """Create a new array in file (specific part)."""
 
         # Pre-conditions and extdim computation
-        zerodims = numpy.sum(numpy.array(self.shape) == 0)
+        zerodims = np.sum(np.array(self.shape) == 0)
         if zerodims > 0:
             if zerodims == 1:
                 self.extdim = list(self.shape).index(0)
@@ -252,7 +252,7 @@ class EArray(CArray):
             object._append(self.__getitem__(tuple(slices)))
         # Active the conversion again (default)
         self._v_convert = True
-        nbytes = numpy.prod(self.shape, dtype=SizeType) * self.atom.itemsize
+        nbytes = np.prod(self.shape, dtype=SizeType) * self.atom.itemsize
 
         return (object, nbytes)
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -27,7 +27,7 @@ import weakref
 import warnings
 
 import numexpr
-import numpy
+import numpy as np
 
 from . import hdf5extension
 from . import utilsextension
@@ -1033,7 +1033,7 @@ class File(hdf5extension.File):
         """
 
         if obj is not None:
-            if not isinstance(obj, numpy.ndarray):
+            if not isinstance(obj, np.ndarray):
                 raise TypeError('invalid obj parameter %r' % obj)
 
             descr, _ = descr_from_dtype(obj.dtype, ptparams=self.params)
@@ -1135,9 +1135,9 @@ class File(hdf5extension.File):
             else:
                 # Making strides=(0,...) below is a trick to create the
                 # array fast and without memory consumption
-                dflt = numpy.zeros((), dtype=atom.dtype)
-                obj = numpy.ndarray(shape, dtype=atom.dtype, buffer=dflt,
-                                    strides=(0,)*len(shape))
+                dflt = np.zeros((), dtype=atom.dtype)
+                obj = np.ndarray(shape, dtype=atom.dtype, buffer=dflt,
+                                 strides=(0,)*len(shape))
         else:
             flavor = flavor_of(obj)
             # use a temporary object because converting obj at this stage
@@ -1632,7 +1632,7 @@ class File(hdf5extension.File):
             basepath = where._v_pathname
             nodepath = join_path(basepath, name or '') or '/'
             node = where._v_file._get_node(nodepath)
-        elif isinstance(where, (str, numpy.str_)):
+        elif isinstance(where, (str, np.str_)):
             if not where.startswith('/'):
                 raise NameError("``where`` must start with a slash ('/')")
 

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -13,7 +13,7 @@
 # Imports
 # =======
 import warnings
-import numpy
+import numpy as np
 
 from . import utilsextension, blosc_compressor_list, blosc_compcode_to_compname
 from .exceptions import FiltersWarning
@@ -114,7 +114,7 @@ class Filters:
 
     This is a small example on using the Filters class::
 
-        import numpy
+        import numpy as np
         import tables
 
         fileh = tables.open_file('test5.h5', mode='w')
@@ -268,7 +268,7 @@ class Filters:
 
         # Byte 3: least significant digit.
         if has_rounding:
-            kwargs['least_significant_digit'] = numpy.int8(packed & 0xff)
+            kwargs['least_significant_digit'] = np.int8(packed & 0xff)
         else:
             kwargs['least_significant_digit'] = None
 
@@ -277,7 +277,7 @@ class Filters:
     def _pack(self):
         """Pack the `Filters` object into a 64-bit NumPy integer."""
 
-        packed = numpy.int64(0)
+        packed = np.int64(0)
 
         # Byte 3: least significant digit.
         if self.least_significant_digit is not None:
@@ -332,7 +332,7 @@ class Filters:
         bitshuffle = bool(bitshuffle)
         fletcher32 = bool(fletcher32)
         if least_significant_digit is not None:
-            least_significant_digit = numpy.int8(least_significant_digit)
+            least_significant_digit = np.int8(least_significant_digit)
 
         if complevel == 0:
             # Override some inputs when compression is not enabled.

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -229,7 +229,7 @@ def restrict_flavors(keep=('python',)):
 # The order in which flavors appear in `all_flavors` determines the
 # order in which they will be tested for by `flavor_of()`, so place
 # most frequent flavors first.
-import numpy
+import numpy as np
 all_flavors.append('numpy')  # this is the internal flavor
 
 all_flavors.append('python')  # this is always supported
@@ -349,26 +349,24 @@ _numpy_aliases = []
 _numpy_desc = "NumPy array, record or scalar"
 
 
-from numpy.lib import NumpyVersion
 
-
-if NumpyVersion(numpy.__version__) >= NumpyVersion('1.19.0'):
+if np.lib.NumpyVersion(np.__version__) >= np.lib.NumpyVersion('1.19.0'):
     def toarray(array, *args, **kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             try:
-                array = numpy.array(array, *args, **kwargs)
-            except numpy.VisibleDeprecationWarning:
+                array = np.array(array, *args, **kwargs)
+            except np.VisibleDeprecationWarning:
                 raise ValueError(
                     'cannot guess the desired dtype from the input')
 
         return array
 else:
-    toarray = numpy.array
+    toarray = np.array
 
 
 def _is_numpy(array):
-    return isinstance(array, (numpy.ndarray, numpy.generic))
+    return isinstance(array, (np.ndarray, np.generic))
 
 
 def _numpy_contiguous(convfunc):
@@ -394,7 +392,7 @@ def _numpy_contiguous(convfunc):
 def _conv_numpy_to_numpy(array):
     # Passes contiguous arrays through and converts scalars into
     # scalar arrays.
-    nparr = numpy.asarray(array)
+    nparr = np.asarray(array)
     if nparr.dtype.kind == 'U':
         # from Python 3 loads of common strings are disguised as Unicode
         try:

--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -12,7 +12,7 @@
 
 import sys
 import math
-import numpy
+import numpy as np
 
 
 # Hints for chunk/slice/block/superblock computations:
@@ -352,15 +352,15 @@ infinitymap = {
     'float64': [-infinity, infinity],
 }
 
-if hasattr(numpy, 'float16'):
-    infinitymap['float16'] = [-numpy.float16(numpy.inf),
-                              numpy.float16(numpy.inf)]
-if hasattr(numpy, 'float96'):
-    infinitymap['float96'] = [-numpy.float96(numpy.inf),
-                              numpy.float96(numpy.inf)]
-if hasattr(numpy, 'float128'):
-    infinitymap['float128'] = [-numpy.float128(numpy.inf),
-                               numpy.float128(numpy.inf)]
+if hasattr(np, 'float16'):
+    infinitymap['float16'] = [-np.float16(np.inf),
+                              np.float16(np.inf)]
+if hasattr(np, 'float96'):
+    infinitymap['float96'] = [-np.float96(np.inf),
+                              np.float96(np.inf)]
+if hasattr(np, 'float128'):
+    infinitymap['float128'] = [-np.float128(np.inf),
+                               np.float128(np.inf)]
 
 # deprecated API
 infinityMap = infinitymap
@@ -438,13 +438,13 @@ def int_type_next_after(x, direction, itemsize):
             return x - 1
         else:
             # return int(PyNextAfter(x, x - 1))
-            return int(numpy.nextafter(x, x - 1))
+            return int(np.nextafter(x, x - 1))
     else:
         if isinstance(x, int):
             return x + 1
         else:
             # return int(PyNextAfter(x,x + 1)) + 1
-            return int(numpy.nextafter(x, x + 1)) + 1
+            return int(np.nextafter(x, x + 1)) + 1
 
 
 def bool_type_next_after(x, direction, itemsize):
@@ -479,9 +479,9 @@ def nextafter(x, direction, dtype, itemsize):
         return int_type_next_after(x, direction, itemsize)
     elif dtype.kind == "f":
         if direction < 0:
-            return numpy.nextafter(x, x - 1)
+            return np.nextafter(x, x - 1)
         else:
-            return numpy.nextafter(x, x + 1)
+            return np.nextafter(x, x + 1)
 
     # elif dtype.name == "float32":
     #    if direction < 0:

--- a/tables/index.py
+++ b/tables/index.py
@@ -22,7 +22,7 @@ import warnings
 from time import perf_counter as clock
 from time import process_time as cpuclock
 
-import numpy
+import numpy as np
 
 from .idxutils import (calc_chunksize, calcoptlevels,
                              get_reduction_level, nextafter, inftype)
@@ -476,10 +476,10 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         rslicesize = self.slicesize // self.reduction
 
         # Save them on disk as attributes
-        self._v_attrs.superblocksize = numpy.uint64(self.superblocksize)
-        self._v_attrs.blocksize = numpy.uint64(self.blocksize)
-        self._v_attrs.slicesize = numpy.uint32(self.slicesize)
-        self._v_attrs.chunksize = numpy.uint32(self.chunksize)
+        self._v_attrs.superblocksize = np.uint64(self.superblocksize)
+        self._v_attrs.blocksize = np.uint64(self.blocksize)
+        self._v_attrs.slicesize = np.uint32(self.slicesize)
+        self._v_attrs.chunksize = np.uint32(self.chunksize)
         # Save the optlevel as well
         self._v_attrs.optlevel = self.optlevel
         # Save the reduction level
@@ -538,9 +538,9 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         self.bebounds = None
 
         # The starts and lengths initialization
-        self.starts = numpy.empty(shape=self.nrows, dtype=numpy.int32)
+        self.starts = np.empty(shape=self.nrows, dtype=np.int32)
         """Where the values fulfiling conditions starts for every slice."""
-        self.lengths = numpy.empty(shape=self.nrows, dtype=numpy.int32)
+        self.lengths = np.empty(shape=self.nrows, dtype=np.int32)
         """Lengths of the values fulfilling conditions for every slice."""
 
         # Finally, create a temporary file for indexes if needed
@@ -562,7 +562,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if profile:
             show_stats("Before creating idx", tref)
         if indsize == 8:
-            idx = numpy.arange(0, len(arr), dtype="uint64") + nrow * slicesize
+            idx = np.arange(0, len(arr), dtype="uint64") + nrow * slicesize
         elif indsize == 4:
             # For medium (32-bit) all the rows in tables should be
             # directly reachable.  But as len(arr) < 2**31, we can
@@ -582,9 +582,9 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             # example, in table sorts).
             #
             # F. Alted 2008-09-15
-            idx = numpy.arange(0, len(arr), dtype="uint32")
+            idx = np.arange(0, len(arr), dtype="uint32")
         else:
-            idx = numpy.empty(len(arr), "uint%d" % (indsize * 8))
+            idx = np.empty(len(arr), "uint%d" % (indsize * 8))
             lbucket = self.lbucket
             # Fill the idx with the bucket indices
             offset = int(lbucket - ((nrow * (slicesize % lbucket)) % lbucket))
@@ -735,7 +735,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nelementsILR = len(idx)
         # Build the cache of bounds
         rchunksize = self.chunksize // reduction
-        self.bebounds = numpy.concatenate((arr[::rchunksize], [larr]))
+        self.bebounds = np.concatenate((arr[::rchunksize], [larr]))
         # The number of elements will be saved as an attribute
         sortedLR.attrs.nelements = nelementsSLR
         indicesLR.attrs.nelements = nelementsILR
@@ -850,21 +850,21 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nelementsLR = self.nelementsILR
         if nelementsLR > 0:
             # Add the ranges corresponding to the last row
-            rangeslr = numpy.array([self.bebounds[0], self.bebounds[-1]])
-            ranges = numpy.concatenate((ranges, [rangeslr]))
+            rangeslr = np.array([self.bebounds[0], self.bebounds[-1]])
+            ranges = np.concatenate((ranges, [rangeslr]))
             nslices += 1
 
         sorted = tmp.sorted
         indices = tmp.indices
         sortedLR = tmp.sortedLR
         indicesLR = tmp.indicesLR
-        sremain = numpy.array([], dtype=self.dtype)
-        iremain = numpy.array([], dtype='u%d' % self.indsize)
-        starts = numpy.zeros(shape=nslices, dtype=numpy.int_)
+        sremain = np.array([], dtype=self.dtype)
+        iremain = np.array([], dtype='u%d' % self.indsize)
+        starts = np.zeros(shape=nslices, dtype=np.int_)
         for i in range(nslices):
             # Find the overlapping elements for slice i
-            sover = numpy.array([], dtype=self.dtype)
-            iover = numpy.array([], dtype='u%d' % self.indsize)
+            sover = np.array([], dtype=self.dtype)
+            iover = np.array([], dtype='u%d' % self.indsize)
             prev_end = ranges[i, 1]
             for j in range(i + 1, nslices):
                 stj = starts[j]
@@ -884,33 +884,33 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 if prev_end > next_end:
                     # Complete overlapping case
                     if j < self.nslices:
-                        sover = numpy.concatenate((sover, sorted[j, stj:]))
-                        iover = numpy.concatenate((iover, indices[j, stj:]))
+                        sover = np.concatenate((sover, sorted[j, stj:]))
+                        iover = np.concatenate((iover, indices[j, stj:]))
                         starts[j] = ss
                     else:
                         n = nelementsLR
-                        sover = numpy.concatenate((sover, sortedLR[stj:n]))
-                        iover = numpy.concatenate((iover, indicesLR[stj:n]))
+                        sover = np.concatenate((sover, sortedLR[stj:n]))
+                        iover = np.concatenate((iover, indicesLR[stj:n]))
                         starts[j] = nelementsLR
                 elif prev_end > next_beg:
                     idx = self.search_item_lt(tmp, prev_end, j, ranges[j], stj)
                     if j < self.nslices:
-                        sover = numpy.concatenate((sover, sorted[j, stj:idx]))
-                        iover = numpy.concatenate((iover, indices[j, stj:idx]))
+                        sover = np.concatenate((sover, sorted[j, stj:idx]))
+                        iover = np.concatenate((iover, indices[j, stj:idx]))
                     else:
-                        sover = numpy.concatenate((sover, sortedLR[stj:idx]))
-                        iover = numpy.concatenate((iover, indicesLR[stj:idx]))
+                        sover = np.concatenate((sover, sortedLR[stj:idx]))
+                        iover = np.concatenate((iover, indicesLR[stj:idx]))
                     starts[j] = idx
             # Build the extended slices to sort out
             if i < self.nslices:
-                ssorted = numpy.concatenate(
+                ssorted = np.concatenate(
                     (sremain, sorted[i, starts[i]:], sover))
-                sindices = numpy.concatenate(
+                sindices = np.concatenate(
                     (iremain, indices[i, starts[i]:], iover))
             else:
-                ssorted = numpy.concatenate(
+                ssorted = np.concatenate(
                     (sremain, sortedLR[starts[i]:nelementsLR], sover))
-                sindices = numpy.concatenate(
+                sindices = np.concatenate(
                     (iremain, indicesLR[starts[i]:nelementsLR], iover))
             # Sort the extended slices
             indexesextension.keysort(ssorted, sindices)
@@ -933,7 +933,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 indicesLR[:n] = sindices
                 # Update the caches for last row
                 sortedlr = sortedLR[:nelementsLR]
-                bebounds = numpy.concatenate(
+                bebounds = np.concatenate(
                     (sortedlr[::self.chunksize], [sortedlr[-1]]))
                 sortedLR[nelementsLR:nelementsLR + len(bebounds)] = bebounds
                 self.bebounds = bebounds
@@ -1120,7 +1120,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             nelementsSLR = len(sortedlr)
             sortedLR[:nelementsSLR] = sortedlr
             # Now, the bounds
-            self.bebounds = numpy.concatenate((sortedlr[::cs], [sortedlr[-1]]))
+            self.bebounds = np.concatenate((sortedlr[::cs], [sortedlr[-1]]))
             offset2 = len(self.bebounds)
             sortedLR[nelementsSLR:nelementsSLR + offset2] = self.bebounds
             # Finally, the indices
@@ -1150,7 +1150,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         cs = self.chunksize
         ncs = ncs2 = self.nchunkslice
         self_nslices = self.nslices
-        tmp = numpy.empty(shape=self.slicesize, dtype=dtype)
+        tmp = np.empty(shape=self.slicesize, dtype=dtype)
         for i in range(nslices):
             ns = offset + i
             if ns == self_nslices:
@@ -1214,7 +1214,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                     can_cross_bbounds):
                 nslices += 1
                 ul = self.nelementsILR // cs
-                bounds = numpy.concatenate((bounds, self.bebounds[:ul]))
+                bounds = np.concatenate((bounds, self.bebounds[:ul]))
             sbounds_idx = bounds.argsort(kind=defsort)
             offset = int(nblock * nsb)
             # Swap sorted and indices following the new order
@@ -1229,19 +1229,17 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Read a slice from the `where` dataset and put it in `buffer`."""
 
         # Create the buffers for specifying the coordinates
-        self.startl = numpy.array([nslice, start], numpy.uint64)
-        self.stopl = numpy.array([nslice + 1, start + buffer.size],
-                                 numpy.uint64)
-        self.stepl = numpy.ones(shape=2, dtype=numpy.uint64)
+        self.startl = np.array([nslice, start], np.uint64)
+        self.stopl = np.array([nslice + 1, start + buffer.size], np.uint64)
+        self.stepl = np.ones(shape=2, dtype=np.uint64)
         where._g_read_slice(self.startl, self.stopl, self.stepl, buffer)
 
     def write_slice(self, where, nslice, buffer, start=0):
         """Write a `slice` to the `where` dataset with the `buffer` data."""
 
-        self.startl = numpy.array([nslice, start], numpy.uint64)
-        self.stopl = numpy.array([nslice + 1, start + buffer.size],
-                                 numpy.uint64)
-        self.stepl = numpy.ones(shape=2, dtype=numpy.uint64)
+        self.startl = np.array([nslice, start], np.uint64)
+        self.stopl = np.array([nslice + 1, start + buffer.size], np.uint64)
+        self.stepl = np.ones(shape=2, dtype=np.uint64)
         countl = self.stopl - self.startl   # (1, self.slicesize)
         where._g_write_slice(self.startl, self.stepl, countl, buffer)
 
@@ -1249,18 +1247,18 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
     def read_slice_lr(self, where, buffer, start=0):
         """Read a slice from the `where` dataset and put it in `buffer`."""
 
-        startl = numpy.array([start], dtype=numpy.uint64)
-        stopl = numpy.array([start + buffer.size], dtype=numpy.uint64)
-        stepl = numpy.array([1], dtype=numpy.uint64)
+        startl = np.array([start], dtype=np.uint64)
+        stopl = np.array([start + buffer.size], dtype=np.uint64)
+        stepl = np.array([1], dtype=np.uint64)
         where._g_read_slice(startl, stopl, stepl, buffer)
 
     # Write version for LastRow
     def write_sliceLR(self, where, buffer, start=0):
         """Write a slice from the `where` dataset with the `buffer` data."""
 
-        startl = numpy.array([start], dtype=numpy.uint64)
-        countl = numpy.array([start + buffer.size], dtype=numpy.uint64)
-        stepl = numpy.array([1], dtype=numpy.uint64)
+        startl = np.array([start], dtype=np.uint64)
+        countl = np.array([start + buffer.size], dtype=np.uint64)
+        stepl = np.array([1], dtype=np.uint64)
         where._g_write_slice(startl, stepl, countl, buffer)
 
 
@@ -1339,9 +1337,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nblocks = self.nblocks
         nelementsLR = self.nelementsILR
         # Create the buffer for reordering 2 slices at a time
-        ssorted = numpy.empty(shape=ss * 2, dtype=self.dtype)
-        sindices = numpy.empty(shape=ss * 2,
-                               dtype=numpy.dtype('u%d' % self.indsize))
+        ssorted = np.empty(shape=ss * 2, dtype=self.dtype)
+        sindices = np.empty(shape=ss * 2, dtype=np.dtype('u%d' % self.indsize))
 
         if self.indsize == 8:
             # Bootstrap the process for reordering
@@ -1373,7 +1370,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 self.write_sliceLR(sortedLR, sortedlr)
                 self.write_sliceLR(indicesLR, indiceslr)
                 # Update the caches for last row
-                bebounds = numpy.concatenate((sortedlr[::cs], [sortedlr[-1]]))
+                bebounds = np.concatenate((sortedlr[::cs], [sortedlr[-1]]))
                 sortedLR[nelementsLR:nelementsLR + len(bebounds)] = bebounds
                 self.bebounds = bebounds
             # Write the first part of the buffers to the regular leaves
@@ -1433,7 +1430,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                 ranges = tmp.mranges[sblock * nss:sblock * nss + nss2]
             sranges_idx = ranges.argsort(kind=defsort)
             # Don't swap the superblock at all if one doesn't need to
-            ndiff = (sranges_idx != numpy.arange(nss2)).sum() / 2
+            ndiff = (sranges_idx != np.arange(nss2)).sum() / 2
             if ndiff * 50 < nss2:
                 # The number of slices to rearrange is less than 2.5%,
                 # so skip the reordering of this superblock
@@ -1539,12 +1536,12 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nelementsLR = self.nelementsILR
         if nelementsLR > 0:
             # Add the ranges corresponding to the last row
-            rangeslr = numpy.array([self.bebounds[0], self.bebounds[-1]])
-            ranges = numpy.concatenate((ranges, [rangeslr]))
+            rangeslr = np.array([self.bebounds[0], self.bebounds[-1]])
+            ranges = np.concatenate((ranges, [rangeslr]))
             nslices += 1
         soverlap = 0
         toverlap = -1
-        multiplicity = numpy.zeros(shape=nslices, dtype="int_")
+        multiplicity = np.zeros(shape=nslices, dtype="int_")
         overlaps = multiplicity.copy()
         starts = multiplicity.copy()
         for i in range(nslices):
@@ -1628,13 +1625,13 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         nslices = self.nslices
         if self.nelementsILR > 0:
             # Add the ranges corresponding to the last row
-            rangeslr = numpy.array([self.bebounds[0], self.bebounds[-1]])
-            ranges = numpy.concatenate((ranges, [rangeslr]))
+            rangeslr = np.array([self.bebounds[0], self.bebounds[-1]])
+            ranges = np.concatenate((ranges, [rangeslr]))
             nslices += 1
         noverlaps = 0
         soverlap = 0
         toverlap = -1
-        multiplicity = numpy.zeros(shape=nslices, dtype="int_")
+        multiplicity = np.zeros(shape=nslices, dtype="int_")
         for i in range(nslices):
             for j in range(i + 1, nslices):
                 if ranges[i, 1] > ranges[j, 0]:
@@ -1674,7 +1671,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """Return the sorted or indices values in the specified range."""
         (start, stop, step) = self._process_range(start, stop, step)
         if start >= stop:
-            return numpy.empty(0, self.dtype)
+            return np.empty(0, self.dtype)
         # Correction for negative values of step (reverse indices)
         if step < 0:
             tmp = start
@@ -1683,11 +1680,11 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if what == "sorted":
             values = self.sorted
             valuesLR = self.sortedLR
-            buffer_ = numpy.empty(stop - start, dtype=self.dtype)
+            buffer_ = np.empty(stop - start, dtype=self.dtype)
         else:
             values = self.indices
             valuesLR = self.indicesLR
-            buffer_ = numpy.empty(stop - start, dtype="u%d" % self.indsize)
+            buffer_ = np.empty(stop - start, dtype="u%d" % self.indsize)
         ss = self.slicesize
         nrow_start = start // ss
         istart = start % ss
@@ -1807,8 +1804,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
                                          'last row chunks')
         """A cache for the last row chunks. Only used for searches in
         the last row, and mainly useful for small indexes."""
-        self.starts = numpy.empty(shape=self.nrows, dtype=numpy.int32)
-        self.lengths = numpy.empty(shape=self.nrows, dtype=numpy.int32)
+        self.starts = np.empty(shape=self.nrows, dtype=np.int32)
+        self.lengths = np.empty(shape=self.nrows, dtype=np.int32)
         self.sorted._init_sorted_slice(self)
         self.dirtycache = False
 
@@ -2009,7 +2006,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         indsize = self.indsize
         bucketsinblock = self.blocksize / lbucket
         nchunks = math.ceil(self.nelements / lbucket)
-        chunkmap = numpy.zeros(shape=nchunks, dtype="bool")
+        chunkmap = np.zeros(shape=nchunks, dtype="bool")
         reduction = self.reduction
         starts = (self.starts - 1) * reduction + 1
         stops = (self.starts + self.lengths) * reduction
@@ -2019,7 +2016,7 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             start = starts[nslice]
             stop = stops[nslice]
             if stop > start:
-                idx = numpy.empty(shape=stop - start, dtype='u%d' % indsize)
+                idx = np.empty(shape=stop - start, dtype='u%d' % indsize)
                 if nslice < nslices:
                     indices._read_index_slice(nslice, start, stop, idx)
                 else:
@@ -2043,11 +2040,11 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             # Map the 'coarse grain' chunkmap into the 'true' chunkmap
             nelements = self.nelements
             tnchunks = math.ceil(nelements / nrowsinchunk)
-            tchunkmap = numpy.zeros(shape=tnchunks, dtype="bool")
+            tchunkmap = np.zeros(shape=tnchunks, dtype="bool")
             ratio = lbucket / nrowsinchunk
             idx = chunkmap.nonzero()[0]
             starts = (idx * ratio).astype('int_')
-            stops = numpy.ceil((idx + 1) * ratio).astype('int_')
+            stops = np.ceil((idx + 1) * ratio).astype('int_')
             for start, stop in zip(starts, stops):
                 tchunkmap[start:stop] = True
             chunkmap = tchunkmap

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -13,7 +13,7 @@
 import warnings
 import math
 
-import numpy
+import numpy as np
 
 from .flavor import (check_flavor, internal_flavor, toarray,
                      alias_map as flavor_alias_map)
@@ -354,7 +354,7 @@ class Leaf(Node):
         chunkshape = list(self.shape)
         # Check whether trimming the main dimension is enough
         chunkshape[maindim] = 1
-        newchunknitems = numpy.prod(chunkshape, dtype=SizeType)
+        newchunknitems = np.prod(chunkshape, dtype=SizeType)
         if newchunknitems <= chunknitems:
             chunkshape[maindim] = chunknitems // newchunknitems
         else:
@@ -362,7 +362,7 @@ class Leaf(Node):
             for j in range(len(chunkshape)):
                 # Check whether trimming this dimension is enough
                 chunkshape[j] = 1
-                newchunknitems = numpy.prod(chunkshape, dtype=SizeType)
+                newchunknitems = np.prod(chunkshape, dtype=SizeType)
                 if newchunknitems <= chunknitems:
                     chunkshape[j] = chunknitems // newchunknitems
                     break
@@ -536,20 +536,20 @@ very small/large chunksize, you may want to increase/decrease it."""
                 key = toarray(key)
             except ValueError:
                 raise TypeError(f"Invalid index or slice: {key!r}")
-        elif not isinstance(key, numpy.ndarray):
+        elif not isinstance(key, np.ndarray):
             raise TypeError(f"Invalid index or slice: {key!r}")
 
         # Protection against empty keys
         if len(key) == 0:
-            return numpy.array([], dtype="i8")
+            return np.array([], dtype="i8")
 
         if key.dtype.kind == 'b':
             if not key.shape == self.shape:
                 raise IndexError(
                     "Boolean indexing array has incompatible shape")
             # Get the True coordinates (64-bit indices!)
-            coords = numpy.asarray(key.nonzero(), dtype='i8')
-            coords = numpy.transpose(coords)
+            coords = np.asarray(key.nonzero(), dtype='i8')
+            coords = np.transpose(coords)
         elif key.dtype.kind == 'i' or key.dtype.kind == 'u':
             if len(key.shape) > 2:
                 raise IndexError(
@@ -558,18 +558,18 @@ very small/large chunksize, you may want to increase/decrease it."""
                 if key.shape[0] != len(self.shape):
                     raise IndexError(
                         "Coordinate indexing array has incompatible shape")
-                coords = numpy.asarray(key, dtype="i8")
-                coords = numpy.transpose(coords)
+                coords = np.asarray(key, dtype="i8")
+                coords = np.transpose(coords)
             else:
                 # For 1-dimensional datasets
-                coords = numpy.asarray(key, dtype="i8")
+                coords = np.asarray(key, dtype="i8")
 
             # handle negative indices
             idx = coords < 0
             coords[idx] = (coords + self.shape)[idx]
 
             # bounds check
-            if numpy.any(coords < 0) or numpy.any(coords >= self.shape):
+            if np.any(coords < 0) or np.any(coords >= self.shape):
                 raise IndexError("Index out of bounds")
         else:
             raise TypeError("Only integer coordinates allowed.")

--- a/tables/table.py
+++ b/tables/table.py
@@ -19,7 +19,7 @@ import warnings
 from functools import reduce as _reduce
 from time import perf_counter as clock
 
-import numpy
+import numpy as np
 import numexpr
 
 from . import tableextension
@@ -68,38 +68,38 @@ except ImportError:
 
 # Maps NumPy types to the types used by Numexpr.
 _nxtype_from_nptype = {
-    numpy.bool_: bool,
-    numpy.int8: int_,
-    numpy.int16: int_,
-    numpy.int32: int_,
-    numpy.int64: long_,
-    numpy.uint8: int_,
-    numpy.uint16: int_,
-    numpy.uint32: long_,
-    numpy.uint64: long_,
-    numpy.float32: float,
-    numpy.float64: double,
-    numpy.complex64: complex,
-    numpy.complex128: complex,
-    numpy.bytes_: bytes,
+    np.bool_: bool,
+    np.int8: int_,
+    np.int16: int_,
+    np.int32: int_,
+    np.int64: long_,
+    np.uint8: int_,
+    np.uint16: int_,
+    np.uint32: long_,
+    np.uint64: long_,
+    np.float32: float,
+    np.float64: double,
+    np.complex64: complex,
+    np.complex128: complex,
+    np.bytes_: bytes,
 }
 
-_nxtype_from_nptype[numpy.str_] = str
+_nxtype_from_nptype[np.str_] = str
 
-if hasattr(numpy, 'float16'):
-    _nxtype_from_nptype[numpy.float16] = float    # XXX: check
-if hasattr(numpy, 'float96'):
-    _nxtype_from_nptype[numpy.float96] = double   # XXX: check
-if hasattr(numpy, 'float128'):
-    _nxtype_from_nptype[numpy.float128] = double  # XXX: check
-if hasattr(numpy, 'complec192'):
-    _nxtype_from_nptype[numpy.complex192] = complex  # XXX: check
-if hasattr(numpy, 'complex256'):
-    _nxtype_from_nptype[numpy.complex256] = complex  # XXX: check
+if hasattr(np, 'float16'):
+    _nxtype_from_nptype[np.float16] = float    # XXX: check
+if hasattr(np, 'float96'):
+    _nxtype_from_nptype[np.float96] = double   # XXX: check
+if hasattr(np, 'float128'):
+    _nxtype_from_nptype[np.float128] = double  # XXX: check
+if hasattr(np, 'complec192'):
+    _nxtype_from_nptype[np.complex192] = complex  # XXX: check
+if hasattr(np, 'complex256'):
+    _nxtype_from_nptype[np.complex256] = complex  # XXX: check
 
 
 # The NumPy scalar type corresponding to `SizeType`.
-_npsizetype = numpy.array(SizeType(0)).dtype.type
+_npsizetype = np.array(SizeType(0)).dtype.type
 
 
 def _index_name_of(node):
@@ -160,7 +160,7 @@ def _table__where_indexed(self, compiled, condition, condvars,
     # Get the values in expression that are not columns
     values = []
     for key, value in condvars.items():
-        if isinstance(value, numpy.ndarray):
+        if isinstance(value, np.ndarray):
             values.append((key, value.item()))
     # Build a key for the sequence cache
     seqkey = (condition, tuple(values), (start, stop, step))
@@ -172,7 +172,7 @@ def _table__where_indexed(self, compiled, condition, condvars,
         if len(seq) == 0:
             return iter([])
         # seq is a list.
-        seq = numpy.array(seq, dtype='int64')
+        seq = np.array(seq, dtype='int64')
         # Correct the ranges in cached sequence
         if (start, stop, step) != (0, self.nrows, 1):
             seq = seq[(seq >= start) & (
@@ -203,7 +203,7 @@ def _table__where_indexed(self, compiled, condition, condvars,
             # No values from index condition, thus the chunkmap should be empty
             nrowsinchunk = self.chunkshape[0]
             nchunks = math.ceil(self.nrows / nrowsinchunk)
-            chunkmap = numpy.zeros(shape=nchunks, dtype="bool")
+            chunkmap = np.zeros(shape=nchunks, dtype="bool")
         else:
             # Get the chunkmap from the index
             chunkmap = index.get_chunkmap()
@@ -291,7 +291,7 @@ def _column__create_index(self, optlevel, kind, filters, tmp_dir,
 
     # Create the atom
     assert dtype.shape == ()
-    atom = Atom.from_dtype(numpy.dtype((dtype, (0,))))
+    atom = Atom.from_dtype(np.dtype((dtype, (0,))))
 
     # Protection on tables larger than the expected rows (perhaps the
     # user forgot to pass this parameter to the Table constructor?)
@@ -564,7 +564,7 @@ class Table(tableextension.Table, Leaf):
         # First, do a check to see whether we need to set default values
         # different from 0 or not.
         for coldflt in self.coldflts.values():
-            if isinstance(coldflt, numpy.ndarray) or coldflt:
+            if isinstance(coldflt, np.ndarray) or coldflt:
                 break
         else:
             # No default different from 0 found.  Returning None.
@@ -784,7 +784,7 @@ class Table(tableextension.Table, Leaf):
         # No description yet?
         if new and self.description is None:
             # Try NumPy dtype instances
-            if isinstance(description, numpy.dtype):
+            if isinstance(description, np.dtype):
                 self.description, self._rabyteorder = \
                     descr_from_dtype(description, ptparams=parentnode._v_file.params)
 
@@ -797,7 +797,7 @@ class Table(tableextension.Table, Leaf):
                 pass
             else:
                 if flavor == 'python':
-                    nparray = numpy.rec.array(description)
+                    nparray = np.rec.array(description)
                 else:
                     nparray = array_as_internal(description, flavor)
                 self.nrows = nrows = SizeType(nparray.size)
@@ -817,7 +817,7 @@ class Table(tableextension.Table, Leaf):
 
         # Check the chunkshape parameter
         if new and chunkshape is not None:
-            if isinstance(chunkshape, (int, numpy.integer)):
+            if isinstance(chunkshape, (int, np.integer)):
                 chunkshape = (chunkshape,)
             try:
                 chunkshape = tuple(chunkshape)
@@ -954,14 +954,14 @@ very small/large chunksize, you may want to increase/decrease it."""
             return self._empty_array_cache[key]
         else:
             self._empty_array_cache[
-                key] = arr = numpy.empty(shape=0, dtype=key)
+                key] = arr = np.empty(shape=0, dtype=key)
             return arr
 
     def _get_container(self, shape):
         """Get the appropriate buffer for data depending on table nestedness."""
 
         # This is *much* faster than the numpy.rec.array counterpart
-        return numpy.empty(shape=shape, dtype=self._v_dtype)
+        return np.empty(shape=shape, dtype=self._v_dtype)
 
     def _get_type_col_names(self, type_):
         """Returns a list containing 'type_' column names."""
@@ -1276,9 +1276,9 @@ very small/large chunksize, you may want to increase/decrease it."""
             else:  # only non-column values are converted to arrays
                 # XXX: not 100% sure about this
                 if isinstance(val, str):
-                    val = numpy.asarray(val.encode('ascii'))
+                    val = np.asarray(val.encode('ascii'))
                 else:
-                    val = numpy.asarray(val)
+                    val = np.asarray(val)
             reqvars[var] = val
         return reqvars
 
@@ -1505,7 +1505,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         if compiled.index_expressions:
             chunkmap = _table__where_indexed(
                 self, compiled, condition, condvars, start, stop, step)
-            if not isinstance(chunkmap, numpy.ndarray):
+            if not isinstance(chunkmap, np.ndarray):
                 # If it is not a NumPy array it should be an iterator
                 # Reset conditions
                 self._use_index = False
@@ -1543,8 +1543,8 @@ very small/large chunksize, you may want to increase/decrease it."""
             cstart, cstop = coords[0], coords[-1] + 1
             if cstop - cstart == len(coords):
                 # Chances for monotonically increasing row values. Refine.
-                inc_seq = numpy.alltrue(
-                    numpy.arange(cstart, cstop) == numpy.array(coords))
+                inc_seq = np.alltrue(
+                    np.arange(cstart, cstop) == np.array(coords))
                 if inc_seq:
                     return self.read(cstart, cstop, field=field)
         return self.read_coordinates(coords, field)
@@ -1605,11 +1605,11 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         coords = [p.nrow for p in
                   self._where(condition, condvars, start, stop, step)]
-        coords = numpy.array(coords, dtype=SizeType)
+        coords = np.array(coords, dtype=SizeType)
         # Reset the conditions
         self._where_condition = None
         if sort:
-            coords = numpy.sort(coords)
+            coords = np.sort(coords)
         return internal_to_flavor(coords, self.flavor)
 
     def itersequence(self, sequence):
@@ -1804,7 +1804,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             if field is None:
                 nra = self._get_container(0)
                 return nra
-            return numpy.empty(shape=0, dtype=dtype_field)
+            return np.empty(shape=0, dtype=dtype_field)
 
         nrows = len(range(start, stop, step))
 
@@ -1812,7 +1812,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             # Compute the shape of the resulting column object
             if field:
                 # Create a container for the results
-                result = numpy.empty(shape=nrows, dtype=dtype_field)
+                result = np.empty(shape=nrows, dtype=dtype_field)
             else:
                 # Recarray case
                 result = self._get_container(nrows)
@@ -1944,12 +1944,12 @@ very small/large chunksize, you may want to increase/decrease it."""
         # Do the real read
         if ncoords > 0:
             # Turn coords into an array of coordinate indexes, if necessary
-            if not (isinstance(coords, numpy.ndarray) and
+            if not (isinstance(coords, np.ndarray) and
                     coords.dtype.type is _npsizetype and
                     coords.flags.contiguous and
                     coords.flags.aligned):
                 # Get a contiguous and aligned coordinate array
-                coords = numpy.array(coords, dtype=SizeType)
+                coords = np.array(coords, dtype=SizeType)
             self._read_elements(coords, result)
 
         # Do the final conversions, if needed
@@ -2075,7 +2075,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 key.start, key.stop, key.step)
             return self.read(start, stop, step)
         # Try with a boolean or point selection
-        elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
+        elif type(key) in (list, tuple) or isinstance(key, np.ndarray):
             return self._read_coordinates(key, None)
         else:
             raise IndexError(f"Invalid index or slice: {key!r}")
@@ -2145,7 +2145,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 key.start, key.stop, key.step)
             return self.modify_rows(start, stop, step, value)
         # Try with a boolean or point selection
-        elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
+        elif type(key) in (list, tuple) or isinstance(key, np.ndarray):
             return self.modify_coordinates(key, value)
         else:
             raise IndexError(f"Invalid index or slice: {key!r}")
@@ -2216,7 +2216,7 @@ very small/large chunksize, you may want to increase/decrease it."""
                 rows = array_as_internal(rows, iflavor)
             # Works for Python structures and always copies the original,
             # so the resulting object is safe for in-place conversion.
-            wbufRA = numpy.rec.array(rows, dtype=self._v_dtype)
+            wbufRA = np.rec.array(rows, dtype=self._v_dtype)
         except Exception as exc:  # XXX
             raise ValueError("rows parameter cannot be converted into a "
                              "recarray object compliant with table '%s'. "
@@ -2239,11 +2239,11 @@ very small/large chunksize, you may want to increase/decrease it."""
                 # See http://projects.scipy.org/scipy/numpy/ticket/315
                 # for discussion on how to pass buffers to constructors
                 # See also http://projects.scipy.org/scipy/numpy/ticket/348
-                recarr = numpy.array([obj], dtype=self._v_dtype)
+                recarr = np.array([obj], dtype=self._v_dtype)
             else:
                 # Works for Python structures and always copies the original,
                 # so the resulting object is safe for in-place conversion.
-                recarr = numpy.rec.array(obj, dtype=self._v_dtype)
+                recarr = np.rec.array(obj, dtype=self._v_dtype)
         except Exception as exc:  # XXX
             raise ValueError("Object cannot be converted into a recarray "
                              "object compliant with table format '%s'. "
@@ -2381,7 +2381,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         try:
             # If the column is a recarray (or kind of), convert into ndarray
             if hasattr(column, 'dtype') and column.dtype.kind == 'V':
-                column = numpy.rec.array(column, dtype=descr).field(0)
+                column = np.rec.array(column, dtype=descr).field(0)
             else:
                 # Make sure the result is always a *copy* of the original,
                 # so the resulting object is safe for in-place conversion.
@@ -2465,9 +2465,9 @@ very small/large chunksize, you may want to increase/decrease it."""
             iflavor = flavor_of(columns)
             if iflavor != 'python':
                 columns = array_as_internal(columns, iflavor)
-                recarray = numpy.rec.array(columns, dtype=descr)
+                recarray = np.rec.array(columns, dtype=descr)
             else:
-                recarray = numpy.rec.fromarrays(columns, dtype=descr)
+                recarray = np.rec.fromarrays(columns, dtype=descr)
         except Exception as exc:  # XXX
             raise ValueError("columns parameter cannot be converted into a "
                              "recarray object compliant with table '%s'. "
@@ -3457,7 +3457,7 @@ class Column:
         table = self.table
         itemsize = self.dtype.itemsize
         nrowsinbuf = table._v_file.params['IO_BUFFER_SIZE'] // itemsize
-        buf = numpy.empty((nrowsinbuf, ), self._itemtype)
+        buf = np.empty((nrowsinbuf, ), self._itemtype)
         max_row = len(self)
         for start_row in range(0, len(self), nrowsinbuf):
             end_row = min(start_row + nrowsinbuf, max_row)

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -22,7 +22,7 @@ from distutils.version import LooseVersion
 
 import unittest
 
-import numpy
+import numpy as np
 import numexpr
 
 import tables
@@ -86,7 +86,7 @@ def print_versions():
     print('-=' * 38)
     print("PyTables version:    %s" % tables.__version__)
     print("HDF5 version:        %s" % tables.which_lib_version("hdf5")[1])
-    print("NumPy version:       %s" % numpy.__version__)
+    print("NumPy version:       %s" % np.__version__)
     tinfo = tables.which_lib_version("zlib")
     if numexpr.use_vml:
         # Get only the main version number and strip out all the rest
@@ -200,7 +200,7 @@ def allequal(a, b, flavor="numpy"):
 
     # Multidimensional case
     result = (a == b)
-    result = numpy.all(result)
+    result = np.all(result)
     if not result and verbose:
         print("Some of the elements in arrays are not equal")
 
@@ -223,7 +223,7 @@ def areArraysEqual(arr1, arr2):
             issubclass(t1, t2) or issubclass(t2, t1)):
         return False
 
-    return numpy.all(arr1 == arr2)
+    return np.all(arr1 == arr2)
 
 
 class PyTablesTestCase(unittest.TestCase):

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import numpy
+import numpy as np
 
 import tables
 from tables.req_versions import min_hdf5_version, min_numpy_version
@@ -26,12 +26,12 @@ if __name__ == '__main__':
     hdf5_version = get_tuple_version(tables.which_lib_version("hdf5")[0])
     hdf5_version_str = "%s.%s.%s" % hdf5_version
     if hdf5_version_str < min_hdf5_version:
-        print("*Warning*: HDF5 version is lower than recommended: %s < %s" %
-              (hdf5_version, min_hdf5_version))
+        print(f"*Warning*: HDF5 version is lower than recommended: "
+              f"{hdf5_version} < {min_hdf5_version}")
 
-    if numpy.__version__ < min_numpy_version:
-        print("*Warning*: NumPy version is lower than recommended: %s < %s" %
-              (numpy.__version__, min_numpy_version))
+    if np.__version__ < min_numpy_version:
+        print(f"*Warning*: NumPy version is lower than recommended: "
+              f"{np.__version__} < {min_numpy_version}")
 
     # Handle some global flags (i.e. only useful for test_all.py)
     only_versions = 0

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -3,8 +3,7 @@ import sys
 import tempfile
 import warnings
 
-import numpy
-from numpy import testing as npt
+import numpy as np
 
 
 import tables
@@ -134,7 +133,7 @@ class BasicTestCase(TestCase):
                 root = fileh.root
 
                 # Read the saved array
-                b = numpy.empty_like(a, dtype=a.dtype)
+                b = np.empty_like(a, dtype=a.dtype)
                 root.somearray.read(out=b)
 
                 # Check strictly the array equality
@@ -256,8 +255,8 @@ class BasicTestCase(TestCase):
     def setup00_char(self):
         """Data integrity during recovery (character objects)"""
 
-        if not isinstance(self.tupleChar, numpy.ndarray):
-            a = numpy.array(self.tupleChar, dtype="S")
+        if not isinstance(self.tupleChar, np.ndarray):
+            a = np.array(self.tupleChar, dtype="S")
         else:
             a = self.tupleChar
 
@@ -296,7 +295,7 @@ class BasicTestCase(TestCase):
                 else:
                     # If a is not a python string, then it should be a list
                     # or ndarray
-                    self.assertIn(type(b), [list, numpy.ndarray])
+                    self.assertIn(type(b), [list, np.ndarray])
         finally:
             # Then, delete the file
             os.remove(filename)
@@ -315,13 +314,13 @@ class BasicTestCase(TestCase):
             # Re-open the file in read-only mode
             with tables.open_file(filename, mode="r") as fileh:
                 # Read the saved array
-                b = numpy.empty_like(a)
+                b = np.empty_like(a)
                 if fileh.root.somearray.flavor != 'numpy':
                     self.assertRaises(TypeError,
                                       lambda: fileh.root.somearray.read(out=b))
                 else:
                     fileh.root.somearray.read(out=b)
-                self.assertIsInstance(b, numpy.ndarray)
+                self.assertIsInstance(b, np.ndarray)
         finally:
             # Then, delete the file
             os.remove(filename)
@@ -335,7 +334,7 @@ class BasicTestCase(TestCase):
         try:
             # Create an instance of HDF5 file
             with tables.open_file(filename, mode="w") as fileh:
-                nparr = numpy.asarray(a)
+                nparr = np.asarray(a)
                 atom = Atom.from_dtype(nparr.dtype)
                 shape = nparr.shape
                 if nparr.dtype.byteorder in ('>', '<'):
@@ -354,13 +353,13 @@ class BasicTestCase(TestCase):
             # Re-open the file in read-only mode
             with tables.open_file(filename, mode="r") as fileh:
                 # Read the saved array
-                b = numpy.empty_like(a)
+                b = np.empty_like(a)
                 if fileh.root.somearray.flavor != 'numpy':
                     self.assertRaises(TypeError,
                                       lambda: fileh.root.somearray.read(out=b))
                 else:
                     fileh.root.somearray.read(out=b)
-                self.assertIsInstance(b, numpy.ndarray)
+                self.assertIsInstance(b, np.ndarray)
         finally:
             # Then, delete the file
             os.remove(filename)
@@ -368,8 +367,8 @@ class BasicTestCase(TestCase):
     def setup01_char_nc(self):
         """Data integrity during recovery (non-contiguous character objects)"""
 
-        if not isinstance(self.tupleChar, numpy.ndarray):
-            a = numpy.array(self.tupleChar, dtype="S")
+        if not isinstance(self.tupleChar, np.ndarray):
+            a = np.array(self.tupleChar, dtype="S")
         else:
             a = self.tupleChar
         if a.ndim == 0:
@@ -408,11 +407,11 @@ class BasicTestCase(TestCase):
                 typecodes.append(name)
 
         for typecode in typecodes:
-            a = numpy.array(self.tupleInt, typecode)
+            a = np.array(self.tupleInt, typecode)
             self.write_read(a)
-            b = numpy.array(self.tupleInt, typecode)
+            b = np.array(self.tupleInt, typecode)
             self.write_read_out_arg(b)
-            c = numpy.array(self.tupleInt, typecode)
+            c = np.array(self.tupleInt, typecode)
             self.write_read_atom_shape_args(c)
 
     def test03_types_nc(self):
@@ -430,7 +429,7 @@ class BasicTestCase(TestCase):
                 typecodes.append(name)
 
         for typecode in typecodes:
-            a = numpy.array(self.tupleInt, typecode)
+            a = np.array(self.tupleInt, typecode)
             if a.ndim == 0:
                 b1 = a.copy()
                 b2 = a.copy()
@@ -503,9 +502,9 @@ class Basic1DThreeTestCase(BasicTestCase):
 class Basic2DOneTestCase(BasicTestCase):
     # 2D case
     title = "Rank-2 case 1"
-    tupleInt = numpy.array(numpy.arange((4)**2))
+    tupleInt = np.array(np.arange((4)**2))
     tupleInt.shape = (4,)*2
-    tupleChar = numpy.array(["abc"]*3**2, dtype="S3")
+    tupleChar = np.array(["abc"]*3**2, dtype="S3")
     tupleChar.shape = (3,)*2
     endiancheck = True
 
@@ -513,18 +512,17 @@ class Basic2DOneTestCase(BasicTestCase):
 class Basic2DTwoTestCase(BasicTestCase):
     # 2D case, with a multidimensional dtype
     title = "Rank-2 case 2"
-    tupleInt = numpy.array(numpy.arange(4), dtype=(numpy.int_, (4,)))
-    tupleChar = numpy.array(["abc"]*3, dtype=("S3", (3,)))
+    tupleInt = np.array(np.arange(4), dtype=(np.int_, (4,)))
+    tupleChar = np.array(["abc"]*3, dtype=("S3", (3,)))
     endiancheck = True
 
 
 class Basic10DTestCase(BasicTestCase):
     # 10D case
     title = "Rank-10 test"
-    tupleInt = numpy.array(numpy.arange((2)**10))
+    tupleInt = np.array(np.arange((2)**10))
     tupleInt.shape = (2,)*10
-    tupleChar = numpy.array(
-        ["abc"]*2**10, dtype="S3")
+    tupleChar = np.array(["abc"]*2**10, dtype="S3")
     tupleChar.shape = (2,)*10
     endiancheck = True
 
@@ -532,9 +530,9 @@ class Basic10DTestCase(BasicTestCase):
 class Basic32DTestCase(BasicTestCase):
     # 32D case (maximum)
     title = "Rank-32 test"
-    tupleInt = numpy.array((32,))
+    tupleInt = np.array((32,))
     tupleInt.shape = (1,)*32
-    tupleChar = numpy.array(["121"], dtype="S3")
+    tupleChar = np.array(["121"], dtype="S3")
     tupleChar.shape = (1,)*32
 
 
@@ -545,47 +543,47 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
         self.size = 1000
 
     def create_array(self):
-        array = numpy.arange(self.size, dtype='f8')
+        array = np.arange(self.size, dtype='f8')
         disk_array = self.h5file.create_array('/', 'array', array)
         return array, disk_array
 
     def test_read_entire_array(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size, ), 'f8')
+        out_buffer = np.empty((self.size, ), 'f8')
         disk_array.read(out=out_buffer)
-        numpy.testing.assert_equal(out_buffer, array)
+        np.testing.assert_equal(out_buffer, array)
 
     def test_read_contiguous_slice1(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.arange(self.size, dtype='f8')
-        out_buffer = numpy.random.permutation(out_buffer)
+        out_buffer = np.arange(self.size, dtype='f8')
+        out_buffer = np.random.permutation(out_buffer)
         out_buffer_orig = out_buffer.copy()
         start = self.size // 2
         disk_array.read(start=start, stop=self.size, out=out_buffer[start:])
-        numpy.testing.assert_equal(out_buffer[start:], array[start:])
-        numpy.testing.assert_equal(out_buffer[:start], out_buffer_orig[:start])
+        np.testing.assert_equal(out_buffer[start:], array[start:])
+        np.testing.assert_equal(out_buffer[:start], out_buffer_orig[:start])
 
     def test_read_contiguous_slice2(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.arange(self.size, dtype='f8')
-        out_buffer = numpy.random.permutation(out_buffer)
+        out_buffer = np.arange(self.size, dtype='f8')
+        out_buffer = np.random.permutation(out_buffer)
         out_buffer_orig = out_buffer.copy()
         start = self.size // 4
         stop = self.size - start
         disk_array.read(start=start, stop=stop, out=out_buffer[start:stop])
-        numpy.testing.assert_equal(out_buffer[start:stop], array[start:stop])
-        numpy.testing.assert_equal(out_buffer[:start], out_buffer_orig[:start])
-        numpy.testing.assert_equal(out_buffer[stop:], out_buffer_orig[stop:])
+        np.testing.assert_equal(out_buffer[start:stop], array[start:stop])
+        np.testing.assert_equal(out_buffer[:start], out_buffer_orig[:start])
+        np.testing.assert_equal(out_buffer[stop:], out_buffer_orig[stop:])
 
     def test_read_non_contiguous_slice_contiguous_buffer(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size // 2, ), dtype='f8')
+        out_buffer = np.empty((self.size // 2, ), dtype='f8')
         disk_array.read(start=0, stop=self.size, step=2, out=out_buffer)
-        numpy.testing.assert_equal(out_buffer, array[0:self.size:2])
+        np.testing.assert_equal(out_buffer, array[0:self.size:2])
 
     def test_read_non_contiguous_buffer(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size, ), 'f8')
+        out_buffer = np.empty((self.size, ), 'f8')
         out_buffer_slice = out_buffer[0:self.size:2]
         # once Python 2.6 support is dropped, this could change
         # to assertRaisesRegexp to check exception type and message at once
@@ -598,7 +596,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def test_buffer_too_small(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size // 2, ), 'f8')
+        out_buffer = np.empty((self.size // 2, ), 'f8')
         self.assertRaises(ValueError, disk_array.read, 0, self.size, 1,
                           out_buffer)
         try:
@@ -608,7 +606,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def test_buffer_too_large(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size + 1, ), 'f8')
+        out_buffer = np.empty((self.size + 1, ), 'f8')
         self.assertRaises(ValueError, disk_array.read, 0, self.size, 1,
                           out_buffer)
         try:
@@ -623,7 +621,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         super().setUp()
         self.array_size = (10, 10)
         self.array = self.h5file.create_array(
-            '/', 'somearray', numpy.zeros(self.array_size, 'i4'))
+            '/', 'somearray', np.zeros(self.array_size, 'i4'))
 
     def test_all_zeros(self):
         self.assertEqual(self.array.size_on_disk, 10 * 10 * 4)
@@ -693,27 +691,27 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test01_signedShort_unaligned(self):
         """Checking an unaligned signed short integer array"""
 
-        r = numpy.rec.array(b'a'*200, formats='i1,f4,i2', shape=10)
+        r = np.rec.array(b'a'*200, formats='i1,f4,i2', shape=10)
         a = r["f2"]
         # Ensure that this array is non-aligned
         self.assertEqual(a.flags.aligned, False)
-        self.assertEqual(a.dtype.type, numpy.int16)
+        self.assertEqual(a.dtype.type, np.int16)
         self.write_read(a)
 
     def test02_float_unaligned(self):
         """Checking an unaligned single precision array"""
 
-        r = numpy.rec.array(b'a'*200, formats='i1,f4,i2', shape=10)
+        r = np.rec.array(b'a'*200, formats='i1,f4,i2', shape=10)
         a = r["f1"]
         # Ensure that this array is non-aligned
         self.assertEqual(a.flags.aligned, 0)
-        self.assertEqual(a.dtype.type, numpy.float32)
+        self.assertEqual(a.dtype.type, np.float32)
         self.write_read(a)
 
     def test03_byte_offset(self):
         """Checking an offsetted byte array"""
 
-        r = numpy.arange(100, dtype=numpy.int8)
+        r = np.arange(100, dtype=np.int8)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -721,7 +719,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test04_short_offset(self):
         """Checking an offsetted unsigned short int precision array"""
 
-        r = numpy.arange(100, dtype=numpy.uint32)
+        r = np.arange(100, dtype=np.uint32)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -729,7 +727,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test05_int_offset(self):
         """Checking an offsetted integer array"""
 
-        r = numpy.arange(100, dtype=numpy.int32)
+        r = np.arange(100, dtype=np.int32)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -737,7 +735,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test06_longlongint_offset(self):
         """Checking an offsetted long long integer array"""
 
-        r = numpy.arange(100, dtype=numpy.int64)
+        r = np.arange(100, dtype=np.int64)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -745,7 +743,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test07_float_offset(self):
         """Checking an offsetted single precision array"""
 
-        r = numpy.arange(100, dtype=numpy.float32)
+        r = np.arange(100, dtype=np.float32)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -753,7 +751,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test08_double_offset(self):
         """Checking an offsetted double precision array"""
 
-        r = numpy.arange(100, dtype=numpy.float64)
+        r = np.arange(100, dtype=np.float64)
         r.shape = (10, 10)
         a = r[2]
         self.write_read(a)
@@ -761,21 +759,21 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
     def test09_float_offset_unaligned(self):
         """Checking an unaligned and offsetted single precision array"""
 
-        r = numpy.rec.array(b'a'*200, formats='i1,3f4,i2', shape=10)
+        r = np.rec.array(b'a'*200, formats='i1,3f4,i2', shape=10)
         a = r["f1"][3]
         # Ensure that this array is non-aligned
         self.assertEqual(a.flags.aligned, False)
-        self.assertEqual(a.dtype.type, numpy.float32)
+        self.assertEqual(a.dtype.type, np.float32)
         self.write_read(a)
 
     def test10_double_offset_unaligned(self):
         """Checking an unaligned and offsetted double precision array"""
 
-        r = numpy.rec.array(b'a'*400, formats='i1,3f8,i2', shape=10)
+        r = np.rec.array(b'a'*400, formats='i1,3f8,i2', shape=10)
         a = r["f1"][3]
         # Ensure that this array is non-aligned
         self.assertEqual(a.flags.aligned, False)
-        self.assertEqual(a.dtype.type, numpy.float64)
+        self.assertEqual(a.dtype.type, np.float64)
         self.write_read(a)
 
     def test11_int_byteorder(self):
@@ -783,7 +781,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
          (integer)"""
 
         # Save an array with the reversed byteorder on it
-        a = numpy.arange(25, dtype=numpy.int32).reshape(5, 5)
+        a = np.arange(25, dtype=np.int32).reshape(5, 5)
         a = a.byteswap()
         a = a.newbyteorder()
         array = self.h5file.create_array(
@@ -811,7 +809,7 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, TestCase):
         """Checking setting data with different byteorder in a range (float)"""
 
         # Save an array with the reversed byteorder on it
-        a = numpy.arange(25, dtype=numpy.float64).reshape(5, 5)
+        a = np.arange(25, dtype=np.float64).reshape(5, 5)
         a = a.byteswap()
         a = a.newbyteorder()
         array = self.h5file.create_array(
@@ -885,7 +883,7 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
             typecodes.append('G')
 
         for i, typecode in enumerate(typecodes):
-            a = numpy.ones((3,), typecode)
+            a = np.ones((3,), typecode)
             dsetname = 'array_' + typecode
             if common.verbose:
                 print("Creating dataset:", group._g_join(dsetname))
@@ -901,7 +899,7 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
         # Get the metadata on the previosly saved arrays
         for i, typecode in enumerate(typecodes):
             # Create an array for later comparison
-            a = numpy.ones((3,), typecode)
+            a = np.ones((3,), typecode)
             # Get the dset object hanging from group
             dset = getattr(group, 'array_' + typecode)
             # Get the actual array
@@ -941,7 +939,7 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
             print("Rank array writing progress: ", end=' ')
         for rank in range(minrank, maxrank + 1):
             # Create an array of integers, with incrementally bigger ranges
-            a = numpy.ones((1,) * rank, numpy.int32)
+            a = np.ones((1,) * rank, np.int32)
             if common.verbose:
                 print("%3d," % (rank), end=' ')
             self.h5file.create_array(group, "array", a, "Rank: %s" % rank)
@@ -957,7 +955,7 @@ class GroupsArrayTestCase(common.TempFileMixin, TestCase):
         # Get the metadata on the previosly saved arrays
         for rank in range(minrank, maxrank + 1):
             # Create an array for later comparison
-            a = numpy.ones((1,) * rank, numpy.int32)
+            a = np.ones((1,) * rank, np.int32)
             # Get the actual array
             b = group.array.read()
             if common.verbose:
@@ -991,7 +989,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test01_copy..." % self.__class__.__name__)
 
         # Create an Array
-        arr = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        arr = np.array([[456, 2], [3, 457]], dtype='int16')
         array1 = self.h5file.create_array(
             self.h5file.root, 'array1', arr, "title array1")
 
@@ -1029,7 +1027,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test02_copy..." % self.__class__.__name__)
 
         # Create an Array
-        arr = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        arr = np.array([[456, 2], [3, 457]], dtype='int16')
         array1 = self.h5file.create_array(
             self.h5file.root, 'array1', arr, "title array1")
 
@@ -1068,7 +1066,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test04_copy..." % self.__class__.__name__)
 
         # Create an Array
-        arr = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        arr = np.array([[456, 2], [3, 457]], dtype='int16')
         array1 = self.h5file.create_array(
             self.h5file.root, 'array1', arr, "title array1")
         # Append some user attrs
@@ -1097,7 +1095,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test05_copy..." % self.__class__.__name__)
 
         # Create an Array
-        arr = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        arr = np.array([[456, 2], [3, 457]], dtype='int16')
         array1 = self.h5file.create_array(
             self.h5file.root, 'array1', arr, "title array1")
         # Append some user attrs
@@ -1129,7 +1127,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test05b_copy..." % self.__class__.__name__)
 
         # Create an Array
-        arr = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        arr = np.array([[456, 2], [3, 457]], dtype='int16')
         array1 = self.h5file.create_array(
             self.h5file.root, 'array1', arr, "title array1")
         # Append some user attrs
@@ -1172,7 +1170,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test01_index..." % self.__class__.__name__)
 
         # Create a numpy
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = (100, 2)
         # Save it in a array:
         array1 = self.h5file.create_array(
@@ -1207,7 +1205,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test02_indexclosef..." % self.__class__.__name__)
 
         # Create a numpy
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = (100, 2)
         # Save it in a array:
         array1 = self.h5file.create_array(
@@ -1458,7 +1456,7 @@ class GetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original before last element:", a[-2])
             print("Read before last element:", arr[-2])
-        if isinstance(a[-2], numpy.ndarray):
+        if isinstance(a[-2], np.ndarray):
             self.assertTrue(allequal(a[-2], arr[-2]))
         else:
             self.assertEqual(a[-2], arr[-2])
@@ -1502,10 +1500,10 @@ class GetItemTestCase(common.TempFileMixin, TestCase):
 
 class GI1NATestCase(GetItemTestCase, TestCase):
     title = "Rank-1 case 1"
-    numericalList = numpy.array([3])
-    numericalListME = numpy.array([3, 2, 1, 0, 4, 5, 6])
-    charList = numpy.array(["3"], 'S')
-    charListME = numpy.array(
+    numericalList = np.array([3])
+    numericalListME = np.array([3, 2, 1, 0, 4, 5, 6])
+    charList = np.array(["3"], 'S')
+    charListME = np.array(
         ["321", "221", "121", "021", "421", "521", "621"], 'S')
 
 
@@ -1520,15 +1518,15 @@ class GI1NACloseTestCase(GI1NATestCase):
 class GI2NATestCase(GetItemTestCase):
     # A more complex example
     title = "Rank-1,2 case 2"
-    numericalList = numpy.array([3, 4])
-    numericalListME = numpy.array([[3, 2, 1, 0, 4, 5, 6],
-                                   [2, 1, 0, 4, 5, 6, 7],
-                                   [4, 3, 2, 1, 0, 4, 5],
-                                   [3, 2, 1, 0, 4, 5, 6],
-                                   [3, 2, 1, 0, 4, 5, 6]])
+    numericalList = np.array([3, 4])
+    numericalListME = np.array([[3, 2, 1, 0, 4, 5, 6],
+                                [2, 1, 0, 4, 5, 6, 7],
+                                [4, 3, 2, 1, 0, 4, 5],
+                                [3, 2, 1, 0, 4, 5, 6],
+                                [3, 2, 1, 0, 4, 5, 6]])
 
-    charList = numpy.array(["a", "b"], 'S')
-    charListME = numpy.array(
+    charList = np.array(["a", "b"], 'S')
+    charListME = np.array(
         [["321", "221", "121", "021", "421", "521", "621"],
          ["21", "21", "11", "02", "42", "21", "61"],
          ["31", "21", "12", "21", "41", "51", "621"],
@@ -1629,7 +1627,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
 
         # Modify elements of a and arr:
         s = slice(1, 3, None)
-        rng = numpy.arange(a[s].size)*2 + 3
+        rng = np.arange(a[s].size)*2 + 3
         rng.shape = a[s].shape
         a[s] = rng
         arr[s] = rng
@@ -1677,7 +1675,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
 
         # Modify elements of a and arr:
         s = slice(1, 4, 2)
-        rng = numpy.arange(a[s].size)*2 + 3
+        rng = np.arange(a[s].size)*2 + 3
         rng.shape = a[s].shape
         a[s] = rng
         arr[s] = rng
@@ -1732,7 +1730,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Original before last element:", a[-2])
             print("Read before last element:", arr[-2])
-        if isinstance(a[-2], numpy.ndarray):
+        if isinstance(a[-2], np.ndarray):
             self.assertTrue(allequal(a[-2], arr[-2]))
         else:
             self.assertEqual(a[-2], arr[-2])
@@ -1774,7 +1772,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
 
         # Modify elements of a and arr:
         s = slice(-3, -1, None)
-        rng = numpy.arange(a[s].size)*2 + 3
+        rng = np.arange(a[s].size)*2 + 3
         rng.shape = a[s].shape
         a[s] = rng
         arr[s] = rng
@@ -1800,10 +1798,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         # Modify elements of arr that are out of range:
         s = slice(1, a.shape[0]+1, None)
         s2 = slice(1, 1000, None)
-        rng = numpy.arange(a[s].size)*2 + 3
+        rng = np.arange(a[s].size)*2 + 3
         rng.shape = a[s].shape
         a[s] = rng
-        rng2 = numpy.arange(a[s2].size)*2 + 3
+        rng2 = np.arange(a[s2].size)*2 + 3
         rng2.shape = a[s2].shape
         arr[s2] = rng2
 
@@ -1816,10 +1814,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
 
 class SI1NATestCase(SetItemTestCase, TestCase):
     title = "Rank-1 case 1"
-    numericalList = numpy.array([3])
-    numericalListME = numpy.array([3, 2, 1, 0, 4, 5, 6])
-    charList = numpy.array(["3"], 'S')
-    charListME = numpy.array(
+    numericalList = np.array([3])
+    numericalListME = np.array([3, 2, 1, 0, 4, 5, 6])
+    charList = np.array(["3"], 'S')
+    charListME = np.array(
         ["321", "221", "121", "021", "421", "521", "621"], 'S')
 
 
@@ -1834,15 +1832,15 @@ class SI1NACloseTestCase(SI1NATestCase):
 class SI2NATestCase(SetItemTestCase):
     # A more complex example
     title = "Rank-1,2 case 2"
-    numericalList = numpy.array([3, 4])
-    numericalListME = numpy.array([[3, 2, 1, 0, 4, 5, 6],
-                                   [2, 1, 0, 4, 5, 6, 7],
-                                   [4, 3, 2, 1, 0, 4, 5],
-                                   [3, 2, 1, 0, 4, 5, 6],
-                                   [3, 2, 1, 0, 4, 5, 6]])
+    numericalList = np.array([3, 4])
+    numericalListME = np.array([[3, 2, 1, 0, 4, 5, 6],
+                                [2, 1, 0, 4, 5, 6, 7],
+                                [4, 3, 2, 1, 0, 4, 5],
+                                [3, 2, 1, 0, 4, 5, 6],
+                                [3, 2, 1, 0, 4, 5, 6]])
 
-    charList = numpy.array(["a", "b"], 'S')
-    charListME = numpy.array(
+    charList = np.array(["a", "b"], 'S')
+    charListME = np.array(
         [["321", "221", "121", "021", "421", "521", "621"],
          ["21", "21", "11", "02", "42", "21", "61"],
          ["31", "21", "12", "21", "41", "51", "621"],
@@ -1949,10 +1947,10 @@ class GeneratorTestCase(common.TempFileMixin, TestCase):
 
 class GE1NATestCase(GeneratorTestCase):
     title = "Rank-1 case 1"
-    numericalList = numpy.array([3])
-    numericalListME = numpy.array([3, 2, 1, 0, 4, 5, 6])
-    charList = numpy.array(["3"], 'S')
-    charListME = numpy.array(
+    numericalList = np.array([3])
+    numericalListME = np.array([3, 2, 1, 0, 4, 5, 6])
+    charList = np.array(["3"], 'S')
+    charListME = np.array(
         ["321", "221", "121", "021", "421", "521", "621"], 'S')
 
 
@@ -1967,15 +1965,15 @@ class GE1NACloseTestCase(GE1NATestCase):
 class GE2NATestCase(GeneratorTestCase):
     # A more complex example
     title = "Rank-1,2 case 2"
-    numericalList = numpy.array([3, 4])
-    numericalListME = numpy.array([[3, 2, 1, 0, 4, 5, 6],
-                                   [2, 1, 0, 4, 5, 6, 7],
-                                   [4, 3, 2, 1, 0, 4, 5],
-                                   [3, 2, 1, 0, 4, 5, 6],
-                                   [3, 2, 1, 0, 4, 5, 6]])
+    numericalList = np.array([3, 4])
+    numericalListME = np.array([[3, 2, 1, 0, 4, 5, 6],
+                                [2, 1, 0, 4, 5, 6, 7],
+                                [4, 3, 2, 1, 0, 4, 5],
+                                [3, 2, 1, 0, 4, 5, 6],
+                                [3, 2, 1, 0, 4, 5, 6]])
 
-    charList = numpy.array(["a", "b"], 'S')
-    charListME = numpy.array(
+    charList = np.array(["a", "b"], 'S')
+    charListME = np.array(
         [["321", "221", "121", "021", "421", "521", "621"],
          ["21", "21", "11", "02", "42", "21", "61"],
          ["31", "21", "12", "21", "41", "51", "621"],
@@ -2025,8 +2023,8 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         ]
 
         # Create a sample array
-        size = numpy.prod(self.shape)
-        nparr = numpy.arange(size, dtype=numpy.int32).reshape(self.shape)
+        size = np.prod(self.shape)
+        nparr = np.arange(size, dtype=np.int32).reshape(self.shape)
         self.nparr = nparr
         self.tbarr = self.h5file.create_array(self.h5file.root, 'array', nparr)
 
@@ -2042,7 +2040,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[key]
             b = tbarr[key]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables selections does not match.")
 
     def test01b_read(self):
@@ -2051,13 +2049,13 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         nparr = self.nparr
         tbarr = self.tbarr
         for value1, value2 in self.limits:
-            key = numpy.where((nparr >= value1) & (nparr < value2))
+            key = np.where((nparr >= value1) & (nparr < value2))
             if common.verbose:
                 print("Selection to test:", key)
             a = nparr[key]
             b = tbarr[key]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables selections does not match.")
 
     def test01c_read(self):
@@ -2066,11 +2064,11 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         nparr = self.nparr
         tbarr = self.tbarr
         for value1, value2 in self.limits:
-            key = numpy.where((nparr >= value1) & (nparr < value2))
+            key = np.where((nparr >= value1) & (nparr < value2))
             if common.verbose:
                 print("Selection to test:", key)
             # a = nparr[key]
-            fkey = numpy.array(key, "f4")
+            fkey = np.array(key, "f4")
             self.assertRaises((IndexError, TypeError), tbarr.__getitem__, fkey)
 
     def test01d_read(self):
@@ -2084,7 +2082,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
                 print("Selection to test:", key)
             a = nparr[key]
             b = tbarr[key]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01e_read(self):
@@ -2111,7 +2109,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[:]
             b = tbarr[:]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables modifications does not match.")
 
     def test02b_write(self):
@@ -2120,7 +2118,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         nparr = self.nparr
         tbarr = self.tbarr
         for value1, value2 in self.limits:
-            key = numpy.where((nparr >= value1) & (nparr < value2))
+            key = np.where((nparr >= value1) & (nparr < value2))
             if common.verbose:
                 print("Selection to test:", key)
             s = nparr[key]
@@ -2129,7 +2127,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[:]
             b = tbarr[:]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables modifications does not match.")
 
     def test02c_write(self):
@@ -2138,7 +2136,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         nparr = self.nparr
         tbarr = self.tbarr
         for value1, value2 in self.limits:
-            key = numpy.where((nparr >= value1) & (nparr < value2))
+            key = np.where((nparr >= value1) & (nparr < value2))
             if common.verbose:
                 print("Selection to test:", key)
             # s = nparr[key]
@@ -2147,7 +2145,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[:]
             b = tbarr[:]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables modifications does not match.")
 
 
@@ -2238,9 +2236,9 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
             ([1, -2], 2, -1),     # more negative indices
             ([1, -2], 2, Ellipsis),     # one ellipsis
             (Ellipsis, [1, 2]),    # one ellipsis
-            (numpy.array(
+            (np.array(
                 [1, -2], 'i4'), 2, -1),  # array 32-bit instead of list
-            (numpy.array(
+            (np.array(
                 [-1, 2], 'i8'), 2, -1),  # array 64-bit instead of list
         ]
 
@@ -2253,7 +2251,7 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
         # Valid selections for NumPy, but not for PyTables (yet)
         # The next should raise an IndexError
         self.not_working_keyset = [
-            numpy.array([False, True], dtype="b1"),  # boolean arrays
+            np.array([False, True], dtype="b1"),  # boolean arrays
             ([1, 2, 1], 2, 1),    # repeated values
             ([1, 2], 2, [1, 2]),  # several lists
             ([], 2, 1),         # empty selections
@@ -2274,8 +2272,8 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
         ]
 
         # Create a sample array
-        nparr = numpy.empty(self.shape, dtype=numpy.int32)
-        data = numpy.arange(N * O, dtype=numpy.int32).reshape(N, O)
+        nparr = np.empty(self.shape, dtype=np.int32)
+        data = np.arange(N * O, dtype=np.int32).reshape(N, O)
         for i in range(M):
             nparr[i] = data * i
         self.nparr = nparr
@@ -2292,7 +2290,7 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[key]
             b = tbarr[key]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables selections does not match.")
 
     def test01b_read(self):
@@ -2344,7 +2342,7 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
             a = nparr[:]
             b = tbarr[:]
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables modifications does not match.")
 
     def test02b_write(self):
@@ -2364,7 +2362,7 @@ class FancySelectionTestCase(common.TempFileMixin, TestCase):
 #                 print("NumPy modified array:", a)
 #                 print("PyTables modifyied array:", b)
             self.assertTrue(
-                numpy.alltrue(a == b),
+                np.alltrue(a == b),
                 "NumPy array and PyTables modifications does not match.")
 
 
@@ -2425,7 +2423,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
         super().setUp()
 
-        a = numpy.zeros((10, 10))
+        a = np.zeros((10, 10))
         self.array = self.h5file.create_array(self.h5file.root, 'array', a)
 
     def test_read(self):
@@ -2449,22 +2447,22 @@ class BroadcastTest(common.TempFileMixin, TestCase):
         array_shape = (2, 3)
         element_shape = (3,)
 
-        dtype = numpy.dtype((numpy.int, element_shape))
+        dtype = np.dtype((np.int, element_shape))
         atom = Atom.from_dtype(dtype)
         h5arr = self.h5file.create_array(self.h5file.root, 'array',
                                           atom=atom, shape=array_shape)
 
-        size = numpy.prod(element_shape)
-        nparr = numpy.arange(size).reshape(element_shape)
+        size = np.prod(element_shape)
+        nparr = np.arange(size).reshape(element_shape)
 
         h5arr[0] = nparr
-        self.assertTrue(numpy.all(h5arr[0] == nparr))
+        self.assertTrue(np.all(h5arr[0] == nparr))
 
 
 class TestCreateArrayArgs(common.TempFileMixin, TestCase):
     where = '/'
     name = 'array'
-    obj = numpy.array([[1, 2], [3, 4]])
+    obj = np.array([[1, 2], [3, 4]])
     title = 'title'
     byteorder = None
     createparents = False
@@ -2499,7 +2497,7 @@ class TestCreateArrayArgs(common.TempFileMixin, TestCase):
         self.assertEqual(ptarr.shape, self.shape)
         self.assertEqual(ptarr.atom, self.atom)
         self.assertEqual(ptarr.atom.dtype, self.atom.dtype)
-        self.assertTrue(allequal(numpy.zeros_like(self.obj), nparr))
+        self.assertTrue(allequal(np.zeros_like(self.obj), nparr))
 
     def test_kwargs_obj(self):
         self.h5file.create_array(self.where, self.name, title=self.title,
@@ -2548,7 +2546,7 @@ class TestCreateArrayArgs(common.TempFileMixin, TestCase):
         self.assertEqual(ptarr.shape, self.shape)
         self.assertEqual(ptarr.atom, self.atom)
         self.assertEqual(ptarr.atom.dtype, self.atom.dtype)
-        self.assertTrue(allequal(numpy.zeros_like(self.obj), nparr))
+        self.assertTrue(allequal(np.zeros_like(self.obj), nparr))
 
     def test_kwargs_obj_atom(self):
         ptarr = self.h5file.create_array(self.where, self.name,
@@ -2603,7 +2601,7 @@ class TestCreateArrayArgs(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(self.obj, nparr))
 
     def test_kwargs_obj_atom_error(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,
@@ -2625,7 +2623,7 @@ class TestCreateArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_01(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,
@@ -2649,7 +2647,7 @@ class TestCreateArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_03(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -5,8 +5,7 @@ import datetime
 import warnings
 from distutils.version import LooseVersion
 
-import numpy
-from numpy.testing import assert_array_equal, assert_almost_equal
+import numpy as np
 
 import tables
 from tables import (IsDescription, Int32Atom, StringCol, IntCol, Int16Col,
@@ -590,15 +589,15 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         # thay are stored in to HDF5 attributes without being actually
         # contiguous and ths causes an error whn they are restored.
 
-        data = numpy.array([[0, 1], [2, 3]])
+        data = np.array([[0, 1], [2, 3]])
 
         self.array.attrs['a'] = data
         self.array.attrs['b'] = data.T.copy()
         self.array.attrs['c'] = data.T
 
-        assert_array_equal(self.array.attrs['a'], data)
-        assert_array_equal(self.array.attrs['b'], data.T)
-        assert_array_equal(self.array.attrs['c'], data.T)  # AssertionError!
+        np.testing.assert_array_equal(self.array.attrs['a'], data)
+        np.testing.assert_array_equal(self.array.attrs['b'], data.T)
+        np.testing.assert_array_equal(self.array.attrs['c'], data.T)  # AssertionError!
 
     def test12_dir(self):
         """Checking AttributeSet.__dir__"""
@@ -723,9 +722,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test00b_setBoolAttributes(self):
         """Checking setting Bool attributes (scalar, NumPy case)"""
 
-        self.array.attrs.pq = numpy.bool_(True)
-        self.array.attrs.qr = numpy.bool_(False)
-        self.array.attrs.rs = numpy.bool_(True)
+        self.array.attrs.pq = np.bool_(True)
+        self.array.attrs.qr = np.bool_(False)
+        self.array.attrs.rs = np.bool_(True)
 
         # Check the results
         if common.verbose:
@@ -740,9 +739,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.root.anarray.attrs.pq, numpy.bool_)
-        self.assertIsInstance(self.root.anarray.attrs.qr, numpy.bool_)
-        self.assertIsInstance(self.root.anarray.attrs.rs, numpy.bool_)
+        self.assertIsInstance(self.root.anarray.attrs.pq, np.bool_)
+        self.assertIsInstance(self.root.anarray.attrs.qr, np.bool_)
+        self.assertIsInstance(self.root.anarray.attrs.rs, np.bool_)
         self.assertEqual(self.root.anarray.attrs.pq, True)
         self.assertEqual(self.root.anarray.attrs.qr, False)
         self.assertEqual(self.root.anarray.attrs.rs, True)
@@ -750,9 +749,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test00c_setBoolAttributes(self):
         """Checking setting Bool attributes (NumPy, 0-dim case)"""
 
-        self.array.attrs.pq = numpy.array(True)
-        self.array.attrs.qr = numpy.array(False)
-        self.array.attrs.rs = numpy.array(True)
+        self.array.attrs.pq = np.array(True)
+        self.array.attrs.qr = np.array(False)
+        self.array.attrs.rs = np.array(True)
 
         # Check the results
         if common.verbose:
@@ -774,9 +773,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test00d_setBoolAttributes(self):
         """Checking setting Bool attributes (NumPy, multidim case)"""
 
-        self.array.attrs.pq = numpy.array([True])
-        self.array.attrs.qr = numpy.array([[False]])
-        self.array.attrs.rs = numpy.array([[True, False], [True, False]])
+        self.array.attrs.pq = np.array([True])
+        self.array.attrs.qr = np.array([[False]])
+        self.array.attrs.rs = np.array([[True, False], [True, False]])
 
         # Check the results
         if common.verbose:
@@ -791,10 +790,12 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.root.anarray.attrs.pq, numpy.array([True]))
-        assert_array_equal(self.root.anarray.attrs.qr, numpy.array([[False]]))
-        assert_array_equal(self.root.anarray.attrs.rs,
-                           numpy.array([[True, False], [True, False]]))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array([True]))
+        np.testing.assert_array_equal(self.root.anarray.attrs.qr,
+                                      np.array([[False]]))
+        np.testing.assert_array_equal(self.root.anarray.attrs.rs,
+                                      np.array([[True, False], [True, False]]))
 
     def test01a_setIntAttributes(self):
         """Checking setting Int attributes (scalar, Python case)"""
@@ -816,9 +817,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.root.anarray.attrs.pq, numpy.int_)
-        self.assertIsInstance(self.root.anarray.attrs.qr, numpy.int_)
-        self.assertIsInstance(self.root.anarray.attrs.rs, numpy.int_)
+        self.assertIsInstance(self.root.anarray.attrs.pq, np.int_)
+        self.assertIsInstance(self.root.anarray.attrs.qr, np.int_)
+        self.assertIsInstance(self.root.anarray.attrs.rs, np.int_)
         self.assertEqual(self.root.anarray.attrs.pq, 1)
         self.assertEqual(self.root.anarray.attrs.qr, 2)
         self.assertEqual(self.root.anarray.attrs.rs, 3)
@@ -831,7 +832,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                       'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype, numpy.array(1, dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array(1, dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -847,8 +848,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            assert_array_equal(getattr(self.array.attrs, dtype),
-                               numpy.array(1, dtype=dtype))
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          np.array(1, dtype=dtype))
 
     def test01c_setIntAttributes(self):
         """Checking setting Int attributes (unidimensional NumPy case)"""
@@ -858,7 +859,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                       'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype, numpy.array([1, 2], dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array([1, 2], dtype=dtype))
 
         # Check the results
         if self.close:
@@ -872,8 +873,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             if common.verbose:
                 print("type, value-->", dtype,
                       getattr(self.array.attrs, dtype))
-            assert_array_equal(getattr(self.array.attrs, dtype),
-                               numpy.array([1, 2], dtype=dtype))
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          np.array([1, 2], dtype=dtype))
 
     def test01d_setIntAttributes(self):
         """Checking setting Int attributes (unidimensional, non-contiguous)"""
@@ -883,7 +884,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                       'uint8', 'uint16', 'uint32']
 
         for dtype in checktypes:
-            arr = numpy.array([1, 2, 3, 4], dtype=dtype)[::2]
+            arr = np.array([1, 2, 3, 4], dtype=dtype)[::2]
             setattr(self.array.attrs, dtype, arr)
 
         # Check the results
@@ -895,11 +896,11 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            arr = numpy.array([1, 2, 3, 4], dtype=dtype)[::2]
+            arr = np.array([1, 2, 3, 4], dtype=dtype)[::2]
             if common.verbose:
                 print("type, value-->", dtype,
                       getattr(self.array.attrs, dtype))
-            assert_array_equal(getattr(self.array.attrs, dtype), arr)
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype), arr)
 
     def test01e_setIntAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
@@ -910,7 +911,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
-                    numpy.array([[1, 2], [2, 3]], dtype=dtype))
+                    np.array([[1, 2], [2, 3]], dtype=dtype))
 
         if self.close:
             if common.verbose:
@@ -924,8 +925,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             if common.verbose:
                 print("type, value-->", dtype,
                       getattr(self.array.attrs, dtype))
-            assert_array_equal(getattr(self.array.attrs, dtype),
-                               numpy.array([[1, 2], [2, 3]], dtype=dtype))
+            np.testing.assert_array_equal(
+                getattr(self.array.attrs, dtype),
+                np.array([[1, 2], [2, 3]], dtype=dtype))
 
     def test02a_setFloatAttributes(self):
         """Checking setting Float (double) attributes."""
@@ -948,9 +950,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.root.anarray.attrs.pq, numpy.float_)
-        self.assertIsInstance(self.root.anarray.attrs.qr, numpy.float_)
-        self.assertIsInstance(self.root.anarray.attrs.rs, numpy.float_)
+        self.assertIsInstance(self.root.anarray.attrs.pq, np.float_)
+        self.assertIsInstance(self.root.anarray.attrs.qr, np.float_)
+        self.assertIsInstance(self.root.anarray.attrs.rs, np.float_)
         self.assertEqual(self.root.anarray.attrs.pq, 1.0)
         self.assertEqual(self.root.anarray.attrs.qr, 2.0)
         self.assertEqual(self.root.anarray.attrs.rs, 3.0)
@@ -961,8 +963,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype,
-                    numpy.array(1.1, dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array(1.1, dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -980,7 +981,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for dtype in checktypes:
             # assert getattr(self.array.attrs, dtype) == 1.1
             # In order to make Float32 tests pass. This is legal, not a trick.
-            assert_almost_equal(getattr(self.array.attrs, dtype), 1.1)
+            np.testing.assert_almost_equal(getattr(self.array.attrs, dtype),
+                                           1.1)
 
     def test02c_setFloatAttributes(self):
         """Checking setting Float attributes (unidimensional NumPy case)"""
@@ -988,8 +990,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype,
-                    numpy.array([1.1, 2.1], dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array([1.1, 2.1], dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -1005,8 +1006,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            assert_array_equal(getattr(self.array.attrs, dtype),
-                               numpy.array([1.1, 2.1], dtype=dtype))
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          np.array([1.1, 2.1], dtype=dtype))
 
     def test02d_setFloatAttributes(self):
         """Checking setting Float attributes (unidimensional,
@@ -1015,7 +1016,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         checktypes = ['float32', 'float64']
 
         for dtype in checktypes:
-            arr = numpy.array([1.1, 2.1, 3.1, 4.1], dtype=dtype)[1::2]
+            arr = np.array([1.1, 2.1, 3.1, 4.1], dtype=dtype)[1::2]
             setattr(self.array.attrs, dtype, arr)
 
         # Check the results
@@ -1032,8 +1033,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            arr = numpy.array([1.1, 2.1, 3.1, 4.1], dtype=dtype)[1::2]
-            assert_array_equal(getattr(self.array.attrs, dtype), arr)
+            arr = np.array([1.1, 2.1, 3.1, 4.1], dtype=dtype)[1::2]
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          arr)
 
     def test02e_setFloatAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
@@ -1042,7 +1044,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
-                    numpy.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
+                    np.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -1058,9 +1060,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            assert_array_equal(
+            np.testing.assert_array_equal(
                 getattr(self.array.attrs, dtype),
-                numpy.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
+                np.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
 
     def test03_setObjectAttributes(self):
         """Checking setting Object attributes."""
@@ -1107,9 +1109,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.root.anarray.attrs.pq, numpy.str_)
-        self.assertIsInstance(self.root.anarray.attrs.qr, numpy.str_)
-        self.assertIsInstance(self.root.anarray.attrs.rs, numpy.str_)
+        self.assertIsInstance(self.root.anarray.attrs.pq, np.str_)
+        self.assertIsInstance(self.root.anarray.attrs.qr, np.str_)
+        self.assertIsInstance(self.root.anarray.attrs.rs, np.str_)
         self.assertEqual(self.root.anarray.attrs.pq, 'foo')
         self.assertEqual(self.root.anarray.attrs.qr, 'bar')
         self.assertEqual(self.root.anarray.attrs.rs, 'baz')
@@ -1117,7 +1119,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test04b_setStringAttributes(self):
         """Checking setting string attributes (unidimensional 1-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['foo'])
+        self.array.attrs.pq = np.array(['foo'])
 
         # Check the results
         if common.verbose:
@@ -1130,13 +1132,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.root.anarray.attrs.pq, numpy.array(['foo']))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array(['foo']))
 
     def test04c_setStringAttributes(self):
         """Checking setting string attributes (empty unidimensional
         1-elem case)"""
 
-        self.array.attrs.pq = numpy.array([''])
+        self.array.attrs.pq = np.array([''])
 
         # Check the results
         if common.verbose:
@@ -1151,13 +1154,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             if common.verbose:
                 print("pq -->", self.array.attrs.pq)
 
-        assert_array_equal(self.root.anarray.attrs.pq,
-                           numpy.array(['']))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array(['']))
 
     def test04d_setStringAttributes(self):
         """Checking setting string attributes (unidimensional 2-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['foo', 'bar3'])
+        self.array.attrs.pq = np.array(['foo', 'bar3'])
 
         # Check the results
         if common.verbose:
@@ -1170,14 +1173,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.root.anarray.attrs.pq,
-                           numpy.array(['foo', 'bar3']))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array(['foo', 'bar3']))
 
     def test04e_setStringAttributes(self):
         """Checking setting string attributes (empty unidimensional
         2-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['', ''])
+        self.array.attrs.pq = np.array(['', ''])
 
         # Check the results
         if common.verbose:
@@ -1190,13 +1193,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.root.anarray.attrs.pq, numpy.array(['', '']))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array(['', '']))
 
     def test04f_setStringAttributes(self):
         """Checking setting string attributes (bidimensional 4-elem case)"""
 
-        self.array.attrs.pq = numpy.array([['foo', 'foo2'],
-                                           ['foo3', 'foo4']])
+        self.array.attrs.pq = np.array([['foo', 'foo2'], ['foo3', 'foo4']])
 
         # Check the results
         if common.verbose:
@@ -1209,9 +1212,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.root.anarray.attrs.pq,
-                           numpy.array([['foo', 'foo2'],
-                                        ['foo3', 'foo4']]))
+        np.testing.assert_array_equal(self.root.anarray.attrs.pq,
+                                      np.array([['foo', 'foo2'],
+                                                ['foo3', 'foo4']]))
 
     def test05a_setComplexAttributes(self):
         """Checking setting Complex (python) attributes."""
@@ -1234,9 +1237,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.root.anarray.attrs.pq, numpy.complex_)
-        self.assertIsInstance(self.root.anarray.attrs.qr, numpy.complex_)
-        self.assertIsInstance(self.root.anarray.attrs.rs, numpy.complex_)
+        self.assertIsInstance(self.root.anarray.attrs.pq, np.complex_)
+        self.assertIsInstance(self.root.anarray.attrs.qr, np.complex_)
+        self.assertIsInstance(self.root.anarray.attrs.rs, np.complex_)
         self.assertEqual(self.root.anarray.attrs.pq, 1.0 + 2j)
         self.assertEqual(self.root.anarray.attrs.qr, 2.0 + 3j)
         self.assertEqual(self.root.anarray.attrs.rs, 3.0 + 4j)
@@ -1247,8 +1250,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         checktypes = ['complex64', 'complex128']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype,
-                    numpy.array(1.1 + 2j, dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array(1.1 + 2j, dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -1266,7 +1268,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for dtype in checktypes:
             # assert getattr(self.array.attrs, dtype) == 1.1 + 2j
             # In order to make Complex32 tests pass.
-            assert_almost_equal(getattr(self.array.attrs, dtype), 1.1 + 2j)
+            np.testing.assert_almost_equal(getattr(self.array.attrs, dtype),
+                                           1.1 + 2j)
 
     def test05c_setComplexAttributes(self):
         """Checking setting Complex attributes (unidimensional NumPy case)"""
@@ -1274,8 +1277,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         checktypes = ['complex64', 'complex128']
 
         for dtype in checktypes:
-            setattr(self.array.attrs, dtype,
-                    numpy.array([1.1, 2.1], dtype=dtype))
+            setattr(self.array.attrs, dtype, np.array([1.1, 2.1], dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -1291,8 +1293,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            assert_array_equal(getattr(self.array.attrs, dtype),
-                               numpy.array([1.1, 2.1], dtype=dtype))
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          np.array([1.1, 2.1], dtype=dtype))
 
     def test05d_setComplexAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
@@ -1301,7 +1303,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         for dtype in checktypes:
             setattr(self.array.attrs, dtype,
-                    numpy.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
+                    np.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
 
         # Check the results
         if common.verbose:
@@ -1317,9 +1319,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.array = self.h5file.root.anarray
 
         for dtype in checktypes:
-            assert_array_equal(
+            np.testing.assert_array_equal(
                 getattr(self.array.attrs, dtype),
-                numpy.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
+                np.array([[1.1, 2.1], [2.1, 3.1]], dtype=dtype))
 
     def test06a_setUnicodeAttributes(self):
         """Checking setting unicode attributes (scalar case)"""
@@ -1345,9 +1347,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.array.attrs.pq, numpy.unicode_)
-        self.assertIsInstance(self.array.attrs.qr, numpy.unicode_)
-        self.assertIsInstance(self.array.attrs.rs, numpy.unicode_)
+        self.assertIsInstance(self.array.attrs.pq, np.unicode_)
+        self.assertIsInstance(self.array.attrs.qr, np.unicode_)
+        self.assertIsInstance(self.array.attrs.rs, np.unicode_)
         self.assertEqual(self.array.attrs.pq, 'para\u0140lel')
         self.assertEqual(self.array.attrs.qr, '')
         self.assertEqual(self.array.attrs.rs, 'baz')
@@ -1355,7 +1357,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
     def test06b_setUnicodeAttributes(self):
         """Checking setting unicode attributes (unidimensional 1-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['para\u0140lel'])
+        self.array.attrs.pq = np.array(['para\u0140lel'])
 
         # Check the results
         if common.verbose:
@@ -1368,8 +1370,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.array.attrs.pq,
-                           numpy.array(['para\u0140lel']))
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.array(['para\u0140lel']))
 
     def test06c_setUnicodeAttributes(self):
         """Checking setting unicode attributes (empty unidimensional
@@ -1378,7 +1380,7 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         # The next raises a `TypeError` when unpickled. See:
         # http://projects.scipy.org/numpy/ticket/1037
         # self.array.attrs.pq = numpy.array([''])
-        self.array.attrs.pq = numpy.array([''], dtype="U1")
+        self.array.attrs.pq = np.array([''], dtype="U1")
 
         # Check the results
         if common.verbose:
@@ -1393,13 +1395,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             if common.verbose:
                 print("pq -->", repr(self.array.attrs.pq))
 
-        assert_array_equal(self.array.attrs.pq,
-                           numpy.array([''], dtype="U1"))
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.array([''], dtype="U1"))
 
     def test06d_setUnicodeAttributes(self):
         """Checking setting unicode attributes (unidimensional 2-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['para\u0140lel', 'bar3'])
+        self.array.attrs.pq = np.array(['para\u0140lel', 'bar3'])
 
         # Check the results
         if common.verbose:
@@ -1412,14 +1414,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.array.attrs.pq,
-                           numpy.array(['para\u0140lel', 'bar3']))
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.array(['para\u0140lel', 'bar3']))
 
     def test06e_setUnicodeAttributes(self):
         """Checking setting unicode attributes (empty unidimensional
         2-elem case)"""
 
-        self.array.attrs.pq = numpy.array(['', ''], dtype="U1")
+        self.array.attrs.pq = np.array(['', ''], dtype="U1")
 
         # Check the results
         if common.verbose:
@@ -1432,14 +1434,14 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.array.attrs.pq,
-                           numpy.array(['', ''], dtype="U1"))
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.array(['', ''], dtype="U1"))
 
     def test06f_setUnicodeAttributes(self):
         """Checking setting unicode attributes (bidimensional 4-elem case)"""
 
-        self.array.attrs.pq = numpy.array([['para\u0140lel', 'foo2'],
-                                           ['foo3', 'para\u0140lel4']])
+        self.array.attrs.pq = np.array([['para\u0140lel', 'foo2'],
+                                        ['foo3', 'para\u0140lel4']])
 
         # Check the results
         if common.verbose:
@@ -1452,18 +1454,18 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        assert_array_equal(self.array.attrs.pq,
-                           numpy.array([['para\u0140lel', 'foo2'],
-                                        ['foo3', 'para\u0140lel4']]))
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.array([['para\u0140lel', 'foo2'],
+                                                ['foo3', 'para\u0140lel4']]))
 
     def test07a_setRecArrayAttributes(self):
         """Checking setting RecArray (NumPy) attributes."""
 
-        dt = numpy.dtype('i4,f8', align=self.aligned)
+        dt = np.dtype('i4,f8', align=self.aligned)
         # Set some attrs
-        self.array.attrs.pq = numpy.zeros(2, dt)
-        self.array.attrs.qr = numpy.ones((2, 2), dt)
-        self.array.attrs.rs = numpy.array([(1, 2.)], dt)
+        self.array.attrs.pq = np.zeros(2, dt)
+        self.array.attrs.qr = np.ones((2, 2), dt)
+        self.array.attrs.rs = np.array([(1, 2.)], dt)
 
         # Check the results
         if common.verbose:
@@ -1478,22 +1480,24 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.array.attrs.pq, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.qr, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.rs, numpy.ndarray)
-        assert_array_equal(self.array.attrs.pq, numpy.zeros(2, dt))
-        assert_array_equal(self.array.attrs.qr, numpy.ones((2, 2), dt))
-        assert_array_equal(self.array.attrs.rs, numpy.array([(1, 2.)], dt))
+        self.assertIsInstance(self.array.attrs.pq, np.ndarray)
+        self.assertIsInstance(self.array.attrs.qr, np.ndarray)
+        self.assertIsInstance(self.array.attrs.rs, np.ndarray)
+        np.testing.assert_array_equal(self.array.attrs.pq, np.zeros(2, dt))
+        np.testing.assert_array_equal(self.array.attrs.qr,
+                                      np.ones((2, 2), dt))
+        np.testing.assert_array_equal(self.array.attrs.rs,
+                                      np.array([(1, 2.)], dt))
 
     def test07b_setRecArrayAttributes(self):
         """Checking setting nested RecArray (NumPy) attributes."""
 
         # Build a nested dtype
-        dt = numpy.dtype([('f1', [('f1', 'i2'), ('f2', 'f8')])])
+        dt = np.dtype([('f1', [('f1', 'i2'), ('f2', 'f8')])])
         # Set some attrs
-        self.array.attrs.pq = numpy.zeros(2, dt)
-        self.array.attrs.qr = numpy.ones((2, 2), dt)
-        self.array.attrs.rs = numpy.array([((1, 2.),)], dt)
+        self.array.attrs.pq = np.zeros(2, dt)
+        self.array.attrs.qr = np.ones((2, 2), dt)
+        self.array.attrs.rs = np.array([((1, 2.),)], dt)
 
         # Check the results
         if common.verbose:
@@ -1508,23 +1512,26 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.array.attrs.pq, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.qr, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.rs, numpy.ndarray)
-        assert_array_equal(self.array.attrs.pq, numpy.zeros(2, dt))
-        assert_array_equal(self.array.attrs.qr, numpy.ones((2, 2), dt))
-        assert_array_equal(self.array.attrs.rs, numpy.array([((1, 2),)], dt))
+        self.assertIsInstance(self.array.attrs.pq, np.ndarray)
+        self.assertIsInstance(self.array.attrs.qr, np.ndarray)
+        self.assertIsInstance(self.array.attrs.rs, np.ndarray)
+        np.testing.assert_array_equal(self.array.attrs.pq,
+                                      np.zeros(2, dt))
+        np.testing.assert_array_equal(self.array.attrs.qr,
+                                      np.ones((2, 2), dt))
+        np.testing.assert_array_equal(self.array.attrs.rs,
+                                      np.array([((1, 2),)], dt))
 
     def test07c_setRecArrayAttributes(self):
         """Checking setting multidim nested RecArray (NumPy) attributes."""
 
         # Build a nested dtype
-        dt = numpy.dtype([('f1', [('f1', 'i2', (2,)), ('f2', 'f8')])], align=True)
+        dt = np.dtype([('f1', [('f1', 'i2', (2,)), ('f2', 'f8')])], align=True)
 
         # Set some attrs
-        self.array.attrs.pq = numpy.zeros(2, dt)
-        self.array.attrs.qr = numpy.ones((2, 2), dt)
-        self.array.attrs.rs = numpy.array([(([1, 3], 2.),)], dt)
+        self.array.attrs.pq = np.zeros(2, dt)
+        self.array.attrs.qr = np.ones((2, 2), dt)
+        self.array.attrs.rs = np.array([(([1, 3], 2.),)], dt)
 
         # Check the results
         if common.verbose:
@@ -1539,22 +1546,22 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.array.attrs.pq, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.qr, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.rs, numpy.ndarray)
-        assert_array_equal(self.array.attrs.pq, numpy.zeros(2, dt))
-        assert_array_equal(self.array.attrs.qr, numpy.ones((2, 2), dt))
-        assert_array_equal(self.array.attrs.rs, numpy.array(
-            [(([1, 3], 2),)], dt))
+        self.assertIsInstance(self.array.attrs.pq, np.ndarray)
+        self.assertIsInstance(self.array.attrs.qr, np.ndarray)
+        self.assertIsInstance(self.array.attrs.rs, np.ndarray)
+        np.testing.assert_array_equal(self.array.attrs.pq, np.zeros(2, dt))
+        np.testing.assert_array_equal(self.array.attrs.qr, np.ones((2, 2), dt))
+        np.testing.assert_array_equal(self.array.attrs.rs,
+                                      np.array([(([1, 3], 2),)], dt))
 
     def test08_setRecArrayNotAllowPadding(self):
         """Checking setting aligned RecArray (NumPy) attributes with `allow_aligned` param set to False when reopen."""
 
-        dt = numpy.dtype('i4,f8', align=self.aligned)
+        dt = np.dtype('i4,f8', align=self.aligned)
         # Set some attrs
-        self.array.attrs.pq = numpy.zeros(2, dt)
-        self.array.attrs.qr = numpy.ones((2, 2), dt)
-        self.array.attrs.rs = numpy.array([(1, 2.)], dt)
+        self.array.attrs.pq = np.zeros(2, dt)
+        self.array.attrs.qr = np.ones((2, 2), dt)
+        self.array.attrs.rs = np.array([(1, 2.)], dt)
 
         # Check the results
         if common.verbose:
@@ -1569,12 +1576,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.root = self.h5file.root
             self.array = self.h5file.root.anarray
 
-        self.assertIsInstance(self.array.attrs.pq, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.qr, numpy.ndarray)
-        self.assertIsInstance(self.array.attrs.rs, numpy.ndarray)
-        assert_array_equal(self.array.attrs.pq, numpy.zeros(2, dt))
-        assert_array_equal(self.array.attrs.qr, numpy.ones((2, 2), dt))
-        assert_array_equal(self.array.attrs.rs, numpy.array([(1, 2.)], dt))
+        self.assertIsInstance(self.array.attrs.pq, np.ndarray)
+        self.assertIsInstance(self.array.attrs.qr, np.ndarray)
+        self.assertIsInstance(self.array.attrs.rs, np.ndarray)
+        np.testing.assert_array_equal(self.array.attrs.pq, np.zeros(2, dt))
+        np.testing.assert_array_equal(self.array.attrs.qr, np.ones((2, 2), dt))
+        np.testing.assert_array_equal(self.array.attrs.rs,
+                                      np.array([(1, 2.)], dt))
 
 
 class NotCloseTypesTestCase(TypesTestCase):
@@ -1686,7 +1694,7 @@ class NoSysAttrsClose(NoSysAttrsTestCase):
 class CompatibilityTestCase(common.TestFileMixin, TestCase):
     h5fname = test_filename('issue_368.h5')
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) < '1.9.0',
+    @unittest.skipIf(LooseVersion(np.__version__) < '1.9.0',
                      'requires numpy >= 1.9')
     def test_pickled_unicode_attrs(self):
         # See also gh-368 and https://github.com/numpy/numpy/issues/4879.

--- a/tables/tests/test_aux.py
+++ b/tables/tests/test_aux.py
@@ -1,5 +1,5 @@
 import unittest
-import numpy
+import numpy as np
 
 from tables import indexesextension
 
@@ -7,11 +7,11 @@ from tables import indexesextension
 class TestAuxiliaryFunctions(unittest.TestCase):
     def test_keysort(self):
         N = 1000
-        rnd = numpy.random.randint(N, size=N)
+        rnd = np.random.randint(N, size=N)
         for dtype1 in ('S6', 'b1', 'i1', 'i8', 'u4', 'u8', 'f4', 'f8'):
             for dtype2 in ('u4', 'i8'):
-                a = numpy.array(rnd, dtype1)
-                b = numpy.array(rnd, dtype2)
+                a = np.array(rnd, dtype1)
+                b = np.array(rnd, dtype2)
 
                 c = a.copy()
                 d = c.argsort()

--- a/tables/tests/test_backcompat.py
+++ b/tables/tests/test_backcompat.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import warnings
 
-import numpy
+import numpy as np
 
 import tables
 from tables.exceptions import FlavorWarning
@@ -87,8 +87,8 @@ class BackCompatAttrsTestCase(common.TestFileMixin, TestCase):
 
         # Read old formats
         a = self.h5file.get_node("/a")
-        scalar = numpy.array(1, dtype="int32")
-        vector = numpy.array([1], dtype="int32")
+        scalar = np.array(1, dtype="int32")
+        vector = np.array([1], dtype="int32")
         if self.format == "1.3":
             self.assertTrue(allequal(a.attrs.arrdim1, vector))
             self.assertTrue(allequal(a.attrs.arrscalar, scalar))

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     multiprocessing_imported = False
 
-import numpy
+import numpy as np
 
 import tables
 import tables.flavor
@@ -120,7 +120,7 @@ class OpenFileTestCase(common.TempFileMixin, TestCase):
         self.h5file.create_array(group, 'anarray2', [2], "Array title 2")
         self.h5file.create_table(group, 'atable1', {
                                  'var1': IntCol()}, "Table title 1")
-        ra = numpy.rec.array([(1, 11, 'a')], formats='u1,f4,a1')
+        ra = np.rec.array([(1, 11, 'a')], formats='u1,f4,a1')
         self.h5file.create_table(group, 'atable2', ra, "Table title 2")
 
         # Create a lonely group in first level
@@ -159,7 +159,7 @@ class OpenFileTestCase(common.TempFileMixin, TestCase):
     def test00_newFile_numpy_str_filename(self):
         temp_dir = tempfile.mkdtemp()
         try:
-            h5fname = numpy.str_(os.path.join(temp_dir, 'test.h5'))
+            h5fname = np.str_(os.path.join(temp_dir, 'test.h5'))
             with tables.open_file(h5fname, 'w') as h5file:
                 self.assertTrue(h5file, tables.File)
         finally:
@@ -168,7 +168,7 @@ class OpenFileTestCase(common.TempFileMixin, TestCase):
     def test00_newFile_numpy_unicode_filename(self):
         temp_dir = tempfile.mkdtemp()
         try:
-            h5fname = numpy.unicode_(os.path.join(temp_dir, 'test.h5'))
+            h5fname = np.unicode_(os.path.join(temp_dir, 'test.h5'))
             with tables.open_file(h5fname, 'w') as h5file:
                 self.assertTrue(h5file, tables.File)
         finally:
@@ -1805,8 +1805,8 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
     """Test that setting, getting and changing the ``flavor`` attribute of a
     leaf works as expected."""
 
-    array_data = numpy.arange(10)
-    scalar_data = numpy.int32(10)
+    array_data = np.arange(10)
+    scalar_data = np.int32(10)
 
     def _reopen(self, mode='r'):
         super()._reopen(mode)
@@ -1973,7 +1973,7 @@ class UnicodeFilename(common.TempFileMixin, TestCase):
         root = self.h5file.root
         group = self.h5file.create_group(root, 'face_data')
         array_name = 'data at 40\N{DEGREE SIGN}C'
-        data = numpy.sinh(numpy.linspace(-1.4, 1.4, 500))
+        data = np.sinh(np.linspace(-1.4, 1.4, 500))
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', NaturalNameWarning)
             self._store_carray(array_name, data, group)
@@ -2043,8 +2043,8 @@ class FilePropertyTestCase(TestCase):
         super().tearDown()
 
     def test_get_filesize(self):
-        data = numpy.zeros((2000, 2000))
-        datasize = numpy.prod(data.shape) * data.dtype.itemsize
+        data = np.zeros((2000, 2000))
+        datasize = np.prod(data.shape) * data.dtype.itemsize
 
         self.h5file = tables.open_file(self.h5fname, mode="w")
         self.h5file.create_array(self.h5file.root, 'array', data)
@@ -2112,7 +2112,7 @@ class BloscBigEndian(common.TestFileMixin, TestCase):
 
         # Check that we can read the contents without problems (nor warnings!)
         for dset_name in ('i1', 'i2', 'i4', 'i8'):
-            a = numpy.arange(10, dtype=dset_name)
+            a = np.arange(10, dtype=dset_name)
             dset = self.h5file.get_node('/'+dset_name)
             self.assertTrue(common.allequal(a, dset[:]),
                             "Error in big-endian data!")
@@ -2155,8 +2155,8 @@ class BloscSubprocess(TestCase):
         h5fname = tempfile.mktemp(prefix="multiproc-blosc9-", suffix=".h5")
         try:
             size = 300_000
-            sa = numpy.fromiter(((i, i**2, i//3)
-                                 for i in range(size)), 'i4,i8,f8')
+            sa = np.fromiter(((i, i**2, i//3) for i in range(size)),
+                             'i4,i8,f8')
             with tables.open_file(h5fname, 'w') as h5file:
                 h5file.create_table(
                     h5file.root, 'table', sa,
@@ -2294,7 +2294,7 @@ class TestDescription(TestCase):
         self.assertIn('c', TestDesc.columns)
 
     def test_descr_from_dtype(self):
-        t = numpy.dtype([('col1', 'int16'), ('col2', float)])
+        t = np.dtype([('col1', 'int16'), ('col2', float)])
         descr, byteorder = descr_from_dtype(t)
 
         self.assertIn('col1', descr._v_colobjects)
@@ -2302,29 +2302,21 @@ class TestDescription(TestCase):
         self.assertEqual(len(descr._v_colobjects), 2)
         self.assertIsInstance(descr._v_colobjects['col1'], Col)
         self.assertIsInstance(descr._v_colobjects['col2'], Col)
-        self.assertEqual(descr._v_colobjects['col1'].dtype, numpy.int16)
+        self.assertEqual(descr._v_colobjects['col1'].dtype, np.int16)
         self.assertEqual(descr._v_colobjects['col2'].dtype, float)
 
     def test_descr_from_dtype_rich_dtype(self):
         header = [(('timestamp', 't'), 'u4'),
                   (('unit (cluster) id', 'unit'), 'u2')]
-        t = numpy.dtype(header)
+        t = np.dtype(header)
 
         descr, byteorder = descr_from_dtype(t)
         self.assertEqual(len(descr._v_names), 2)
         self.assertEqual(sorted(descr._v_names), ['t', 'unit'])
 
     def test_descr_from_dtype_comp_01(self):
-        d1 = numpy.dtype([
-            ('x', 'int16'),
-            ('y', 'int16'),
-        ])
-
-        d_comp = numpy.dtype([
-            ('time', 'float64'),
-            ('value', d1)
-            #('value', (d1, (1,)))
-        ])
+        d1 = np.dtype([('x', 'int16'), ('y', 'int16')])
+        d_comp = np.dtype([('time', 'float64'), ('value', d1)])
 
         descr, byteorder = descr_from_dtype(d_comp)
 
@@ -2335,18 +2327,12 @@ class TestDescription(TestCase):
         self.assertIsInstance(descr._v_colobjects['time'], Col)
         self.assertTrue(isinstance(descr._v_colobjects['value'],
                                    tables.Description))
-        self.assertEqual(descr._v_colobjects['time'].dtype, numpy.float64)
+        self.assertEqual(descr._v_colobjects['time'].dtype, np.float64)
 
     def test_descr_from_dtype_comp_02(self):
-        d1 = numpy.dtype([
-            ('x', 'int16'),
-            ('y', 'int16'),
-        ])
+        d1 = np.dtype([('x', 'int16'), ('y', 'int16')])
 
-        d_comp = numpy.dtype([
-            ('time', 'float64'),
-            ('value', (d1, (1,)))
-        ])
+        d_comp = np.dtype([('time', 'float64'), ('value', (d1, (1,)))])
 
         with self.assertWarns(UserWarning):
             descr, byteorder = descr_from_dtype(d_comp)
@@ -2358,7 +2344,7 @@ class TestDescription(TestCase):
         self.assertIsInstance(descr._v_colobjects['time'], Col)
         self.assertTrue(isinstance(descr._v_colobjects['value'],
                                    tables.Description))
-        self.assertEqual(descr._v_colobjects['time'].dtype, numpy.float64)
+        self.assertEqual(descr._v_colobjects['time'].dtype, np.float64)
 
     def test_dtype_from_descr_is_description(self):
         # See gh-152
@@ -2366,7 +2352,7 @@ class TestDescription(TestCase):
             col1 = Int16Col()
             col2 = FloatCol()
 
-        dtype = numpy.dtype([('col1', 'int16'), ('col2', float)])
+        dtype = np.dtype([('col1', 'int16'), ('col2', float)])
         t = dtype_from_descr(TestDescParent)
 
         self.assertEqual(t, dtype)
@@ -2377,7 +2363,7 @@ class TestDescription(TestCase):
             col1 = Int16Col()
             col2 = FloatCol()
 
-        dtype = numpy.dtype([('col1', 'int16'), ('col2', float)])
+        dtype = np.dtype([('col1', 'int16'), ('col2', float)])
         t = dtype_from_descr(TestDescParent())
 
         self.assertEqual(t, dtype)
@@ -2388,7 +2374,7 @@ class TestDescription(TestCase):
             col1 = Int16Col()
             col2 = FloatCol()
 
-        dtype = numpy.dtype([('col1', 'int16'), ('col2', float)])
+        dtype = np.dtype([('col1', 'int16'), ('col2', float)])
         desctiption = Description(TestDescParent().columns)
         t = dtype_from_descr(desctiption)
 
@@ -2396,7 +2382,7 @@ class TestDescription(TestCase):
 
     def test_dtype_from_descr_dict(self):
         # See gh-152
-        dtype = numpy.dtype([('col1', 'int16'), ('col2', float)])
+        dtype = np.dtype([('col1', 'int16'), ('col2', float)])
         t = dtype_from_descr({'col1': Int16Col(), 'col2': FloatCol()})
 
         self.assertEqual(t, dtype)
@@ -2421,7 +2407,7 @@ class TestDescription(TestCase):
         d = {'name': tables.Int16Col()}
         descr = Description(d)
         self.assertEqual(sorted(descr._v_names), sorted(d.keys()))
-        self.assertIsInstance(descr._v_dtype, numpy.dtype)
+        self.assertIsInstance(descr._v_dtype, np.dtype)
         self.assertTrue(sorted(descr._v_dtype.fields), sorted(d.keys()))
 
 
@@ -2431,13 +2417,13 @@ class TestAtom(TestCase):
         a = Float64Atom(shape=shape)
 
         self.assertEqual(a.dflt, 0.)
-        self.assertEqual(a.dtype, numpy.dtype((numpy.float64, shape)))
+        self.assertEqual(a.dtype, np.dtype((np.float64, shape)))
         self.assertEqual(a.itemsize, a.dtype.base.itemsize)
         self.assertEqual(a.kind, 'float')
         self.assertEqual(a.ndim, len(shape))
         # self.assertEqual(a.recarrtype, )
         self.assertEqual(a.shape, shape)
-        self.assertEqual(a.size, a.itemsize * numpy.prod(shape))
+        self.assertEqual(a.size, a.itemsize * np.prod(shape))
         self.assertEqual(a.type, 'float64')
 
     def test_atom_copy01(self):

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import numpy
+import numpy as np
 
 import tables
 from tables import (
@@ -65,15 +65,15 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Fill it with data
         self.rowshape = list(carray.shape)
-        self.objsize = self.length * numpy.prod(carray.shape)
+        self.objsize = self.length * np.prod(carray.shape)
 
         if self.flavor == "numpy":
             if self.type == "string":
-                object = numpy.ndarray(buffer=b"a"*self.objsize,
+                object = np.ndarray(buffer=b"a"*self.objsize,
                                        shape=self.shape,
                                        dtype="S%s" % carray.atom.itemsize)
             else:
-                object = numpy.arange(self.objsize, dtype=carray.atom.dtype)
+                object = np.arange(self.objsize, dtype=carray.atom.dtype)
                 object.shape = carray.shape
         if common.verbose:
             print("Object to append -->", repr(object))
@@ -84,7 +84,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         if self.shape is not None:
             shape = self.shape
         else:
-            shape = numpy.asarray(self.obj).shape
+            shape = np.asarray(self.obj).shape
 
         return shape
 
@@ -126,11 +126,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         # Build the array to do comparisons
         if self.flavor == "numpy":
             if self.type == "string":
-                object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                        shape=self.shape,
-                                        dtype="S%s" % carray.atom.itemsize)
+                object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                     shape=self.shape,
+                                     dtype=f"S{carray.atom.itemsize}")
             else:
-                object_ = numpy.arange(self.objsize, dtype=carray.atom.dtype)
+                object_ = np.arange(self.objsize, dtype=carray.atom.dtype)
                 object_.shape = shape
 
         stop = self.stop
@@ -156,9 +156,9 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             data = carray.read(self.start, stop, self.step)
         except IndexError:
             if self.flavor == "numpy":
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
             else:
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
 
         if common.verbose:
             if hasattr(obj, "shape"):
@@ -189,11 +189,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         # Build the array to do comparisons
         if self.flavor == "numpy":
             if self.type == "string":
-                object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                        shape=self.shape,
-                                        dtype="S%s" % carray.atom.itemsize)
+                object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                     shape=self.shape,
+                                     dtype=f"S{carray.atom.itemsize}")
             else:
-                object_ = numpy.arange(self.objsize, dtype=carray.atom.dtype)
+                object_ = np.arange(self.objsize, dtype=carray.atom.dtype)
                 object_.shape = shape
 
         stop = self.stop
@@ -216,14 +216,14 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Read all the array
         try:
-            data = numpy.empty(shape, dtype=carray.atom.dtype)
+            data = np.empty(shape, dtype=carray.atom.dtype)
             data = data[self.start:stop:self.step].copy()
             carray.read(self.start, stop, self.step, out=data)
         except IndexError:
             if self.flavor == "numpy":
-                data = numpy.empty(shape=shape, dtype=self.type)
+                data = np.empty(shape=shape, dtype=self.type)
             else:
-                data = numpy.empty(shape=shape, dtype=self.type)
+                data = np.empty(shape=shape, dtype=self.type)
 
         if hasattr(data, "shape"):
             self.assertEqual(len(data.shape), len(shape))
@@ -259,11 +259,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.shape,
-                                    dtype="S%s" % carray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                 shape=self.shape,
+                                 dtype=f"S{carray.atom.itemsize}")
         else:
-            object_ = numpy.arange(self.objsize, dtype=carray.atom.dtype)
+            object_ = np.arange(self.objsize, dtype=carray.atom.dtype)
             object_.shape = shape
 
         # do a copy() in order to ensure that len(object._data)
@@ -276,9 +276,9 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         except IndexError:
             print("IndexError!")
             if self.flavor == "numpy":
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
             else:
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
 
         if common.verbose:
             print("Object read:\n", repr(data))  # , data.info()
@@ -320,11 +320,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.shape,
-                                    dtype="S%s" % carray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                 shape=self.shape,
+                                 dtype=f"S{carray.atom.itemsize}")
         else:
-            object_ = numpy.arange(self.objsize, dtype=carray.atom.dtype)
+            object_ = np.arange(self.objsize, dtype=carray.atom.dtype)
             object_.shape = shape
 
         # do a copy() in order to ensure that len(object._data)
@@ -345,19 +345,19 @@ class BasicTestCase(common.TempFileMixin, TestCase):
                 carray[self.wslice] = carray[self.wslice] * 2 + 3
             elif sum(obj[self.slices].shape) != 0:
                 obj = obj * 2 + 3
-                if numpy.prod(obj.shape) > 0:
+                if np.prod(obj.shape) > 0:
                     carray[self.slices] = carray[self.slices] * 2 + 3
             # Cast again object to its original type
-            obj = numpy.array(obj, dtype=carray.atom.dtype)
+            obj = np.array(obj, dtype=carray.atom.dtype)
         # Read datafrom the array
         try:
             data = carray.__getitem__(self.slices)
         except IndexError:
             print("IndexError!")
             if self.flavor == "numpy":
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
             else:
-                data = numpy.empty(shape=self.shape, dtype=self.type)
+                data = np.empty(shape=self.shape, dtype=self.type)
 
         if common.verbose:
             print("Object read:\n", repr(data))  # , data.info()
@@ -393,7 +393,7 @@ class BasicWrite2TestCase(BasicTestCase):
 
 class BasicWrite3TestCase(BasicTestCase):
     obj = [1, 2]
-    type = numpy.asarray(obj).dtype.name
+    type = np.asarray(obj).dtype.name
     shape = None
     chunkshape = (5,)
     step = 1
@@ -401,7 +401,7 @@ class BasicWrite3TestCase(BasicTestCase):
 
 
 class BasicWrite4TestCase(BasicTestCase):
-    obj = numpy.array([1, 2])
+    obj = np.array([1, 2])
     type = obj.dtype.name
     shape = None
     chunkshape = (5,)
@@ -411,7 +411,7 @@ class BasicWrite4TestCase(BasicTestCase):
 
 class BasicWrite5TestCase(BasicTestCase):
     obj = [[1, 2], [3, 4]]
-    type = numpy.asarray(obj).dtype.name
+    type = np.asarray(obj).dtype.name
     shape = None
     chunkshape = (5, 1)
     step = 1
@@ -420,7 +420,7 @@ class BasicWrite5TestCase(BasicTestCase):
 
 class BasicWrite6TestCase(BasicTestCase):
     obj = [1, 2]
-    type = numpy.asarray(obj).dtype.name
+    type = np.asarray(obj).dtype.name
     shape = None
     chunkshape = (5,)
     step = 1
@@ -428,7 +428,7 @@ class BasicWrite6TestCase(BasicTestCase):
 
 
 class BasicWrite7TestCase(BasicTestCase):
-    obj = numpy.array([1, 2])
+    obj = np.array([1, 2])
     type = obj.dtype.name
     shape = None
     chunkshape = (5,)
@@ -438,7 +438,7 @@ class BasicWrite7TestCase(BasicTestCase):
 
 class BasicWrite8TestCase(BasicTestCase):
     obj = [[1, 2], [3, 4]]
-    type = numpy.asarray(obj).dtype.name
+    type = np.asarray(obj).dtype.name
     shape = None
     chunkshape = (5, 1)
     step = 1
@@ -1065,7 +1065,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
         self.filters = tables.Filters(complevel=1, complib='blosc')
 
     def create_array(self):
-        array = numpy.arange(self.size, dtype='i8')
+        array = np.arange(self.size, dtype='i8')
         disk_array = self.h5file.create_carray('/', 'array', atom=Int64Atom(),
                                                shape=(self.size, ),
                                                filters=self.filters)
@@ -1074,13 +1074,13 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def test_read_entire_array(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size, ), 'i8')
+        out_buffer = np.empty((self.size, ), 'i8')
         disk_array.read(out=out_buffer)
-        numpy.testing.assert_equal(out_buffer, array)
+        np.testing.assert_equal(out_buffer, array)
 
     def test_read_non_contiguous_buffer(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size, ), 'i8')
+        out_buffer = np.empty((self.size, ), 'i8')
         out_buffer_slice = out_buffer[0:self.size:2]
         # once Python 2.6 support is dropped, this could change
         # to assertRaisesRegexp to check exception type and message at once
@@ -1093,7 +1093,7 @@ class ReadOutArgumentTests(common.TempFileMixin, TestCase):
 
     def test_buffer_too_small(self):
         array, disk_array = self.create_array()
-        out_buffer = numpy.empty((self.size // 2, ), 'i8')
+        out_buffer = np.empty((self.size // 2, ), 'i8')
         self.assertRaises(ValueError, disk_array.read, 0, self.size, 1,
                           out_buffer)
         try:
@@ -1149,7 +1149,7 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
     def test_random_data(self):
         complevel = 1
         self.create_array(complevel)
-        self.array[:] = numpy.random.randint(0, 1e6, self.array_size)
+        self.array[:] = np.random.randint(0, 1e6, self.array_size)
         self.h5file.flush()
         file_size = os.stat(self.h5fname).st_size
         self.assertTrue(
@@ -1187,11 +1187,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            shape=shape,
                                            title="Array of strings",
                                            chunkshape=(1, 2, 2))
-        a = numpy.array([[["a", "b"], [
-                        "123", "45"], ["45", "123"]]], dtype="S3")
+        a = np.array([[["a", "b"], ["123", "45"], ["45", "123"]]], dtype="S3")
         carray[0] = a[0, 1:]
-        a = numpy.array([[["s", "a"], [
-                        "ab", "f"], ["s", "abc"], ["abc", "f"]]])
+        a = np.array([[["s", "a"], ["ab", "f"], ["s", "abc"], ["abc", "f"]]])
         carray[1] = a[0, 2:]
 
         # Read all the data:
@@ -1223,11 +1221,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            shape=shape,
                                            title="Array of strings",
                                            chunkshape=(1, 2, 2))
-        a = numpy.array([[["a", "b"], [
-                        "123", "45"], ["45", "123"]]], dtype="S3")
+        a = np.array([[["a", "b"], ["123", "45"], ["45", "123"]]], dtype="S3")
         carray[0] = a[0, ::2]
-        a = numpy.array([[["s", "a"], [
-                        "ab", "f"], ["s", "abc"], ["abc", "f"]]])
+        a = np.array([[["s", "a"], ["ab", "f"], ["s", "abc"], ["abc", "f"]]])
         carray[1] = a[0, ::2]
 
         # Read all the rows:
@@ -1258,10 +1254,10 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=Int32Atom(), shape=shape,
                                            title="array of ints",
                                            chunkshape=(1, 3))
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (0, 0, 0)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (0, 0, 0)],
+                     dtype='int32')
         carray[0:2] = a[2:]  # Introduce an offset
-        a = numpy.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
+        a = np.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
         carray[2:3] = a[1:]  # Introduce an offset
 
         # Read all the rows:
@@ -1272,12 +1268,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
             print("Third row in carray ==>", data[2])
 
         self.assertEqual(carray.nrows, 3)
-        self.assertTrue(allequal(data[
-                        0], numpy.array([1, 1, 1], dtype='int32')))
-        self.assertTrue(allequal(data[
-                        1], numpy.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(allequal(data[
-                        2], numpy.array([-1, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(data[0], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(allequal(data[1], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(data[2], np.array([-1, 0, 0], dtype='int32')))
 
     def test02b_int(self):
         """Checking carray with strided NumPy ints appends."""
@@ -1294,10 +1287,10 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=Int32Atom(), shape=shape,
                                            title="array of ints",
                                            chunkshape=(1, 3))
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='int32')
         carray[0:2] = a[::3]  # Create an offset
-        a = numpy.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
+        a = np.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
         carray[2:3] = a[::2]  # Create an offset
 
         # Read all the rows:
@@ -1308,12 +1301,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
             print("Third row in carray ==>", data[2])
 
         self.assertEqual(carray.nrows, 3)
-        self.assertTrue(allequal(data[
-                        0], numpy.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(allequal(data[
-                        1], numpy.array([3, 3, 3], dtype='int32')))
-        self.assertTrue(allequal(data[
-                        2], numpy.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(allequal(data[0], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(data[1], np.array([3, 3, 3], dtype='int32')))
+        self.assertTrue(allequal(data[2], np.array([1, 1, 1], dtype='int32')))
 
 
 class CopyTestCase(common.TempFileMixin, TestCase):
@@ -1331,7 +1321,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[...] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[...] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         if self.close:
             if common.verbose:
@@ -1386,7 +1376,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(5, 5))
-        array1[...] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[...] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         if self.close:
             if common.verbose:
@@ -1439,7 +1429,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[:2, :2] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[:2, :2] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         if self.close:
             if common.verbose:
@@ -1494,7 +1484,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[:2, :2] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[:2, :2] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         if self.close:
             if common.verbose:
@@ -1654,7 +1644,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[...] = numpy.array([["456", "2"], ["3", "457"]], dtype="S4")
+        array1[...] = np.array([["456", "2"], ["3", "457"]], dtype="S4")
 
         if self.close:
             if common.verbose:
@@ -1705,7 +1695,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[...] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[...] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
@@ -1745,7 +1735,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[...] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[...] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
@@ -1788,7 +1778,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        array1[...] = numpy.array([[456, 2], [3, 457]], dtype='int16')
+        array1[...] = np.array([[456, 2], [3, 457]], dtype='int16')
 
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
@@ -1843,7 +1833,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = shape
         array1[...] = r
 
@@ -1889,7 +1879,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_carray(
             self.h5file.root, 'array1', atom=atom, shape=shape,
             title="title array1", chunkshape=(2, 2))
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = shape
         array1[...] = r
 
@@ -2021,7 +2011,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
             filters=tables.Filters(complib='lzo', complevel=1))
 
         # Fill the array
-        na = numpy.arange(self.narows, dtype='int8')
+        na = np.arange(self.narows, dtype='int8')
         #~ for i in xrange(self.nanumber):
             #~ s = slice(i * self.narows, (i + 1)*self.narows)
             #~ array[s] = na
@@ -2060,7 +2050,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
                 stop -= 256
             start = stop - 10
             # print("start, stop-->", start, stop)
-            print("Should look like:", numpy.arange(start, stop, dtype='int8'))
+            print("Should look like:", np.arange(start, stop, dtype='int8'))
 
         nrows = self.narows * self.nanumber
 
@@ -2071,7 +2061,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(array.shape, (nrows,))
 
         # check the 10 first elements
-        self.assertTrue(allequal(array[:10], numpy.arange(10, dtype='int8')))
+        self.assertTrue(allequal(array[:10], np.arange(10, dtype='int8')))
 
         # check the 10 last elements
         stop = self.narows % 256
@@ -2079,7 +2069,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
             stop -= 256
         start = stop - 10
         self.assertTrue(allequal(array[-10:],
-                                 numpy.arange(start, stop, dtype='int8')))
+                                 np.arange(start, stop, dtype='int8')))
 
 
 class Rows64bitsTestCase1(Rows64bitsTestCase):
@@ -2108,7 +2098,7 @@ class BigArrayTestCase(common.TempFileMixin, TestCase):
             self.assertEqual(len(self.h5file.root.array), self.shape[0])
         except OverflowError:
             # This can't be avoided in 32-bit platforms.
-            self.assertTrue(self.shape[0] > numpy.iinfo(int).max,
+            self.assertTrue(self.shape[0] > np.iinfo(int).max,
                             "Array length overflowed but ``int`` "
                             "is wide enough.")
 
@@ -2137,7 +2127,7 @@ class DfltAtomTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Read values:", values)
         self.assertTrue(
-            allequal(values, numpy.array(["abdef"]*100, "S5").reshape(10, 10)))
+            allequal(values, np.array(["abdef"]*100, "S5").reshape(10, 10)))
 
     def test01_dflt(self):
         """Check that Atom.dflt is honored (int version)."""
@@ -2153,7 +2143,7 @@ class DfltAtomTestCase(common.TempFileMixin, TestCase):
         values = self.h5file.root.bar[:]
         if common.verbose:
             print("Read values:", values)
-        self.assertTrue(allequal(values, numpy.ones((10, 10), "i4")))
+        self.assertTrue(allequal(values, np.ones((10, 10), "i4")))
 
     def test02_dflt(self):
         """Check that Atom.dflt is honored (float version)."""
@@ -2169,7 +2159,7 @@ class DfltAtomTestCase(common.TempFileMixin, TestCase):
         values = self.h5file.root.bar[:]
         if common.verbose:
             print("Read values:", values)
-        self.assertTrue(allequal(values, numpy.ones((10, 10), "f8")*1.134))
+        self.assertTrue(allequal(values, np.ones((10, 10), "f8")*1.134))
 
 
 class DfltAtomNoReopen(DfltAtomTestCase):
@@ -2196,8 +2186,8 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", repr(ca[0]))
             print("Defaults-->", repr(ca.atom.dflt))
-        self.assertTrue(allequal(ca[0], numpy.zeros(N, 'S3')))
-        self.assertTrue(allequal(ca.atom.dflt, numpy.zeros(N, 'S3')))
+        self.assertTrue(allequal(ca[0], np.zeros(N, 'S3')))
+        self.assertTrue(allequal(ca.atom.dflt, np.zeros(N, 'S3')))
 
     def test00b_zeros(self):
         """Testing default values.  Zeros (array)."""
@@ -2212,8 +2202,8 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", ca[0])
             print("Defaults-->", ca.atom.dflt)
-        self.assertTrue(allequal(ca[0], numpy.zeros(N, 'S3')))
-        self.assertTrue(allequal(ca.atom.dflt, numpy.zeros(N, 'S3')))
+        self.assertTrue(allequal(ca[0], np.zeros(N, 'S3')))
+        self.assertTrue(allequal(ca.atom.dflt, np.zeros(N, 'S3')))
 
     def test01a_values(self):
         """Testing default values.  Ones."""
@@ -2228,8 +2218,8 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", ca[0])
             print("Defaults-->", ca.atom.dflt)
-        self.assertTrue(allequal(ca[0], numpy.ones(N, 'i4')))
-        self.assertTrue(allequal(ca.atom.dflt, numpy.ones(N, 'i4')))
+        self.assertTrue(allequal(ca[0], np.ones(N, 'i4')))
+        self.assertTrue(allequal(ca.atom.dflt, np.ones(N, 'i4')))
 
     def test01b_values(self):
         """Testing default values.  Generic value."""
@@ -2245,8 +2235,8 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", ca[0])
             print("Defaults-->", ca.atom.dflt)
-        self.assertTrue(allequal(ca[0], numpy.ones(N, 'f4')*generic))
-        self.assertTrue(allequal(ca.atom.dflt, numpy.ones(N, 'f4')*generic))
+        self.assertTrue(allequal(ca[0], np.ones(N, 'f4')*generic))
+        self.assertTrue(allequal(ca.atom.dflt, np.ones(N, 'f4')*generic))
 
     def test02a_None(self):
         """Testing default values.  None (scalar)."""
@@ -2261,7 +2251,7 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", repr(ca[0]))
             print("Defaults-->", repr(ca.atom.dflt))
-        self.assertTrue(allequal(ca.atom.dflt, numpy.zeros(N, 'i4')))
+        self.assertTrue(allequal(ca.atom.dflt, np.zeros(N, 'i4')))
 
     def test02b_None(self):
         """Testing default values.  None (array)."""
@@ -2276,7 +2266,7 @@ class AtomDefaultReprTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("First row-->", ca[0])
             print("Defaults-->", ca.atom.dflt)
-        self.assertTrue(allequal(ca.atom.dflt, numpy.zeros(N, 'i4')))
+        self.assertTrue(allequal(ca.atom.dflt, np.zeros(N, 'i4')))
 
 
 class AtomDefaultReprNoReopen(AtomDefaultReprTestCase):
@@ -2312,7 +2302,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ca.nrows, 1)
         if common.verbose:
             print("First row-->", ca[0])
-        self.assertTrue(allequal(ca[0], numpy.array([[1, 3], [4, 5]], 'i4')))
+        self.assertTrue(allequal(ca[0], np.array([[1, 3], [4, 5]], 'i4')))
 
     def test01b_assign(self):
         """Assign several rows to a (unidimensional) CArray with a MD atom."""
@@ -2328,7 +2318,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ca.nrows, 3)
         if common.verbose:
             print("Third row-->", ca[2])
-        self.assertTrue(allequal(ca[2], numpy.array([[3, 3], [3, 3]], 'i4')))
+        self.assertTrue(allequal(ca[2], np.array([[3, 3], [3, 3]], 'i4')))
 
     def test02a_assign(self):
         """Assign a row to a (multidimensional) CArray with a MD atom."""
@@ -2344,7 +2334,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ca.nrows, 1)
         if common.verbose:
             print("First row-->", ca[0])
-        self.assertTrue(allequal(ca[0], numpy.array(
+        self.assertTrue(allequal(ca[0], np.array(
             [[1, 3], [4, 5], [7, 9]], 'i4')))
 
     def test02b_assign(self):
@@ -2365,7 +2355,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("Third row-->", ca[2])
         self.assertTrue(
-            allequal(ca[2], numpy.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
+            allequal(ca[2], np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
 
     def test03a_MDMDMD(self):
         """Complex assign of a MD array in a MD CArray with a MD atom."""
@@ -2379,7 +2369,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
 
         # Assign values
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 2, 4))
+        a = np.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 2, 4))
         ca[:] = [a * 1, a*2, a*3]
         self.assertEqual(ca.nrows, 3)
         if common.verbose:
@@ -2398,7 +2388,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
 
         # Assign values
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(2 * 3*3*2*4, dtype='i4').reshape((2, 3, 3, 2, 4))
+        a = np.arange(2 * 3*3*2*4, dtype='i4').reshape((2, 3, 3, 2, 4))
         ca[:] = a
         self.assertEqual(ca.nrows, 2)
         if common.verbose:
@@ -2417,7 +2407,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
 
         # Assign values
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(3 * 1*2*2*4, dtype='i4').reshape((3, 1, 2, 2, 4))
+        a = np.arange(3 * 1*2*2*4, dtype='i4').reshape((3, 1, 2, 2, 4))
         ca[:] = a
         self.assertEqual(ca.nrows, 3)
         if common.verbose:
@@ -2449,7 +2439,7 @@ class MDLargeAtomTestCase(common.TempFileMixin, TestCase):
         # Check the value
         if common.verbose:
             print("First row-->", ca[0])
-        self.assertTrue(allequal(ca[0], numpy.zeros(N, 'i4')))
+        self.assertTrue(allequal(ca[0], np.zeros(N, 'i4')))
 
 
 class MDLargeAtomNoReopen(MDLargeAtomTestCase):
@@ -2467,7 +2457,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
         self.array = self.h5file.create_carray(self.h5file.root, 'array',
                                                atom=Int32Atom(),
                                                shape=(10, 10))
-        self.array[...] = numpy.zeros((10, 10))
+        self.array[...] = np.zeros((10, 10))
 
     def test_read(self):
         self.h5file.close()
@@ -2483,7 +2473,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
 
 class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
-    obj = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    obj = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     where = '/'
     name = 'carray'
     atom = Atom.from_dtype(obj.dtype)
@@ -2509,7 +2499,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
         self.assertEqual(ptarr.atom, self.atom)
         self.assertEqual(ptarr.atom.dtype, self.atom.dtype)
         self.assertEqual(ptarr.chunkshape, self.chunkshape)
-        self.assertTrue(allequal(numpy.zeros_like(self.obj), nparr))
+        self.assertTrue(allequal(np.zeros_like(self.obj), nparr))
 
     def test_positional_args_02(self):
         ptarr = self.h5file.create_carray(self.where, self.name,
@@ -2603,7 +2593,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
         self.assertEqual(ptarr.atom, self.atom)
         self.assertEqual(ptarr.atom.dtype, self.atom.dtype)
         self.assertEqual(ptarr.chunkshape, self.chunkshape)
-        self.assertTrue(allequal(numpy.zeros_like(self.obj), nparr))
+        self.assertTrue(allequal(np.zeros_like(self.obj), nparr))
 
     def test_kwargs_obj_atom(self):
         ptarr = self.h5file.create_carray(self.where, self.name,
@@ -2664,7 +2654,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(self.obj, nparr))
 
     def test_kwargs_obj_atom_error(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,
@@ -2686,7 +2676,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_01(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,
@@ -2710,7 +2700,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_03(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -15,7 +15,7 @@ import hashlib
 import tempfile
 import warnings
 
-import numpy
+import numpy as np
 
 import tables
 from tables import (
@@ -1544,7 +1544,7 @@ class SetBloscMaxThreadsTestCase(common.TempFileMixin, TestCase):
 
 class FilterTestCase(TestCase):
     def test_filter_pack_type(self):
-        self.assertEqual(type(Filters()._pack()), numpy.int64)
+        self.assertEqual(type(Filters()._pack()), np.int64)
 
     @staticmethod
     def _hexl(n):
@@ -1567,7 +1567,7 @@ class FilterTestCase(TestCase):
         self.assertEqual(self._hexl(filter_._pack()), '0x5040101')
 
     def test_filter_unpack_01(self):
-        filter_ = Filters._unpack(numpy.int64(0x0))
+        filter_ = Filters._unpack(np.int64(0x0))
         self.assertFalse(filter_.shuffle)
         self.assertFalse(filter_.fletcher32)
         self.assertEqual(filter_.least_significant_digit, None)
@@ -1575,7 +1575,7 @@ class FilterTestCase(TestCase):
         self.assertEqual(filter_.complib, None)
 
     def test_filter_unpack_02(self):
-        filter_ = Filters._unpack(numpy.int64(0x101))
+        filter_ = Filters._unpack(np.int64(0x101))
         self.assertFalse(filter_.shuffle)
         self.assertFalse(filter_.fletcher32)
         self.assertEqual(filter_.least_significant_digit, None)
@@ -1583,7 +1583,7 @@ class FilterTestCase(TestCase):
         self.assertEqual(filter_.complib, 'zlib')
 
     def test_filter_unpack_03(self):
-        filter_ = Filters._unpack(numpy.int64(0x30109))
+        filter_ = Filters._unpack(np.int64(0x30109))
         self.assertTrue(filter_.shuffle)
         self.assertTrue(filter_.fletcher32)
         self.assertEqual(filter_.least_significant_digit, None)
@@ -1591,7 +1591,7 @@ class FilterTestCase(TestCase):
         self.assertEqual(filter_.complib, 'zlib')
 
     def test_filter_unpack_04(self):
-        filter_ = Filters._unpack(numpy.int64(0x5040101))
+        filter_ = Filters._unpack(np.int64(0x5040101))
         self.assertFalse(filter_.shuffle)
         self.assertFalse(filter_.fletcher32)
         self.assertEqual(filter_.least_significant_digit, 5)
@@ -2434,18 +2434,18 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
     def setUp(self):
         super().setUp()
 
-        self.data = numpy.linspace(-5., 5., 41)
-        self.randomdata = numpy.random.random_sample(1_000_000)
-        self.randomints = numpy.random.randint(-1_000_000, 1_000_000,
-                                               1_000_000).astype('int64')
+        self.data = np.linspace(-5., 5., 41)
+        self.randomdata = np.random.random_sample(1_000_000)
+        self.randomints = np.random.randint(
+            -1_000_000, 1_000_000, 1_000_000).astype('int64')
 
         self.populateFile()
         self.h5file.close()
 
-        self.quantizeddata_0 = numpy.asarray(
+        self.quantizeddata_0 = np.asarray(
             [-5.] * 2 + [-4.] * 5 + [-3.] * 3 + [-2.] * 5 + [-1.] * 3 +
             [0.] * 5 + [1.] * 3 + [2.] * 5 + [3.] * 3 + [4.] * 5 + [5.] * 2)
-        self.quantizeddata_m1 = numpy.asarray(
+        self.quantizeddata_m1 = np.asarray(
             [-8.] * 4 + [0.] * 33 + [8.] * 4)
 
     def populateFile(self):
@@ -2484,10 +2484,10 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
         quantized_1 = quantize(self.data, 1)
         quantized_2 = quantize(self.data, 2)
         quantized_m1 = quantize(self.data, -1)
-        numpy.testing.assert_array_equal(quantized_0, self.quantizeddata_0)
-        numpy.testing.assert_array_equal(quantized_1, self.data)
-        numpy.testing.assert_array_equal(quantized_2, self.data)
-        numpy.testing.assert_array_equal(quantized_m1, self.quantizeddata_m1)
+        np.testing.assert_array_equal(quantized_0, self.quantizeddata_0)
+        np.testing.assert_array_equal(quantized_1, self.data)
+        np.testing.assert_array_equal(quantized_2, self.data)
+        np.testing.assert_array_equal(quantized_m1, self.quantizeddata_m1)
 
     def test01_quantizeDataMaxError(self):
         """Checking the maximum error introduced by the quantize() function."""
@@ -2503,23 +2503,23 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
         #self.assertLess(numpy.abs(quantized_2 - self.randomdata).max(), 0.005)
         #self.assertLess(numpy.abs(quantized_m1 - self.randomdata).max(), 1.)
 
-        self.assertTrue(numpy.abs(quantized_0 - self.randomdata).max() < 0.5)
-        self.assertTrue(numpy.abs(quantized_1 - self.randomdata).max() < 0.05)
-        self.assertTrue(numpy.abs(quantized_2 - self.randomdata).max() < 0.005)
-        self.assertTrue(numpy.abs(quantized_m1 - self.randomdata).max() < 1.)
+        self.assertTrue(np.abs(quantized_0 - self.randomdata).max() < 0.5)
+        self.assertTrue(np.abs(quantized_1 - self.randomdata).max() < 0.05)
+        self.assertTrue(np.abs(quantized_2 - self.randomdata).max() < 0.005)
+        self.assertTrue(np.abs(quantized_m1 - self.randomdata).max() < 1.)
 
     def test02_array(self):
         """Checking quantized data as written to disk."""
 
         self.h5file = tables.open_file(self.h5fname, "r")
-        numpy.testing.assert_array_equal(self.h5file.root.data1[:], self.data)
-        numpy.testing.assert_array_equal(self.h5file.root.data2[:], self.data)
-        numpy.testing.assert_array_equal(self.h5file.root.data0[:],
-                                         self.quantizeddata_0)
-        numpy.testing.assert_array_equal(self.h5file.root.datam1[:],
-                                         self.quantizeddata_m1)
-        numpy.testing.assert_array_equal(self.h5file.root.integers[:],
-                                         self.randomints)
+        np.testing.assert_array_equal(self.h5file.root.data1[:], self.data)
+        np.testing.assert_array_equal(self.h5file.root.data2[:], self.data)
+        np.testing.assert_array_equal(self.h5file.root.data0[:],
+                                      self.quantizeddata_0)
+        np.testing.assert_array_equal(self.h5file.root.datam1[:],
+                                      self.quantizeddata_m1)
+        np.testing.assert_array_equal(self.h5file.root.integers[:],
+                                      self.randomints)
         self.assertEqual(self.h5file.root.integers[:].dtype,
                          self.randomints.dtype)
 
@@ -2529,8 +2529,7 @@ class QuantizeTestCase(common.TempFileMixin, TestCase):
         #    0.05
         #)
         self.assertTrue(
-            numpy.abs(self.h5file.root.floats[:] - self.randomdata).max() <
-            0.05
+            np.abs(self.h5file.root.floats[:] - self.randomdata).max() < 0.05
         )
 
 

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import numpy
+import numpy as np
 
 import tables
 from tables import Int16Atom, Int32Atom, Float64Atom, StringAtom
@@ -75,11 +75,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         self.rowshape[earray.extdim] = self.chunksize
 
         if self.type == "string":
-            object = numpy.ndarray(buffer=b"a"*self.objsize,
-                                   shape=self.rowshape,
-                                   dtype="S%s" % earray.atom.itemsize)
+            object = np.ndarray(buffer=b"a"*self.objsize,
+                                shape=self.rowshape,
+                                dtype="S%s" % earray.atom.itemsize)
         else:
-            object = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object.shape = self.rowshape
 
         if common.verbose:
@@ -97,7 +97,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         if self.shape is not None:
             shape = self.shape
         else:
-            shape = numpy.asarray(self.obj).shape
+            shape = np.asarray(self.obj).shape
 
         return shape
 
@@ -140,11 +140,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a"*self.objsize,
+                                 shape=self.rowshape,
+                                 dtype="S%s" % earray.atom.itemsize)
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
         object_ = object_.swapaxes(earray.extdim, 0)
 
@@ -159,7 +159,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         for idx, row in enumerate(earray):
             if idx < initialrows:
                 self.assertTrue(
-                    allequal(row, numpy.asarray(self.obj[idx]), self.flavor))
+                    allequal(row, np.asarray(self.obj[idx]), self.flavor))
                 continue
 
             chunk = int((earray.nrow - initialrows) % self.chunksize)
@@ -226,11 +226,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a"*self.objsize,
+                                 shape=self.rowshape,
+                                 dtype="S%s" % earray.atom.itemsize)
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
         object_ = object_.swapaxes(earray.extdim, 0)
 
@@ -247,7 +247,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
                                                   step=self.step)):
             if idx < initialrows:
                 self.assertTrue(
-                    allequal(row, numpy.asarray(self.obj[idx]), self.flavor))
+                    allequal(row, np.asarray(self.obj[idx]), self.flavor))
                 continue
 
             if self.chunksize == 1:
@@ -308,11 +308,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a"*self.objsize,
+                                 shape=self.rowshape,
+                                 dtype="S%s" % earray.atom.itemsize)
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
         object_ = object_.swapaxes(earray.extdim, 0)
 
@@ -324,10 +324,10 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         rowshape = self.rowshape
         rowshape[self.extdim] *= (self.nappends + initialrows)
         if self.type == "string":
-            object__ = numpy.empty(
-                shape=rowshape, dtype="S%s" % earray.atom.itemsize)
+            object__ = np.empty(shape=rowshape,
+                                dtype=f"S{earray.atom.itemsize}")
         else:
-            object__ = numpy.empty(shape=rowshape, dtype=self.dtype)
+            object__ = np.empty(shape=rowshape, dtype=self.dtype)
 
         object__ = object__.swapaxes(0, self.extdim)
 
@@ -365,13 +365,13 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             if self.flavor == "numpy":
                 object = object.swapaxes(0, self.extdim)
         else:
-            object = numpy.empty(shape=self.shape, dtype=self.dtype)
+            object = np.empty(shape=self.shape, dtype=self.dtype)
 
         # Read all the array
         try:
             row = earray.read(self.start, self.stop, self.step)
         except IndexError:
-            row = numpy.empty(shape=self.shape, dtype=self.dtype)
+            row = np.empty(shape=self.shape, dtype=self.dtype)
 
         if common.verbose:
             if hasattr(object, "shape"):
@@ -412,11 +412,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         earray.nrowsinbuf = 3
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a"*self.objsize,
+                                 shape=self.rowshape,
+                                 dtype="S%s" % earray.atom.itemsize)
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
         object_ = object_.swapaxes(earray.extdim, 0)
 
@@ -428,10 +428,10 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         rowshape = self.rowshape
         rowshape[self.extdim] *= (self.nappends + initialrows)
         if self.type == "string":
-            object__ = numpy.empty(
-                shape=rowshape, dtype="S%s" % earray.atom.itemsize)
+            object__ = np.empty(shape=rowshape,
+                                dtype=f"S{earray.atom.itemsize}")
         else:
-            object__ = numpy.empty(shape=rowshape, dtype=self.dtype)
+            object__ = np.empty(shape=rowshape, dtype=self.dtype)
 
         object__ = object__.swapaxes(0, self.extdim)
 
@@ -469,18 +469,18 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             if self.flavor == "numpy":
                 object = object.swapaxes(0, self.extdim)
         else:
-            object = numpy.empty(shape=self.shape, dtype=self.dtype)
+            object = np.empty(shape=self.shape, dtype=self.dtype)
 
         # Read all the array
         try:
-            row = numpy.empty(earray.shape, dtype=earray.atom.dtype)
+            row = np.empty(earray.shape, dtype=earray.atom.dtype)
             slice_obj = [slice(None)] * len(earray.shape)
             #slice_obj[earray.maindim] = slice(self.start, stop, self.step)
             slice_obj[earray.maindim] = slice(self.start, self.stop, self.step)
             row = row[tuple(slice_obj)].copy()
             earray.read(self.start, self.stop, self.step, out=row)
         except IndexError:
-            row = numpy.empty(shape=self.shape, dtype=self.dtype)
+            row = np.empty(shape=self.shape, dtype=self.dtype)
 
         if common.verbose:
             if hasattr(object, "shape"):
@@ -534,11 +534,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                 shape=self.rowshape,
+                                 dtype=f"S{earray.atom.itemsize}")
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
 
         object_ = object_.swapaxes(earray.extdim, 0)
@@ -551,10 +551,10 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         rowshape = self.rowshape
         rowshape[self.extdim] *= (self.nappends + initialrows)
         if self.type == "string":
-            object__ = numpy.empty(
-                shape=rowshape, dtype="S%s" % earray.atom.itemsize)
+            object__ = np.empty(shape=rowshape,
+                                dtype=f"S{earray.atom.itemsize}")
         else:
-            object__ = numpy.empty(shape=rowshape, dtype=self.dtype)
+            object__ = np.empty(shape=rowshape, dtype=self.dtype)
             # Additional conversion for the numpy case
         object__ = object__.swapaxes(0, earray.extdim)
 
@@ -578,13 +578,13 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             # actually do a measure of its length
             object = object__.__getitem__(self.slices).copy()
         else:
-            object = numpy.empty(shape=self.shape, dtype=self.dtype)
+            object = np.empty(shape=self.shape, dtype=self.dtype)
 
         # Read all the array
         try:
             row = earray.__getitem__(self.slices)
         except IndexError:
-            row = numpy.empty(shape=self.shape, dtype=self.dtype)
+            row = np.empty(shape=self.shape, dtype=self.dtype)
 
         if common.verbose:
             print("Object read:\n", repr(row))
@@ -640,11 +640,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
         # Build the array to do comparisons
         if self.type == "string":
-            object_ = numpy.ndarray(buffer=b"a"*self.objsize,
-                                    shape=self.rowshape,
-                                    dtype="S%s" % earray.atom.itemsize)
+            object_ = np.ndarray(buffer=b"a" * self.objsize,
+                                 shape=self.rowshape,
+                                 dtype=f"S{earray.atom.itemsize}")
         else:
-            object_ = numpy.arange(self.objsize, dtype=earray.atom.dtype.base)
+            object_ = np.arange(self.objsize, dtype=earray.atom.dtype.base)
             object_.shape = self.rowshape
 
         object_ = object_.swapaxes(earray.extdim, 0)
@@ -657,10 +657,10 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         rowshape = self.rowshape
         rowshape[self.extdim] *= (self.nappends + initialrows)
         if self.type == "string":
-            object__ = numpy.empty(
-                shape=rowshape, dtype="S%s" % earray.atom.itemsize)
+            object__ = np.empty(shape=rowshape,
+                                dtype=f"S{earray.atom.itemsize}")
         else:
-            object__ = numpy.empty(shape=rowshape, dtype=self.dtype)
+            object__ = np.empty(shape=rowshape, dtype=self.dtype)
             # Additional conversion for the numpy case
         object__ = object__.swapaxes(0, earray.extdim)
 
@@ -687,10 +687,10 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             # actually do a measure of its length
             object = object__.__getitem__(self.slices).copy()
         else:
-            object = numpy.empty(shape=self.shape, dtype=self.dtype)
+            object = np.empty(shape=self.shape, dtype=self.dtype)
 
         if self.flavor == "numpy":
-            object = numpy.asarray(object)
+            object = np.asarray(object)
 
         if self.type == "string":
             if hasattr(self, "wslice"):
@@ -710,7 +710,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
                 earray[self.wslice] = earray[self.wslice] * 2 + 3
             elif sum(object[self.slices].shape) != 0:
                 object = object * 2 + 3
-                if numpy.prod(object.shape) > 0:
+                if np.prod(object.shape) > 0:
                     earray[self.slices] = earray[self.slices] * 2 + 3
         # Read all the array
         row = earray.__getitem__(self.slices)
@@ -718,7 +718,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
             row = earray.__getitem__(self.slices)
         except IndexError:
             print("IndexError!")
-            row = numpy.empty(shape=self.shape, dtype=self.dtype)
+            row = np.empty(shape=self.shape, dtype=self.dtype)
 
         if common.verbose:
             print("Object read:\n", repr(row))
@@ -759,8 +759,8 @@ class Basic2WriteTestCase(BasicTestCase):
 
 class Basic3WriteTestCase(BasicTestCase):
     obj = [1, 2]
-    type = numpy.asarray(obj).dtype.name
-    dtype = numpy.asarray(obj).dtype.str
+    type = np.asarray(obj).dtype.name
+    dtype = np.asarray(obj).dtype.str
     shape = (0,)
     chunkshape = (5,)
     step = 1
@@ -768,7 +768,7 @@ class Basic3WriteTestCase(BasicTestCase):
 
 
 class Basic4WriteTestCase(BasicTestCase):
-    obj = numpy.array([1, 2])
+    obj = np.array([1, 2])
     type = obj.dtype.name
     dtype = obj.dtype.str
     shape = None
@@ -779,8 +779,8 @@ class Basic4WriteTestCase(BasicTestCase):
 
 class Basic5WriteTestCase(BasicTestCase):
     obj = [1, 2]
-    type = numpy.asarray(obj).dtype.name
-    dtype = numpy.asarray(obj).dtype.str
+    type = np.asarray(obj).dtype.name
+    dtype = np.asarray(obj).dtype.str
     shape = (0,)
     chunkshape = (5,)
     step = 1
@@ -788,7 +788,7 @@ class Basic5WriteTestCase(BasicTestCase):
 
 
 class Basic6WriteTestCase(BasicTestCase):
-    obj = numpy.array([1, 2])
+    obj = np.array([1, 2])
     type = obj.dtype.name
     dtype = obj.dtype.str
     shape = None
@@ -799,8 +799,8 @@ class Basic6WriteTestCase(BasicTestCase):
 
 class Basic7WriteTestCase(BasicTestCase):
     obj = [[1, 2], [3, 4]]
-    type = numpy.asarray(obj).dtype.name
-    dtype = numpy.asarray(obj).dtype.str
+    type = np.asarray(obj).dtype.name
+    dtype = np.asarray(obj).dtype.str
     shape = (0, 2)
     chunkshape = (5,)
     step = 1
@@ -809,8 +809,8 @@ class Basic7WriteTestCase(BasicTestCase):
 
 class Basic8WriteTestCase(BasicTestCase):
     obj = [[1, 2], [3, 4]]
-    type = numpy.asarray(obj).dtype.name
-    dtype = numpy.asarray(obj).dtype.str
+    type = np.asarray(obj).dtype.name
+    dtype = np.asarray(obj).dtype.str
     shape = (0, 2)
     chunkshape = (5,)
     step = 1
@@ -819,7 +819,7 @@ class Basic8WriteTestCase(BasicTestCase):
 
 class EmptyEArrayTestCase(BasicTestCase):
     type = 'int32'
-    dtype = numpy.dtype('int32')
+    dtype = np.dtype('int32')
     shape = (2, 0)
     chunksize = 5
     nappends = 0
@@ -830,7 +830,7 @@ class EmptyEArrayTestCase(BasicTestCase):
 
 class NP_EmptyEArrayTestCase(BasicTestCase):
     type = 'int32'
-    dtype = numpy.dtype('()int32')
+    dtype = np.dtype('()int32')
     shape = (2, 0)
     chunksize = 5
     nappends = 0
@@ -1295,11 +1295,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=StringAtom(itemsize=3),
                                            shape=(0, 2, 2),
                                            title="Array of strings")
-        a = numpy.array([[["a", "b"], [
-                        "123", "45"], ["45", "123"]]], dtype="S3")
+        a = np.array([[["a", "b"], ["123", "45"], ["45", "123"]]], dtype="S3")
         earray.append(a[:, 1:])
-        a = numpy.array([[["s", "a"], [
-                        "ab", "f"], ["s", "abc"], ["abc", "f"]]])
+        a = np.array([[["s", "a"], ["ab", "f"], ["s", "abc"], ["abc", "f"]]])
         earray.append(a[:, 2:])
 
         # Read all the rows:
@@ -1327,11 +1325,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=StringAtom(itemsize=3),
                                            shape=(0, 2, 2),
                                            title="Array of strings")
-        a = numpy.array([[["a", "b"], [
-                        "123", "45"], ["45", "123"]]], dtype="S3")
+        a = np.array([[["a", "b"], ["123", "45"], ["45", "123"]]], dtype="S3")
         earray.append(a[:, ::2])
-        a = numpy.array([[["s", "a"], [
-                        "ab", "f"], ["s", "abc"], ["abc", "f"]]])
+        a = np.array([[["s", "a"], ["ab", "f"], ["s", "abc"], ["abc", "f"]]])
         earray.append(a[:, ::2])
 
         # Read all the rows:
@@ -1359,10 +1355,10 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         earray = self.h5file.create_earray(root, 'EAtom',
                                            atom=Int32Atom(), shape=(0, 3),
                                            title="array of ints")
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (0, 0, 0)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (0, 0, 0)],
+                     dtype='int32')
         earray.append(a[2:])  # Create an offset
-        a = numpy.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
+        a = np.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
         earray.append(a[1:])  # Create an offset
 
         # Read all the rows:
@@ -1373,12 +1369,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
             print("Third row in vlarray ==>", row[2])
 
         self.assertEqual(earray.nrows, 3)
-        self.assertTrue(allequal(row[
-                        0], numpy.array([1, 1, 1], dtype='int32')))
-        self.assertTrue(allequal(row[
-                        1], numpy.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(allequal(row[
-                        2], numpy.array([-1, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(row[0], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(allequal(row[1], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(row[2], np.array([-1, 0, 0], dtype='int32')))
 
     def test02b_int(self):
         """Checking earray with strided NumPy ints appends."""
@@ -1391,10 +1384,10 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         earray = self.h5file.create_earray(root, 'EAtom',
                                            atom=Int32Atom(), shape=(0, 3),
                                            title="array of ints")
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='int32')
         earray.append(a[::3])  # Create an offset
-        a = numpy.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
+        a = np.array([(1, 1, 1), (-1, 0, 0)], dtype='int32')
         earray.append(a[::2])  # Create an offset
 
         # Read all the rows:
@@ -1405,12 +1398,9 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
             print("Third row in vlarray ==>", row[2])
 
         self.assertEqual(earray.nrows, 3)
-        self.assertTrue(allequal(row[
-                        0], numpy.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(allequal(row[
-                        1], numpy.array([3, 3, 3], dtype='int32')))
-        self.assertTrue(allequal(row[
-                        2], numpy.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(allequal(row[0], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(allequal(row[1], np.array([3, 3, 3], dtype='int32')))
+        self.assertTrue(allequal(row[2], np.array([1, 1, 1], dtype='int32')))
 
     def test03a_int(self):
         """Checking earray with byteswapped appends (ints)"""
@@ -1424,8 +1414,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=Int32Atom(), shape=(0, 3),
                                            title="array of ints")
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1456,8 +1446,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            atom=Float64Atom(), shape=(0, 3),
                                            title="array of floats")
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='float64')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1490,8 +1480,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            title="array of ints",
                                            byteorder=byteorder)
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1526,8 +1516,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         self._reopen(mode="a")
         earray = self.h5file.get_node("/EAtom")
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='int32')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='int32')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1560,8 +1550,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
                                            title="array of floats",
                                            byteorder=byteorder)
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='float64')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1596,8 +1586,8 @@ class OffsetStrideTestCase(common.TempFileMixin, TestCase):
         self._reopen(mode='a')
         earray = self.h5file.get_node("/EAtom")
         # Add a native ordered array
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (3, 3, 3)], dtype='float64')
+        a = np.array([(0, 0, 0), (1, 0, 3), (1, 1, 1), (3, 3, 3)],
+                     dtype='float64')
         earray.append(a)
         # Change the byteorder of the array
         a = a.byteswap()
@@ -1631,7 +1621,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
 
         if self.close:
             if common.verbose:
@@ -1682,7 +1672,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
 
         if self.close:
             if common.verbose:
@@ -1829,7 +1819,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
         array1.flavor = "numpy"
-        array1.append(numpy.array([["456", "2"], ["3", "457"]], dtype="S4"))
+        array1.append(np.array([["456", "2"], ["3", "457"]], dtype="S4"))
 
         if self.close:
             if common.verbose:
@@ -1876,7 +1866,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -1914,7 +1904,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -1955,7 +1945,7 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
         # Append some user attrs
         array1.attrs.attr1 = "attr1"
         array1.attrs.attr2 = 2
@@ -2008,7 +1998,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = (100, 2)
         array1.append(r)
 
@@ -2048,7 +2038,7 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
         array1 = self.h5file.create_earray(self.h5file.root, 'array1',
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
-        r = numpy.arange(200, dtype='int32')
+        r = np.arange(200, dtype='int32')
         r.shape = (100, 2)
         array1.append(r)
 
@@ -2172,7 +2162,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
                                            atom=atom, shape=(0, 2),
                                            title="title array1")
         # Add a couple of rows
-        array1.append(numpy.array([[456, 2], [3, 457]], dtype='int16'))
+        array1.append(np.array([[456, 2], [3, 457]], dtype='int16'))
 
     def test00_truncate(self):
         """Checking EArray.truncate() method (truncating to 0 rows)"""
@@ -2190,8 +2180,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("array1-->", array1.read())
 
-        self.assertTrue(allequal(
-            array1[:], numpy.array([], dtype='int16').reshape(0, 2)))
+        self.assertTrue(allequal(array1[:],
+                                 np.array([],dtype='int16').reshape(0, 2)))
 
     def test01_truncate(self):
         """Checking EArray.truncate() method (truncating to 1 rows)"""
@@ -2209,8 +2199,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("array1-->", array1.read())
 
-        self.assertTrue(allequal(
-            array1.read(), numpy.array([[456, 2]], dtype='int16')))
+        self.assertTrue(allequal(array1.read(),
+                                 np.array([[456, 2]], dtype='int16')))
 
     def test02_truncate(self):
         """Checking EArray.truncate() method (truncating to == self.nrows)"""
@@ -2228,9 +2218,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
         if common.verbose:
             print("array1-->", array1.read())
 
-        self.assertTrue(
-            allequal(array1.read(),
-                     numpy.array([[456, 2], [3, 457]], dtype='int16')))
+        self.assertTrue(allequal(
+            array1.read(), np.array([[456, 2], [3, 457]], dtype='int16')))
 
     def test03_truncate(self):
         """Checking EArray.truncate() method (truncating to > self.nrows)"""
@@ -2250,11 +2239,11 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         self.assertEqual(array1.nrows, 4)
         # Check the original values
-        self.assertTrue(allequal(array1[:2], numpy.array([[456, 2], [3, 457]],
-                                                         dtype='int16')))
+        self.assertTrue(allequal(
+            array1[:2], np.array([[456, 2], [3, 457]], dtype='int16')))
         # Check that the added rows have the default values
-        self.assertTrue(allequal(array1[2:], numpy.array([[3, 3], [3, 3]],
-                                                         dtype='int16')))
+        self.assertTrue(allequal(
+            array1[2:], np.array([[3, 3], [3, 3]], dtype='int16')))
 
 
 class TruncateOpenTestCase(TruncateTestCase):
@@ -2285,7 +2274,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
             expectedrows=self.narows * self.nanumber)
 
         # Fill the array
-        na = numpy.arange(self.narows, dtype='int8')
+        na = np.arange(self.narows, dtype='int8')
         for i in range(self.nanumber):
             array.append(na)
 
@@ -2319,8 +2308,7 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
             if stop > 127:
                 stop -= 256
             start = stop - 10
-            print("Should look like-->", numpy.arange(start, stop,
-                                                      dtype='int8'))
+            print("Should look like-->", np.arange(start, stop, dtype='int8'))
 
         nrows = self.narows * self.nanumber
         # check nrows
@@ -2328,14 +2316,14 @@ class Rows64bitsTestCase(common.TempFileMixin, TestCase):
         # Check shape
         self.assertEqual(array.shape, (nrows,))
         # check the 10 first elements
-        self.assertTrue(allequal(array[:10], numpy.arange(10, dtype='int8')))
+        self.assertTrue(allequal(array[:10], np.arange(10, dtype='int8')))
         # check the 10 last elements
         stop = self.narows % 256
         if stop > 127:
             stop -= 256
         start = stop - 10
         self.assertTrue(allequal(array[-10:],
-                                 numpy.arange(start, stop, dtype='int8')))
+                                 np.arange(start, stop, dtype='int8')))
 
 
 class Rows64bitsTestCase1(Rows64bitsTestCase):
@@ -2364,8 +2352,8 @@ class ZeroSizedTestCase(common.TempFileMixin, TestCase):
 
         fileh = self.h5file
         ea = fileh.root.test
-        np = numpy.empty(shape=(3, 0), dtype='int32')
-        ea.append(np)
+        arr = np.empty(shape=(3, 0), dtype='int32')
+        ea.append(arr)
         self.assertEqual(ea.nrows, 1, "The number of rows should be 1.")
 
     def test02_appendWithWrongShape(self):
@@ -2373,8 +2361,8 @@ class ZeroSizedTestCase(common.TempFileMixin, TestCase):
 
         fileh = self.h5file
         ea = fileh.root.test
-        np = numpy.empty(shape=(3, 0, 3), dtype='int32')
-        self.assertRaises(ValueError, ea.append, np)
+        arr = np.empty(shape=(3, 0, 3), dtype='int32')
+        self.assertRaises(ValueError, ea.append, arr)
 
 
 # Test for dealing with multidimensional atoms
@@ -2394,7 +2382,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ea.nrows, 1)
         if common.verbose:
             print("First row-->", ea[0])
-        self.assertTrue(allequal(ea[0], numpy.array([[1, 3], [4, 5]], 'i4')))
+        self.assertTrue(allequal(ea[0], np.array([[1, 3], [4, 5]], 'i4')))
 
     def test01b_append(self):
         """Append several rows to a (unidimensional) EArray with a MD
@@ -2411,7 +2399,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[2])
-        self.assertTrue(allequal(ea[2], numpy.array([[3, 3], [3, 3]], 'i4')))
+        self.assertTrue(allequal(ea[2], np.array([[3, 3], [3, 3]], 'i4')))
 
     def test02a_append(self):
         """Append a row to a (multidimensional) EArray with a
@@ -2428,8 +2416,8 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ea.nrows, 1)
         if common.verbose:
             print("First row-->", ea[0])
-        self.assertTrue(allequal(ea[0], numpy.array(
-            [[1, 3], [4, 5], [7, 9]], 'i4')))
+        self.assertTrue(allequal(ea[0],
+                                 np.array([[1, 3], [4, 5], [7, 9]], 'i4')))
 
     def test02b_append(self):
         """Append several rows to a (multidimensional) EArray with a MD
@@ -2448,8 +2436,8 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[2])
-        self.assertTrue(allequal(
-            ea[2], numpy.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
+        self.assertTrue(allequal(ea[2],
+                                 np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
 
     def test03a_MDMDMD(self):
         """Complex append of a MD array in a MD EArray with a
@@ -2463,7 +2451,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
             ea = self.h5file.root.test
         # Append three rows
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 2, 4))
+        a = np.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 2, 4))
         ea.append([a * 1, a*2, a*3])
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
@@ -2480,7 +2468,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
             ea = self.h5file.root.test
         # Append three rows
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(2 * 3*2*4, dtype='i4').reshape((2, 1, 3, 2, 4))
+        a = np.arange(2 * 3*2*4, dtype='i4').reshape((2, 1, 3, 2, 4))
         ea.append(a * 1)
         ea.append(a * 2)
         ea.append(a * 3)
@@ -2499,7 +2487,7 @@ class MDAtomTestCase(common.TempFileMixin, TestCase):
             ea = self.h5file.root.test
         # Append three rows
         # The shape of the atom should be added at the end of the arrays
-        a = numpy.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 1, 2, 4))
+        a = np.arange(2 * 3*2*4, dtype='i4').reshape((2, 3, 1, 2, 4))
         ea.append(a * 1)
         ea.append(a * 2)
         ea.append(a * 3)
@@ -2523,7 +2511,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
         super().setUp()
         self.array = self.h5file.create_earray(self.h5file.root, 'array',
                                                atom=Int32Atom(), shape=(0, 10))
-        self.array.append(numpy.zeros((10, 10)))
+        self.array.append(np.zeros((10, 10)))
 
     def test_read(self):
         self.h5file.close()
@@ -2539,12 +2527,12 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
     def test_append(self):
         self.h5file.close()
-        self.assertRaises(tables.ClosedNodeError, self.array.append,
-                          numpy.zeros((10, 10)))
+        self.assertRaises(tables.ClosedNodeError,
+                          self.array.append, np.zeros((10, 10)))
 
 
 class TestCreateEArrayArgs(common.TempFileMixin, TestCase):
-    obj = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    obj = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     where = '/'
     name = 'earray'
     atom = tables.Atom.from_dtype(obj.dtype)
@@ -2737,7 +2725,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(self.obj, nparr))
 
     def test_kwargs_obj_atom_error(self):
-        atom = tables.Atom.from_dtype(numpy.dtype('complex'))
+        atom = tables.Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,
@@ -2759,7 +2747,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_01(self):
-        atom = tables.Atom.from_dtype(numpy.dtype('complex'))
+        atom = tables.Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,
@@ -2783,7 +2771,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, TestCase):
                           shape=shape)
 
     def test_kwargs_obj_atom_shape_error_03(self):
-        atom = tables.Atom.from_dtype(numpy.dtype('complex'))
+        atom = tables.Atom.from_dtype(np.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,

--- a/tables/tests/test_hdf5compat.py
+++ b/tables/tests/test_hdf5compat.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 
-import numpy
+import numpy as np
 
 import tables
 from tables.tests import common
@@ -48,10 +48,10 @@ class PaddedArrayTestCase(common.TestFileMixin, TestCase):
     def test(self):
         arr = self.h5file.get_node('/Test')
         data = arr.read()
-        expectedData = numpy.array(
-                [(1, 11), (2, 12), (3, 13)],
-                dtype={'names': ['A', 'B'], 'formats': ['<u4', '<u4'],
-                       'offsets': [0, 4], 'itemsize': 16})
+        expectedData = np.array(
+            [(1, 11), (2, 12), (3, 13)],
+            dtype={'names': ['A', 'B'], 'formats': ['<u4', '<u4'],
+                   'offsets': [0, 4], 'itemsize': 16})
         self.assertTrue(common.areArraysEqual(data, expectedData))
 
 
@@ -102,7 +102,7 @@ class NumericTestCase(common.TestFileMixin, TestCase):
         self.assertEqual(arr.shape, (6, 5))
 
         data = arr.read()
-        expectedData = numpy.array([
+        expectedData = np.array([
             [0, 1, 2, 3, 4],
             [1, 2, 3, 4, 5],
             [2, 3, 4, 5, 6],
@@ -237,8 +237,8 @@ class ContiguousCompoundTestCase(common.TestFileMixin, TestCase):
         for row in tbl.iterrows():
             self.assertEqual(row['a'], 3.0)
             self.assertEqual(row['b'], 4.0)
-            self.assertTrue(allequal(row['c'], numpy.array([2.0, 3.0],
-                                                           dtype="float64")))
+            self.assertTrue(allequal(row['c'],
+                                     np.array([2.0, 3.0], dtype="float64")))
             self.assertEqual(row['d'], b"d")
 
         self.h5file.close()
@@ -294,7 +294,7 @@ class ExtendibleTestCase(common.TestFileMixin, TestCase):
         self.assertEqual(len(arr), 10)
 
         data = arr.read()
-        expectedData = numpy.array([
+        expectedData = np.array([
             [1, 1, 1, 3, 3],
             [1, 1, 1, 3, 3],
             [1, 1, 1, 0, 0],
@@ -337,7 +337,7 @@ class MatlabFileTestCase(common.TestFileMixin, TestCase):
         self.assertEqual(array.shape, (3, 1))
 
     def test_numpy_str(self):
-        array = self.h5file.get_node(numpy.str_('/'), numpy.str_('a'))
+        array = self.h5file.get_node(np.str_('/'), np.str_('a'))
         self.assertEqual(array.shape, (3, 1))
 
 
@@ -352,9 +352,7 @@ class ObjectReferenceTestCase(common.TestFileMixin, TestCase):
         array = self.h5file.get_node('/ANN/my_arr')
 
         self.assertTrue(common.areArraysEqual(
-                        array[0][0][0],
-                        numpy.array([0, 0],
-                                    dtype=numpy.uint64)))
+            array[0][0][0], np.array([0, 0], dtype=np.uint64)))
 
 
 class ObjectReferenceRecursiveTestCase(common.TestFileMixin, TestCase):
@@ -368,16 +366,15 @@ class ObjectReferenceRecursiveTestCase(common.TestFileMixin, TestCase):
         array = self.h5file.get_node('/var')
 
         self.assertTrue(common.areArraysEqual(
-                        array[1][0][0],
-                        numpy.array([[116], [101], [115], [116]],
-                                    dtype=numpy.uint16)))
+            array[1][0][0],
+            np.array([[116], [101], [115], [116]], dtype=np.uint16)))
 
     def test_double_ref(self):
         array = self.h5file.get_node('/var')
         self.assertTrue(common.areArraysEqual(
-                        array[2][0][0][1][0],
-                        numpy.array([[105], [110], [115], [105], [100], [101]],
-                                    dtype=numpy.uint16)))
+            array[2][0][0][1][0],
+            np.array([[105], [110], [115], [105], [100], [101]],
+                     dtype=np.uint16)))
 
 
 def suite():

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -2,7 +2,7 @@ import os
 import copy
 import tempfile
 
-import numpy
+import numpy as np
 
 import tables
 from tables import (
@@ -277,7 +277,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         rowList1 = table.get_where_list('var2 == False', sort=True)
         rowList2 = [p.nrow for p in table if p['var2'] is False]
         # Convert to a NumPy object
-        rowList2 = numpy.array(rowList2, numpy.int64)
+        rowList2 = np.array(rowList2, np.int64)
         if verbose:
             print("Selected values:", rowList1)
             print("Should look like:", rowList2)
@@ -1825,7 +1825,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_sorted() method with no arguments."""
 
         icol = self.icol
-        sortedcol = numpy.sort(icol[:])
+        sortedcol = np.sort(icol[:])
         sortedcol2 = icol.index.read_sorted()
         if verbose:
             print("Original sorted column:", sortedcol)
@@ -1836,7 +1836,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_sorted() method with arguments (I)."""
 
         icol = self.icol
-        sortedcol = numpy.sort(icol[:])[30:55]
+        sortedcol = np.sort(icol[:])[30:55]
         sortedcol2 = icol.index.read_sorted(30, 55)
         if verbose:
             print("Original sorted column:", sortedcol)
@@ -1847,7 +1847,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_sorted() method with arguments (II)."""
 
         icol = self.icol
-        sortedcol = numpy.sort(icol[:])[33:97]
+        sortedcol = np.sort(icol[:])[33:97]
         sortedcol2 = icol.index.read_sorted(33, 97)
         if verbose:
             print("Original sorted column:", sortedcol)
@@ -1858,7 +1858,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with no arguments."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:]).astype('uint64')
+        indicescol = np.argsort(icol[:]).astype('uint64')
         indicescol2 = icol.index.read_indices()
         if verbose:
             print("Original indices column:", indicescol)
@@ -1869,7 +1869,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with arguments (I)."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[30:55].astype('uint64')
+        indicescol = np.argsort(icol[:])[30:55].astype('uint64')
         indicescol2 = icol.index.read_indices(30, 55)
         if verbose:
             print("Original indices column:", indicescol)
@@ -1880,7 +1880,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with arguments (II)."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[33:97].astype('uint64')
+        indicescol = np.argsort(icol[:])[33:97].astype('uint64')
         indicescol2 = icol.index.read_indices(33, 97)
         if verbose:
             print("Original indices column:", indicescol)
@@ -1891,7 +1891,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with arguments (III)."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[33:97:2].astype('uint64')
+        indicescol = np.argsort(icol[:])[33:97:2].astype('uint64')
         indicescol2 = icol.index.read_indices(33, 97, 2)
         if verbose:
             print("Original indices column:", indicescol)
@@ -1902,7 +1902,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with arguments (IV)."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[33:55:5].astype('uint64')
+        indicescol = np.argsort(icol[:])[33:55:5].astype('uint64')
         indicescol2 = icol.index.read_indices(33, 55, 5)
         if verbose:
             print("Original indices column:", indicescol)
@@ -1913,7 +1913,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.read_indices() method with step only."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[::3].astype('uint64')
+        indicescol = np.argsort(icol[:])[::3].astype('uint64')
         indicescol2 = icol.index.read_indices(step=3)
         if verbose:
             print("Original indices column:", indicescol)
@@ -1924,7 +1924,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.__getitem__() method with no arguments."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:]).astype('uint64')
+        indicescol = np.argsort(icol[:]).astype('uint64')
         indicescol2 = icol.index[:]
         if verbose:
             print("Original indices column:", indicescol)
@@ -1935,7 +1935,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.__getitem__() method with start."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[31].astype('uint64')
+        indicescol = np.argsort(icol[:])[31].astype('uint64')
         indicescol2 = icol.index[31]
         if verbose:
             print("Original indices column:", indicescol)
@@ -1946,7 +1946,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Index.__getitem__() method with start, stop."""
 
         icol = self.icol
-        indicescol = numpy.argsort(icol[:])[2:16].astype('uint64')
+        indicescol = np.argsort(icol[:])[2:16].astype('uint64')
         indicescol2 = icol.index[2:16]
         if verbose:
             print("Original indices column:", indicescol)
@@ -1957,8 +1957,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.itersorted() method with no arguments."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol')], dtype=table._v_dtype)
         if verbose:
@@ -1970,8 +1970,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.itersorted() method with a start."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[15:]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[15:]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', start=15)], dtype=table._v_dtype)
         if verbose:
@@ -1983,8 +1983,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.itersorted() method with a stop."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[:20]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[:20]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', stop=20)], dtype=table._v_dtype)
         if verbose:
@@ -1996,8 +1996,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.itersorted() method with a start and stop."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[15:20]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[15:20]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', start=15, stop=20)], dtype=table._v_dtype)
         if verbose:
@@ -2010,8 +2010,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         step."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[15:45:4]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[15:45:4]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', start=15, stop=45, step=4)], dtype=table._v_dtype)
         if verbose:
@@ -2024,8 +2024,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         step."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[33:55:5]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[33:55:5]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', start=33, stop=55, step=5)], dtype=table._v_dtype)
         if verbose:
@@ -2037,8 +2037,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.itersorted() method with checkCSI=True."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', checkCSI=True)], dtype=table._v_dtype)
         if verbose:
@@ -2052,8 +2052,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
 
         # see also gh-252
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[55:33:-5]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[55:33:-5]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', start=55, stop=33, step=-5)], dtype=table._v_dtype)
         if verbose:
@@ -2066,8 +2066,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
 
         # see also gh-252
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[::-5]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[::-5]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
              'icol', step=-5)], dtype=table._v_dtype)
         if verbose:
@@ -2080,8 +2080,8 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
 
         # see also gh-252
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[::-1]
-        sortedtable2 = numpy.array(
+        sortedtable = np.sort(table[:], order='icol')[::-1]
+        sortedtable2 = np.array(
             [row.fetch_all_fields() for row in table.itersorted(
                 'icol', step=-1)], dtype=table._v_dtype)
         if verbose:
@@ -2093,7 +2093,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with no arguments."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table.read_sorted('icol')
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2104,7 +2104,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with a start."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[16:17]
+        sortedtable = np.sort(table[:], order='icol')[16:17]
         sortedtable2 = table.read_sorted('icol', start=16)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2115,7 +2115,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with a start and stop."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[16:33]
+        sortedtable = np.sort(table[:], order='icol')[16:33]
         sortedtable2 = table.read_sorted('icol', start=16, stop=33)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2127,7 +2127,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         step."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[33:55:5]
+        sortedtable = np.sort(table[:], order='icol')[33:55:5]
         sortedtable2 = table.read_sorted('icol', start=33, stop=55, step=5)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2138,7 +2138,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with only a step."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[::3]
+        sortedtable = np.sort(table[:], order='icol')[::3]
         sortedtable2 = table.read_sorted('icol', step=3)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2149,7 +2149,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with negative step."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[::-1]
+        sortedtable = np.sort(table[:], order='icol')[::-1]
         sortedtable2 = table.read_sorted('icol', step=-1)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2160,7 +2160,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with negative step (II)."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')[::-2]
+        sortedtable = np.sort(table[:], order='icol')[::-2]
         sortedtable2 = table.read_sorted('icol', step=-2)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2173,7 +2173,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         table = self.table
         sstart = 100-24-1
         sstop = 100-54-1
-        sortedtable = numpy.sort(table[:], order='icol')[sstart:sstop:-1]
+        sortedtable = np.sort(table[:], order='icol')[sstart:sstop:-1]
         sortedtable2 = table.read_sorted('icol', start=24, stop=54, step=-1)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2186,7 +2186,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         table = self.table
         sstart = 100-14-1
         sstop = 100-54-1
-        sortedtable = numpy.sort(table[:], order='icol')[sstart:sstop:-3]
+        sortedtable = np.sort(table[:], order='icol')[sstart:sstop:-3]
         sortedtable2 = table.read_sorted('icol', start=14, stop=54, step=-3)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2199,7 +2199,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         table = self.table
         sstart = 100-24-1
         sstop = 100-25-1
-        sortedtable = numpy.sort(table[:], order='icol')[sstart:sstop:-2]
+        sortedtable = np.sort(table[:], order='icol')[sstart:sstop:-2]
         sortedtable2 = table.read_sorted('icol', start=24, stop=25, step=-2)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2212,7 +2212,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         table = self.table
         sstart = 100-137-1
         sstop = 100-25-1
-        sortedtable = numpy.sort(table[:], order='icol')[sstart:sstop:-2]
+        sortedtable = np.sort(table[:], order='icol')[sstart:sstop:-2]
         sortedtable2 = table.read_sorted('icol', start=137, stop=25, step=-2)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2223,7 +2223,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with checkCSI (I)."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table.read_sorted('icol', checkCSI=True)
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2244,7 +2244,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol")
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2258,7 +2258,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol", step=-1)
-        sortedtable = numpy.sort(table[:], order='icol')[::-1]
+        sortedtable = np.sort(table[:], order='icol')[::-1]
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2272,7 +2272,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol", start=3)
-        sortedtable = numpy.sort(table[:], order='icol')[3:4]
+        sortedtable = np.sort(table[:], order='icol')[3:4]
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2286,7 +2286,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol", start=3, stop=40)
-        sortedtable = numpy.sort(table[:], order='icol')[3:40]
+        sortedtable = np.sort(table[:], order='icol')[3:40]
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2301,7 +2301,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol",
                             start=3, stop=33, step=5)
-        sortedtable = numpy.sort(table[:], order='icol')[3:33:5]
+        sortedtable = np.sort(table[:], order='icol')[3:33:5]
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2316,7 +2316,7 @@ class CompletelySortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol")
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table2[:]
         if verbose:
             print("Original sorted table:", sortedtable)
@@ -2389,7 +2389,7 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         """Testing the Table.read_sorted() method with no arguments."""
 
         table = self.table
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table.read_sorted('icol')
         if verbose:
             print("Sorted table:", sortedtable)
@@ -2397,7 +2397,7 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         # Compare with the sorted read table because we have no
         # guarantees that read_sorted returns a completely sorted table
         self.assertTrue(allequal(sortedtable,
-                                 numpy.sort(sortedtable2, order="icol")))
+                                 np.sort(sortedtable2, order="icol")))
 
     def test01_readSorted2(self):
         """Testing the Table.read_sorted() method with no arguments
@@ -2405,7 +2405,7 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
 
         self._reopen()
         table = self.h5file.root.table
-        sortedtable = numpy.sort(table[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
         sortedtable2 = table.read_sorted('icol')
         if verbose:
             print("Sorted table:", sortedtable)
@@ -2413,7 +2413,7 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         # Compare with the sorted read table because we have no
         # guarantees that read_sorted returns a completely sorted table
         self.assertTrue(allequal(sortedtable,
-                                 numpy.sort(sortedtable2, order="icol")))
+                                 np.sort(sortedtable2, order="icol")))
 
     def test02_copy_sorted1(self):
         """Testing the Table.copy(sortby) method."""
@@ -2422,8 +2422,8 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol")
-        sortedtable = numpy.sort(table[:], order='icol')
-        sortedtable2 = numpy.sort(table2[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
+        sortedtable2 = np.sort(table2[:], order='icol')
         if verbose:
             print("Original table:", table2[:])
             print("The sorted values from copy:", sortedtable2)
@@ -2437,8 +2437,8 @@ class ReadSortedIndexTestCase(TempFileMixin, TestCase):
         # Copy to another table
         table.nrowsinbuf = self.nrowsinbuf
         table2 = table.copy("/", 'table2', sortby="icol")
-        sortedtable = numpy.sort(table[:], order='icol')
-        sortedtable2 = numpy.sort(table2[:], order='icol')
+        sortedtable = np.sort(table[:], order='icol')
+        sortedtable2 = np.sort(table2[:], order='icol')
         if verbose:
             print("Original table:", table2[:])
             print("The sorted values from copy:", sortedtable2)
@@ -2484,8 +2484,8 @@ class Issue156TestBase(common.TempFileMixin, TestCase):
         # fill table with 10 random numbers
         for k in range(10):
             row = table.row
-            row['frame'] = numpy.random.randint(0, 2**16-1)
-            row['Bar/code'] = numpy.random.randint(0, 2**16-1)
+            row['frame'] = np.random.randint(0, 2**16-1)
+            row['Bar/code'] = np.random.randint(0, 2**16-1)
             row.append()
 
         self.h5file.flush()
@@ -2504,7 +2504,7 @@ class Issue156TestBase(common.TempFileMixin, TestCase):
                                 propindexes=True)
 
         # check column is sorted
-        self.assertTrue(numpy.all(
+        self.assertTrue(np.all(
             new_node.col(self.sort_field) ==
             sorted(oldNode.col(self.sort_field))))
         # check index is available
@@ -2580,7 +2580,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         r = table.row
         for i in range(5):
             r['index'] = i
-            r['values'] = numpy.nan if i == 0 else i
+            r['values'] = np.nan if i == 0 else i
             r.append()
         table.flush()
 
@@ -2600,7 +2600,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         r = table.row
         for i in range(5):
             r['index'] = i
-            r['values'] = numpy.nan if i == 2 or i == 3 else i
+            r['values'] = np.nan if i == 2 or i == 3 else i
             r['values2'] = i
             r.append()
         table.flush()
@@ -2625,7 +2625,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         for _ in range(100):
             for i in range(5):
                 r['index'] = i
-                r['values'] = numpy.nan if i == 2 or i == 3 else i
+                r['values'] = np.nan if i == 2 or i == 3 else i
                 r['values2'] = i
                 r.append()
         table.flush()
@@ -2650,7 +2650,7 @@ class TestIndexingNans(TempFileMixin, TestCase):
         for x in range(100):
             for i in range(5):
                 r['index'] = i
-                r['values'] = numpy.nan if i == 2 or i == 3 else i
+                r['values'] = np.nan if i == 2 or i == 3 else i
                 r['values2'] = i
                 r.append()
         table.flush()

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -2,7 +2,7 @@ import os
 import random
 import tempfile
 
-import numpy
+import numpy as np
 
 import tables
 from tables import StringCol, BoolCol, IntCol, FloatCol
@@ -874,7 +874,7 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
 
         # Convert the limits to the appropriate type
         # il = numpy.string_(self.il)
-        sl = numpy.string_(self.sl)
+        sl = np.string_(self.sl)
 
         # Do some selections and check the results
         t1col = table1.cols.var1
@@ -998,7 +998,7 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
 
         # Do some selections and check the results
         t1var2 = table1.cols.var2
-        false = numpy.bool_(False)
+        false = np.bool_(False)
         self.assertFalse(false)     # silence pyflakes
         condition = 't1var2==false'
         self.assertTrue(
@@ -1125,7 +1125,7 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
 
         # Convert the limits to the appropriate type
         # il = numpy.int32(self.il)
-        sl = numpy.uint16(self.sl)
+        sl = np.uint16(self.sl)
 
         # Do some selections and check the results
         t1col = table1.cols.var3
@@ -1321,7 +1321,7 @@ class SelectValuesTestCase(common.TempFileMixin, TestCase):
 
         # Convert the limits to the appropriate type
         # il = numpy.float32(self.il)
-        sl = numpy.float64(self.sl)
+        sl = np.float64(self.sl)
 
         # Do some selections and check the results
         t1col = table1.cols.var4
@@ -3159,7 +3159,7 @@ class LastRowReuseBuffers(TestCase):
     # Test that checks for possible reuse of buffers coming
     # from last row in the sorted part of indexes
     nelem = 1221
-    numpy.random.seed(1)
+    np.random.seed(1)
     random.seed(1)
 
     class Record(tables.IsDescription):
@@ -3181,7 +3181,7 @@ class LastRowReuseBuffers(TestCase):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=64)
         ta = self.h5file.create_table('/', 'table', self.Record,
                                       filters=tables.Filters(1))
-        id1 = numpy.random.randint(0, 2**15, self.nelem)
+        id1 = np.random.randint(0, 2**15, self.nelem)
         ta.append([id1])
 
         ta.cols.id1.create_index()
@@ -3200,7 +3200,7 @@ class LastRowReuseBuffers(TestCase):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=0)
         ta = self.h5file.create_table('/', 'table', self.Record,
                                       filters=tables.Filters(1))
-        id1 = numpy.random.randint(0, 2**15, self.nelem)
+        id1 = np.random.randint(0, 2**15, self.nelem)
         ta.append([id1])
 
         ta.cols.id1.create_index()
@@ -3219,7 +3219,7 @@ class LastRowReuseBuffers(TestCase):
         self.h5file = tables.open_file(self.h5fname, 'w', node_cache_slots=-64)
         ta = self.h5file.create_table('/', 'table', self.Record,
                                       filters=tables.Filters(1))
-        id1 = numpy.random.randint(0, 2**15, self.nelem)
+        id1 = np.random.randint(0, 2**15, self.nelem)
         ta.append([id1])
 
         ta.cols.id1.create_index()
@@ -3304,16 +3304,16 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
     open_mode = 'w'
 
     def test01(self):
-        numpy.random.seed(2)
+        np.random.seed(2)
         n = 700_000
         cs = 50_000
         nchunks = n // cs
 
-        arr = numpy.zeros(
+        arr = np.zeros(
             (n,), dtype=[('index', 'i8'), ('o', 'i8'), ('value', 'f8')])
-        arr['index'] = numpy.arange(n)
-        arr['o'] = numpy.random.randint(-20_000, -15_000, size=n)
-        arr['value'] = numpy.random.randn(n)
+        arr['index'] = np.arange(n)
+        arr['o'] = np.random.randint(-20_000, -15_000, size=n)
+        arr['value'] = np.random.randn(n)
 
         node = self.h5file.create_group('/', 'foo')
         table = self.h5file.create_table(node, 'table', dict(
@@ -3325,17 +3325,17 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
 
         self._reopen('a')
 
-        v1 = numpy.unique(arr['o'])[0]
-        v2 = numpy.unique(arr['o'])[1]
-        res = numpy.array([v1, v2])
+        v1 = np.unique(arr['o'])[0]
+        v2 = np.unique(arr['o'])[1]
+        res = np.array([v1, v2])
         selector = f'((o == {v1}) | (o == {v2}))'
         if verbose:
             print("selecting values: %s" % selector)
 
         table = self.h5file.root.foo.table
 
-        result = numpy.unique(table.read_where(selector)['o'])
-        numpy.testing.assert_almost_equal(result, res)
+        result = np.unique(table.read_where(selector)['o'])
+        np.testing.assert_almost_equal(result, res)
         if verbose:
             print("select entire table:")
             print(f"result: {result}\texpected: {res}")
@@ -3348,8 +3348,8 @@ class BuffersizeMultipleChunksize(common.TempFileMixin, TestCase):
             print("select via chunks")
         for i in range(nchunks):
             result = table.read_where(selector, start=i*cs, stop=(i+1)*cs)
-            result = numpy.unique(result['o'])
-            numpy.testing.assert_almost_equal(numpy.unique(result), res)
+            result = np.unique(result['o'])
+            np.testing.assert_almost_equal(np.unique(result), res)
             if verbose:
                 print(f"result: {result}\texpected: {res}")
 
@@ -3364,7 +3364,7 @@ class SideEffectNumPyQuicksort(TestCase):
         h5 = tables.open_file(tmp_file, "a")
         o = h5.root.table
         vals = o.cols.path[:]
-        npvals = set(numpy.where(vals == 6)[0])
+        npvals = set(np.where(vals == 6)[0])
 
         # Setting the chunkshape is critical for reproducing the bug
         t = o.copy(newname="table2", chunkshape=2730)

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -14,7 +14,7 @@
 import sys
 import itertools
 
-import numpy
+import numpy as np
 
 import tables as t
 from tables.utils import SizeType
@@ -117,7 +117,7 @@ testABuffer = [
     ((4, 3), (7j, 7., ('oo', (7j, 5j), (7., 5.), (2, 1)),
      'OO', 9), 'dd', ('OO', 7j), ((7., 5.), (7., 5.)), 9),
 ]
-testAData = numpy.array(testABuffer, dtype=testADescr)
+testAData = np.array(testABuffer, dtype=testADescr)
 # The name of the column to be searched:
 testCondCol = 'Info/z2'
 # The name of a nested column (it can not be searched):
@@ -259,7 +259,7 @@ class CreateTestCase(common.TempFileMixin, TestCase):
         tbl = self.h5file.create_table(
             '/', 'test', self._TestTDescr, title=self._getMethodName())
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         self.assertTrue(common.areArraysEqual(nrarr, self._testAData),
                         "Can not create a compatible structured array.")
 
@@ -467,7 +467,7 @@ class WriteTestCase(common.TempFileMixin, TestCase):
         raTable = self._testAData.copy()
         raColumn = raTable[nColumn]
         (raColumn[0], raColumn[-1]) = (raColumn[-1].copy(), raColumn[0].copy())
-        newdtype = numpy.dtype([(nColumn, raTable.dtype.fields[nColumn][0])])
+        newdtype = np.dtype([(nColumn, raTable.dtype.fields[nColumn][0])])
         self.assertIsNotNone(newdtype)
 
         # Write the resulting column and re-read the whole table.
@@ -497,7 +497,7 @@ class WriteTestCase(common.TempFileMixin, TestCase):
 
         # Get the nested column data and swap the first and last rows.
         colnames = ['x', 'color']  # Get the first two columns
-        raCols = numpy.rec.fromarrays([
+        raCols = np.rec.fromarrays([
             self._testAData['x'].copy(),
             self._testAData['color'].copy()],
             dtype=[('x', '(2,)i4'), ('color', 'a2')])
@@ -516,9 +516,9 @@ class WriteTestCase(common.TempFileMixin, TestCase):
             tbl = self.h5file.root.test
 
         # Re-read the appropriate columns
-        raCols2 = numpy.rec.fromarrays([tbl.cols._f_col('x'),
-                                        tbl.cols._f_col('color')],
-                                       dtype=raCols.dtype)
+        raCols2 = np.rec.fromarrays([tbl.cols._f_col('x'),
+                                     tbl.cols._f_col('color')],
+                                    dtype=raCols.dtype)
         if common.verbose:
             print("Table read:", raCols2)
             print("Should look like:", raCols)
@@ -588,7 +588,7 @@ class WriteTestCase(common.TempFileMixin, TestCase):
             self._testCondition, self._testCondVars(tbl))
         searchedCoords.sort()
 
-        expectedCoords = numpy.arange(0, minRowIndex * 2, 2, SizeType)
+        expectedCoords = np.arange(0, minRowIndex * 2, 2, SizeType)
         if common.verbose:
             print("Searched coords:", searchedCoords)
             print("Expected coords:", expectedCoords)
@@ -748,8 +748,8 @@ class ReadTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.rec.array(testABuffer,
-                                dtype=tbl.description._v_nested_descr)
+        nrarr = np.rec.array(testABuffer,
+                             dtype=tbl.description._v_nested_descr)
         tblcols = tbl.read(start=0, step=2, field='Info')
         nrarrcols = nrarr['Info'][0::2]
         if common.verbose:
@@ -767,13 +767,13 @@ class ReadTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.rec.array(testABuffer,
-                                dtype=tbl.description._v_nested_descr)
+        nrarr = np.rec.array(testABuffer,
+                             dtype=tbl.description._v_nested_descr)
         # When reading an entire nested column, the output array must contain
         # all fields in the table.  The output buffer will contain the contents
         # of all fields.  The selected column alone will be returned from the
         # method call.
-        all_cols = numpy.empty(1, tbl.dtype)
+        all_cols = np.empty(1, tbl.dtype)
         tblcols = tbl.read(start=0, step=2, field='Info', out=all_cols)
         nrarrcols = nrarr['Info'][0::2]
         if common.verbose:
@@ -796,8 +796,8 @@ class ReadTestCase(common.TempFileMixin, TestCase):
             tbl = self.h5file.root.test
 
         tblcols = tbl.read(start=0, step=2, field='Info/value')
-        nrarr = numpy.rec.array(testABuffer,
-                                dtype=tbl.description._v_nested_descr)
+        nrarr = np.rec.array(testABuffer,
+                             dtype=tbl.description._v_nested_descr)
         nrarrcols = nrarr['Info']['value'][0::2]
         self.assertTrue(common.areArraysEqual(nrarrcols, tblcols),
                         "Original array are retrieved doesn't match.")
@@ -813,10 +813,10 @@ class ReadTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        tblcols = numpy.empty(1, dtype='c16')
+        tblcols = np.empty(1, dtype='c16')
         tbl.read(start=0, step=2, field='Info/value', out=tblcols)
-        nrarr = numpy.rec.array(testABuffer,
-                                dtype=tbl.description._v_nested_descr)
+        nrarr = np.rec.array(testABuffer,
+                             dtype=tbl.description._v_nested_descr)
         nrarrcols = nrarr['Info']['value'][0::2]
         self.assertTrue(common.areArraysEqual(nrarrcols, tblcols),
                         "Original array are retrieved doesn't match.")
@@ -872,7 +872,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
   info (Cols(), Description)
   y (Column(0, 2, 2), ('{}', (2, 2)))
   z (Column(0,), uint8)
-""".format(numpy.int32(0).dtype.str, numpy.float64(0).dtype.str))
+""".format(np.int32(0).dtype.str, np.float64(0).dtype.str))
 
     def test00b_repr(self):
         """Checking string representation of nested Cols."""
@@ -986,7 +986,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols[1]
         nrarrcols = nrarr[1]
         if common.verbose:
@@ -1006,7 +1006,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols[0:2]
         nrarrcols = nrarr[0:2]
         if common.verbose:
@@ -1026,7 +1026,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols[0::2]
         nrarrcols = nrarr[0::2]
         if common.verbose:
@@ -1046,7 +1046,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info')[1]
         nrarrcols = nrarr['Info'][1]
         if common.verbose:
@@ -1066,7 +1066,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info')[0:2]
         nrarrcols = nrarr['Info'][0:2]
         if common.verbose:
@@ -1087,7 +1087,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info')[0::2]
         nrarrcols = nrarr['Info'][0::2]
         if common.verbose:
@@ -1107,7 +1107,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info/value')[1]
         nrarrcols = nrarr['Info']['value'][1]
         if common.verbose:
@@ -1127,7 +1127,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info/value')[0:2]
         nrarrcols = nrarr['Info']['value'][0:2]
         if common.verbose:
@@ -1148,7 +1148,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         tblcols = tbl.cols._f_col('Info/value')[0::2]
         nrarrcols = nrarr['Info']['value'][0::2]
         if common.verbose:
@@ -1166,7 +1166,7 @@ class ColsTestCase(common.TempFileMixin, TestCase):
             self._reopen()
             tbl = self.h5file.root.test
 
-        nrarr = numpy.array(testABuffer, dtype=tbl.description._v_nested_descr)
+        nrarr = np.array(testABuffer, dtype=tbl.description._v_nested_descr)
         row_num = 0
         for item in tbl.cols.Info.value:
             self.assertEqual(item, nrarr['Info']['value'][row_num])

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -16,7 +16,7 @@ import types
 import warnings
 import functools
 
-import numpy
+import numpy as np
 
 import tables
 from tables.utils import SizeType
@@ -26,10 +26,6 @@ from tables.tests.common import verbosePrint as vprint
 from tables.tests.common import PyTablesTestCase as TestCase
 
 
-from numpy import (log10, exp, log, abs, sqrt, sin, cos, tan,
-                   arcsin, arccos, arctan)
-
-
 # Data parameters
 # ---------------
 row_period = 50
@@ -37,8 +33,8 @@ row_period = 50
 md_shape = (2, 2)
 """Shape of multidimensional fields."""
 
-_maxnvalue = row_period + numpy.prod(md_shape, dtype=SizeType) - 1
-_strlen = int(numpy.log10(_maxnvalue-1)) + 1
+_maxnvalue = row_period + np.prod(md_shape, dtype=SizeType) - 1
+_strlen = int(np.log10(_maxnvalue-1)) + 1
 
 str_format = '%%0%dd' % _strlen
 """Format of string values."""
@@ -51,36 +47,36 @@ small_blocksizes = (300, 60, 20, 5)
 # Type information
 # ----------------
 type_info = {
-    'bool': (numpy.bool_, bool),
-    'int8': (numpy.int8, int),
-    'uint8': (numpy.uint8, int),
-    'int16': (numpy.int16, int),
-    'uint16': (numpy.uint16, int),
-    'int32': (numpy.int32, int),
-    'uint32': (numpy.uint32, int),
-    'int64': (numpy.int64, int),
-    'uint64': (numpy.uint64, int),
-    'float32': (numpy.float32, float),
-    'float64': (numpy.float64, float),
-    'complex64': (numpy.complex64, complex),
-    'complex128': (numpy.complex128, complex),
-    'time32': (numpy.int32, int),
-    'time64': (numpy.float64, float),
-    'enum': (numpy.uint8, int),  # just for these tests
-    'string': ('S%s' % _strlen, numpy.string_),  # just for these tests
+    'bool': (np.bool_, bool),
+    'int8': (np.int8, int),
+    'uint8': (np.uint8, int),
+    'int16': (np.int16, int),
+    'uint16': (np.uint16, int),
+    'int32': (np.int32, int),
+    'uint32': (np.uint32, int),
+    'int64': (np.int64, int),
+    'uint64': (np.uint64, int),
+    'float32': (np.float32, float),
+    'float64': (np.float64, float),
+    'complex64': (np.complex64, complex),
+    'complex128': (np.complex128, complex),
+    'time32': (np.int32, int),
+    'time64': (np.float64, float),
+    'enum': (np.uint8, int),  # just for these tests
+    'string': ('S%s' % _strlen, np.string_),  # just for these tests
 }
 """NumPy and Numexpr type for each PyTables type that will be tested."""
 
 # globals dict for eval()
-func_info = {'log10': log10, 'log': log, 'exp': exp,
-             'abs': abs, 'sqrt': sqrt,
-             'sin': sin, 'cos': cos, 'tan': tan,
-             'arcsin': arcsin, 'arccos': arccos, 'arctan': arctan}
+func_info = {'log10': np.log10, 'log': np.log, 'exp': np.exp,
+             'abs': np.abs, 'sqrt': np.sqrt,
+             'sin': np.sin, 'cos': np.cos, 'tan': np.tan,
+             'arcsin': np.arcsin, 'arccos': np.arccos, 'arctan': np.arctan}
 """functions and NumPy.ufunc() for each function that will be tested."""
 
 
-if hasattr(numpy, 'float16'):
-    type_info['float16'] = (numpy.float16, float)
+if hasattr(np, 'float16'):
+    type_info['float16'] = (np.float16, float)
 # if hasattr(numpy, 'float96'):
 #    type_info['float96'] = (numpy.float96, float)
 # if hasattr(numpy, 'float128'):
@@ -124,7 +120,7 @@ def append_columns(classdict, shape=()):
             col = tables.EnumCol(enum, enum(0), base, shape=shape, pos=colpos)
         else:
             sctype = sctype_from_type[type_]
-            dtype = numpy.dtype((sctype, shape))
+            dtype = np.dtype((sctype, shape))
             col = tables.Col.from_dtype(dtype, pos=colpos)
         classdict[colname] = col
     ncols = colpos
@@ -208,11 +204,11 @@ def fill_table(table, shape, nrows):
         return
 
     heavy = common.heavy
-    size = int(numpy.prod(shape, dtype=SizeType))
+    size = int(np.prod(shape, dtype=SizeType))
 
     row, value = table.row, 0
     for nrow in range(nrows):
-        data = numpy.arange(value, value + size).reshape(shape)
+        data = np.arange(value, value + size).reshape(shape)
         for (type_, sctype) in sctype_from_type.items():
             if not heavy and type_ in heavy_types:
                 continue  # skip heavy type in non-heavy mode
@@ -222,9 +218,9 @@ def fill_table(table, shape, nrows):
                 coldata = data > (row_period // 2)
             elif type_ == 'string':
                 sdata = [str_format % x for x in range(value, value + size)]
-                coldata = numpy.array(sdata, dtype=sctype).reshape(shape)
+                coldata = np.array(sdata, dtype=sctype).reshape(shape)
             else:
-                coldata = numpy.asarray(data, dtype=sctype)
+                coldata = np.asarray(data, dtype=sctype)
             row[ncolname] = row[colname] = coldata
             row['c_extra'] = data - (row_period // 2)
             row['c_idxextra'] = data - (row_period // 2)
@@ -435,8 +431,8 @@ def create_test_method(type_, op, extracond, func=None):
                 if isvalidrow:
                     pyrownos.append(row.nrow)
                     pyfvalues.append(row[acolname])
-            pyrownos = numpy.array(pyrownos)  # row numbers already sorted
-            pyfvalues = numpy.array(pyfvalues, dtype=sctype)
+            pyrownos = np.array(pyrownos)  # row numbers already sorted
+            pyfvalues = np.array(pyfvalues, dtype=sctype)
             pyfvalues.sort()
             vprint("* %d rows selected by Python from ``%s``."
                    % (len(pyrownos), acolname))
@@ -444,8 +440,8 @@ def create_test_method(type_, op, extracond, func=None):
                 rownos = pyrownos  # initialise reference results
                 fvalues = pyfvalues
             else:
-                self.assertTrue(numpy.all(pyrownos == rownos))  # check
-                self.assertTrue(numpy.all(pyfvalues == fvalues))
+                self.assertTrue(np.all(pyrownos == rownos))  # check
+                self.assertTrue(np.all(pyfvalues == fvalues))
 
             # Then the in-kernel or indexed version.
             ptvars = condvars.copy()
@@ -475,11 +471,11 @@ def create_test_method(type_, op, extracond, func=None):
             vprint("* %d rows selected by PyTables from ``%s``"
                    % (len(ptrownos[0]), acolname), nonl=True)
             vprint("(indexing: %s)." % ["no", "yes"][bool(isidxq)])
-            self.assertTrue(numpy.all(ptrownos[0] == rownos))
-            self.assertTrue(numpy.all(ptfvalues[0] == fvalues))
+            self.assertTrue(np.all(ptrownos[0] == rownos))
+            self.assertTrue(np.all(ptfvalues[0] == fvalues))
             # The following test possible caching of query results.
-            self.assertTrue(numpy.all(ptrownos[0] == ptrownos[1]))
-            self.assertTrue(numpy.all(ptfvalues[0] == ptfvalues[1]))
+            self.assertTrue(np.all(ptrownos[0] == ptrownos[1]))
+            self.assertTrue(np.all(ptfvalues[0] == ptfvalues[1]))
 
     test_method.__doc__ = "Testing ``%s``." % cond
     return test_method

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -6,8 +6,6 @@ import struct
 import platform
 
 import numpy as np
-from numpy import rec as records
-from numpy import testing as npt
 
 import tables
 from tables import (
@@ -207,8 +205,8 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
             buflist.append(tuple(tmplist))
 
-        self.record = records.array(buflist, dtype=record.dtype,
-                                    shape=self.expectedrows)
+        self.record = np.rec.array(buflist, dtype=record.dtype,
+                                   shape=self.expectedrows)
 
     def populateFile(self):
         group = self.rootgroup
@@ -585,18 +583,18 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         nrows = table.nrows
         rec = list(table.iterrows())[-1]
         if isinstance(rec['var5'], np.ndarray):
-            npt.assert_array_equal(result[0],
-                                   np.array((float(0),)*4, np.float32))
-            npt.assert_array_equal(result[1],
-                                   np.array((float(1),)*4, np.float32))
-            npt.assert_array_equal(result[2],
-                                   np.array((float(2),)*4, np.float32))
-            npt.assert_array_equal(result[3],
-                                   np.array((float(3),)*4, np.float32))
-            npt.assert_array_equal(result[10],
-                                   np.array((float(10),)*4, np.float32))
-            npt.assert_array_equal(rec['var5'],
-                                   np.array((float(nrows-1),)*4, np.float32))
+            np.testing.assert_array_equal(
+                result[0], np.array((float(0),)*4, np.float32))
+            np.testing.assert_array_equal(
+                result[1], np.array((float(1),)*4, np.float32))
+            np.testing.assert_array_equal(
+                result[2], np.array((float(2),)*4, np.float32))
+            np.testing.assert_array_equal(
+                result[3], np.array((float(3),)*4, np.float32))
+            np.testing.assert_array_equal(
+                result[10], np.array((float(10),)*4, np.float32))
+            np.testing.assert_array_equal(
+                rec['var5'], np.array((float(nrows-1),)*4, np.float32))
         else:
             self.assertEqual(rec['var5'], float(nrows - 1))
 
@@ -604,22 +602,22 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         result = [record['var10'] for record in table.iterrows()
                   if record['var2'] < 20]
         if isinstance(rec['var10'], np.ndarray):
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 result[0],
                 np.array([float(0)+0.j, 1.+float(0)*1j], np.complex128))
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 result[1],
                 np.array([float(1)+0.j, 1.+float(1)*1j], np.complex128))
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 result[2],
                 np.array([float(2)+0.j, 1.+float(2)*1j], np.complex128))
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 result[3],
                 np.array([float(3)+0.j, 1.+float(3)*1j], np.complex128))
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 result[10],
                 np.array([float(10)+0.j, 1.+float(10)*1j], np.complex128))
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 rec['var10'],
                 np.array([float(nrows-1)+0.j, 1.+float(nrows-1)*1j],
                          np.complex128))
@@ -1626,8 +1624,8 @@ class RecArrayOneWriteTestCase(BasicTestCase):
         formats.append('c32')
         names.append('var15')
 
-    record = records.array(None, shape=0, formats=','.join(formats),
-                           names=names)
+    record = np.rec.array(
+        None, shape=0, formats=','.join(formats), names=names)
 
 
 class RecArrayTwoWriteTestCase(BasicTestCase):
@@ -1653,8 +1651,8 @@ class RecArrayTwoWriteTestCase(BasicTestCase):
         formats.append('c32')
         names.append('var15')
 
-    recordtemplate = records.array(None, shape=1, formats=','.join(formats),
-                                   names=names)
+    recordtemplate = np.rec.array(
+        None, shape=1, formats=','.join(formats), names=names)
 
 
 class RecArrayThreeWriteTestCase(BasicTestCase):
@@ -1680,8 +1678,8 @@ class RecArrayThreeWriteTestCase(BasicTestCase):
         formats.append('c32')
         names.append('var15')
 
-    recordtemplate = records.array(None, shape=1, formats=','.join(formats),
-                                   names=names)
+    recordtemplate = np.rec.array(
+        None, shape=1, formats=','.join(formats), names=names)
 
 
 class RecArrayAlignedWriteTestCase(BasicTestCase):
@@ -1707,8 +1705,8 @@ class RecArrayAlignedWriteTestCase(BasicTestCase):
         formats.append('c32')
         names.append('var15')
 
-    recordtemplate = records.array(None, shape=1, formats=','.join(formats),
-                                   names=names, aligned=True)
+    recordtemplate = np.rec.array(
+        None, shape=1, formats=','.join(formats), names=names, aligned=True)
 
 
 @unittest.skipIf(not common.blosc_avail,
@@ -1947,19 +1945,19 @@ class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):
 
     def test_read_all(self):
         output = self.table.read()
-        npt.assert_array_equal(output, self.array)
+        np.testing.assert_array_equal(output, self.array)
 
     def test_read_slice1(self):
         output = self.table.read(0, 51)
-        npt.assert_array_equal(output, self.array[0:51])
+        np.testing.assert_array_equal(output, self.array[0:51])
 
     def test_read_all_rows_specified_field(self):
         output = self.table.read(field='f1')
-        npt.assert_array_equal(output, self.array['f1'])
+        np.testing.assert_array_equal(output, self.array['f1'])
 
     def test_read_slice1_specified_field(self):
         output = self.table.read(1, 64, field='f1')
-        npt.assert_array_equal(output, self.array['f1'][1:64])
+        np.testing.assert_array_equal(output, self.array['f1'][1:64])
 
     def test_out_arg_with_non_numpy_flavor(self):
         output = np.empty(self.shape, self.dtype)
@@ -1973,40 +1971,40 @@ class NonNestedTableReadTestCase(common.TempFileMixin, TestCase):
     def test_read_all_out_arg(self):
         output = np.empty(self.shape, self.dtype)
         self.table.read(out=output)
-        npt.assert_array_equal(output, self.array)
+        np.testing.assert_array_equal(output, self.array)
 
     def test_read_slice1_out_arg(self):
         output = np.empty((51, ), self.dtype)
         self.table.read(0, 51, out=output)
-        npt.assert_array_equal(output, self.array[0:51])
+        np.testing.assert_array_equal(output, self.array[0:51])
 
     def test_read_all_rows_specified_field_out_arg(self):
         output = np.empty(self.shape, 'i4')
         self.table.read(field='f1', out=output)
-        npt.assert_array_equal(output, self.array['f1'])
+        np.testing.assert_array_equal(output, self.array['f1'])
 
     def test_read_slice1_specified_field_out_arg(self):
         output = np.empty((63, ), 'i4')
         self.table.read(1, 64, field='f1', out=output)
-        npt.assert_array_equal(output, self.array['f1'][1:64])
+        np.testing.assert_array_equal(output, self.array['f1'][1:64])
 
     def test_read_all_out_arg_sliced(self):
         output = np.empty((200, ), self.dtype)
         output['f0'] = np.random.randint(0, 10_000, (200, ))
         output_orig = output.copy()
         self.table.read(out=output[0:100])
-        npt.assert_array_equal(output[0:100], self.array)
-        npt.assert_array_equal(output[100:], output_orig[100:])
+        np.testing.assert_array_equal(output[0:100], self.array)
+        np.testing.assert_array_equal(output[100:], output_orig[100:])
 
     def test_all_fields_non_contiguous_slice_contiguous_buffer(self):
         output = np.empty((50, ), self.dtype)
         self.table.read(0, 100, 2, out=output)
-        npt.assert_array_equal(output, self.array[0:100:2])
+        np.testing.assert_array_equal(output, self.array[0:100:2])
 
     def test_specified_field_non_contiguous_slice_contiguous_buffer(self):
         output = np.empty((50, ), 'i4')
         self.table.read(0, 100, 2, field='f3', out=output)
-        npt.assert_array_equal(output, self.array['f3'][0:100:2])
+        np.testing.assert_array_equal(output, self.array['f3'][0:100:2])
 
     def test_all_fields_non_contiguous_buffer(self):
         output = np.empty((100, ), self.dtype)
@@ -2080,14 +2078,14 @@ class TableReadByteorderTestCase(common.TempFileMixin, TestCase):
         output = self.table.read()
         self.assertEqual(byteorders[output['f0'].dtype.byteorder],
                          self.system_byteorder)
-        npt.assert_array_equal(output['f0'], np.arange(10))
+        np.testing.assert_array_equal(output['f0'], np.arange(10))
 
     def test_table_other_byteorder_no_out_argument(self):
         self.create_table(self.other_byteorder)
         output = self.table.read()
         self.assertEqual(byteorders[output['f0'].dtype.byteorder],
                          self.system_byteorder)
-        npt.assert_array_equal(output['f0'], np.arange(10))
+        np.testing.assert_array_equal(output['f0'], np.arange(10))
 
     def test_table_system_byteorder_out_argument_system_byteorder(self):
         self.create_table(self.system_byteorder)
@@ -2097,7 +2095,7 @@ class TableReadByteorderTestCase(common.TempFileMixin, TestCase):
         self.table.read(out=output)
         self.assertEqual(byteorders[output['f0'].dtype.byteorder],
                          self.system_byteorder)
-        npt.assert_array_equal(output['f0'], np.arange(10))
+        np.testing.assert_array_equal(output['f0'], np.arange(10))
 
     def test_table_other_byteorder_out_argument_system_byteorder(self):
         self.create_table(self.other_byteorder)
@@ -2107,7 +2105,7 @@ class TableReadByteorderTestCase(common.TempFileMixin, TestCase):
         self.table.read(out=output)
         self.assertEqual(byteorders[output['f0'].dtype.byteorder],
                          self.system_byteorder)
-        npt.assert_array_equal(output['f0'], np.arange(10))
+        np.testing.assert_array_equal(output['f0'], np.arange(10))
 
     def test_table_system_byteorder_out_argument_other_byteorder(self):
         self.create_table(self.system_byteorder)
@@ -2937,18 +2935,18 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing row
         table[2] = (456, 'db2', 1.2)
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (456, b'db2', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (456, b'db2', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -2969,18 +2967,18 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing row
         table[2] = (456, 'db2', 1.2)
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (456, b'db2', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (456, b'db2', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3001,19 +2999,19 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, b'db1', 1.2)], formats="i4,a3,f8")
+        rows = np.rec.array([(457, b'db1', 1.2)], formats="i4,a3,f8")
         table[1:3:2] = rows
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3034,21 +3032,21 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
+        rows = np.rec.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
                              formats="i4,a3,f8")
         # table.modify_rows(start=1, rows=rows)
         table[1:3] = rows
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (5, b'de1', 1.3), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (5, b'de1', 1.3), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3069,21 +3067,21 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, b'db1', 1.2), (6, b'de2', 1.3)],
-                             formats="i4,a3,f8")
+        rows = np.rec.array([(457, b'db1', 1.2), (6, b'de2', 1.3)],
+                            formats="i4,a3,f8")
         # table[1:4:2] = rows
         table[1::2] = rows
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (457, b'db1', 1.2), (6, b'de2', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (457, b'db1', 1.2), (6, b'de2', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3104,18 +3102,18 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3)],
-                          formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
         table.cols.col1[1] = -1
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (-1, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (-1, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3136,18 +3134,18 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
         table.cols.col1[1:4] = [2, 3, 4]
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3168,8 +3166,8 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3181,7 +3179,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
             table.flush()
 
 #         # Create the modified recarray
-#         r1=records.array([[1,b'dbe',1.2],[2,b'ded',1.3],
+#         r1=np.rec.array([[1,b'dbe',1.2],[2,b'ded',1.3],
 #                           [3,b'db1',1.2],[4,b'de1',1.3]],
 #                          formats="i4,a3,f8",
 #                          names = "col1,col2,col3")
@@ -3206,17 +3204,17 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          1, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (1, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify just one existing column
         table.cols.col1[1:4:2] = [2, 3]
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (3, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (3, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3237,18 +3235,18 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
         table.cols.col1[1:4:3] = [2]
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3269,20 +3267,20 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Try to modify beyond the extend
         # This will silently exclude the non-fitting rows
-        rows = records.array([(457, b'db1', 1.2), (6, b'de2', 1.3)],
-                             formats="i4,a3,f8")
+        rows = np.rec.array(
+            [(457, b'db1', 1.2), (6, b'de2', 1.3)], formats="i4,a3,f8")
         table[1::2] = rows
         # How it should look like
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (457, b'db1', 1.2), (6, b'de2', 1.3)],
-                           formats="i4,a3,f8")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (457, b'db1', 1.2), (6, b'de2', 1.3)],
+                          formats="i4,a3,f8")
 
         # Read the modified table
         if self.reopen:
@@ -3326,8 +3324,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3336,10 +3334,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             (row['col1'], row['col2'], row['col3']) = (456, 'db2', 1.2)
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (456, b'db2', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (456, b'db2', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3360,8 +3358,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3373,10 +3371,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
                 (row['col1'], row['col2'], row['col3']) = (6, 'de2', 1.3)
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3397,8 +3395,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3410,10 +3408,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
                 (row['col1'], row['col2'], row['col3']) = (5, 'de1', 1.3)
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (5, b'de1', 1.3), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (5, b'de1', 1.3), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3434,8 +3432,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3447,10 +3445,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
                 (row['col1'], row['col2'], row['col3']) = (6, 'de2', 1.3)
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (457, b'db1', 1.2), (6, b'de2', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (457, b'db1', 1.2), (6, b'de2', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3471,8 +3469,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3)],
-                          formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3481,10 +3479,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row['col1'] = -1
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (-1, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (-1, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3505,8 +3503,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3515,10 +3513,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row['col1'] = row.nrow + 1
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3539,8 +3537,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         table.nrowsinbuf = self.buffersize  # set buffer value
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          1, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (1, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify just rows with col1 < 456
@@ -3549,10 +3547,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row['col2'] = 'ada'
             row.update()
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ada', 1.3),
-                            (457, b'db1', 1.2), (2, b'ada', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ada', 1.3),
+                           (457, b'db1', 1.2), (2, b'ada', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -3590,9 +3588,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats="i4,a3,f8", names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i
             r1['col2'][i] = 'b'+str(i)
@@ -3634,9 +3631,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             # row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats="i4,a3,f8", names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i-1
             r1['col2'][i] = 'a'+str(i-1)
@@ -3678,9 +3674,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats="i4,a3,f8", names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i-1
             r1['col2'][i] = 'a'+str(i-1)
@@ -3727,9 +3722,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats="i4,a3,f8", names="col1,col2,col3")
         for i in range(nrows):
             if i % 10 > 0:
                 r1['col1'][i] = i-1
@@ -3782,8 +3776,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test00..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'de', 1.3)], names='col1,col2,col3')
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'de', 1.3)], names='col1,col2,col3')
 
         # Save it in a table:
         self.h5file.create_table(self.h5file.root, 'recarray', r)
@@ -3802,8 +3796,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test01..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'de', 1.3)], names='col1,col2,col3')
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'de', 1.3)], names='col1,col2,col3')
 
         # Get an offsetted bytearray
         r1 = r[1:]
@@ -3826,7 +3820,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test02..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
+        r = np.rec.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
 
         # Get an offsetted bytearray
         r1 = r[2000:]
@@ -3849,7 +3843,7 @@ class RecArrayIO(common.TempFileMixin, TestCase):
             print("Running %s.test03..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
+        r = np.rec.array(b'a'*200_000, 'f4,3i4,a5,i2', 3000)
 
         # Get an strided recarray
         r2 = r[::2]
@@ -3883,15 +3877,15 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Create the complete table
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the original table
         if self.reopen:
             self._reopen()
@@ -3914,8 +3908,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -3923,10 +3917,10 @@ class RecArrayIO(common.TempFileMixin, TestCase):
 
         table = self.h5file.root.recarray
         # Create the complete table
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
 
         # Read the original table
         if self.reopen:
@@ -3950,17 +3944,17 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-            2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify just one existing rows
         table.modify_rows(start=1, rows=[(456, 'db1', 1.2)])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (456, b'db1', 1.2),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (456, b'db1', 1.2),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -3984,15 +3978,16 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify just one existing rows
-        table.modify_rows(start=2, rows=records.array([(456, 'db2', 1.2)],
-                                                      formats="i4,a3,f8"))
+        table.modify_rows(
+            start=2,
+            rows=np.rec.array([(456, 'db2', 1.2)], formats="i4,a3,f8"))
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
                             (456, b'db2', 1.2), (5, b'de1', 1.3)],
                            formats="i4,a3,f8",
                            names="col1,col2,col3")
@@ -4018,17 +4013,17 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify two existing rows
         table.modify_rows(start=1, rows=[(457, 'db1', 1.2), (5, 'de1', 1.3)])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (5, b'de1', 1.3), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (5, b'de1', 1.3), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4051,19 +4046,19 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify two existing rows
-        rows = records.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
-                             formats="i4,a3,f8")
+        rows = np.rec.array(
+            [(457, b'db1', 1.2), (5, b'de1', 1.3)],formats="i4,a3,f8")
         table.modify_rows(start=1, rows=rows)
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
-                            (5, b'de1', 1.3), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),
+                           (5, b'de1', 1.3), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4086,13 +4081,13 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify two existing rows
-        rows = records.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
-                             formats="i4,a3,f8")
+        rows = np.rec.array(
+            [(457, b'db1', 1.2), (5, b'de1', 1.3)], formats="i4,a3,f8")
         self.assertRaises(ValueError, table.modify_rows,
                           start=1, stop=2, rows=rows)
 
@@ -4107,18 +4102,18 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
         table.modify_columns(start=1, columns=[[2, 3, 4]], names=["col1"])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4142,18 +4137,18 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
         table.modify_column(start=1, column=[2, 3, 4], colname="col1")
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4176,19 +4171,19 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
-        columns = records.fromarrays(np.array([[2, 3, 4]]), formats="i4")
+        columns = np.rec.fromarrays(np.array([[2, 3, 4]]), formats="i4")
         table.modify_columns(start=1, columns=columns, names=["col1"])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4212,19 +4207,19 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
-        columns = records.fromarrays(np.array([[2, 3, 4]]), formats="i4")
+        columns = np.rec.fromarrays(np.array([[2, 3, 4]]), formats="i4")
         table.modify_column(start=1, column=columns, colname="col1")
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (3, b'db1', 1.2), (4, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
+                           (3, b'db1', 1.2), (4, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4248,20 +4243,20 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify just one existing column
-        # columns = records.fromarrays(np.array([[4]]), formats="i4")
+        # columns = np.rec.fromarrays(np.array([[4]]), formats="i4")
         # table.modify_columns(start=1, columns=columns, names=["col1"])
         table.modify_columns(start=1, columns=[[4]], names=["col1"])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (4, b'ded', 1.3),
-                            (457, b'db1', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (4, b'ded', 1.3),
+                           (457, b'db1', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4284,8 +4279,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -4293,10 +4288,10 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         columns = [["aaa", "bbb", "ccc"], [1.2, .1, .3]]
         table.modify_columns(start=1, columns=columns, names=["col2", "col3"])
         # Create the modified recarray
-        r1 = records.array([(456, b'dbe', 1.2), (2, b'aaa', 1.2),
-                            (457, b'bbb', .1), (5, b'ccc', .3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'aaa', 1.2),
+                           (457, b'bbb', .1), (5, b'ccc', .3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -4320,20 +4315,20 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify a couple of columns
-        columns = records.array([("aaa", 1.2), ("bbb", .1), ("ccc", .3)],
+        columns = np.rec.array([("aaa", 1.2), ("bbb", .1), ("ccc", .3)],
                                 formats="a3,f8")
         table.modify_columns(start=1, columns=columns, names=["col2", "col3"])
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'aaa', 1.2),
-                            (457, 'bbb', .1), (5, 'ccc', .3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'aaa', 1.2),
+                           (457, 'bbb', .1), (5, 'ccc', .3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4356,20 +4351,19 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify a couple of columns
-        columns = records.array([("aaa", 1.2), ("bbb", .1)],
-                                formats="a3,f8")
+        columns = np.rec.array([("aaa", 1.2), ("bbb", .1)], formats="a3,f8")
         table.modify_columns(start=1, step=2, columns=columns,
                              names=["col2", "col3"])
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'aaa', 1.2),
-                            (457, 'db1', 1.2), (5, 'bbb', .1)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'aaa', 1.2),
+                           (457, 'db1', 1.2), (5, 'bbb', .1)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4392,21 +4386,20 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
         # Modify a couple of columns
-        columns = records.array([("aaa", 1.3), ("bbb", .1)],
-                                formats="a3,f8")
+        columns = np.rec.array([("aaa", 1.3), ("bbb", .1)], formats="a3,f8")
         table.modify_columns(start=0, step=2, columns=columns,
                              names=["col2", "col3"])
         # Create the modified recarray
-        r1 = records.array([(456, 'aaa', 1.3), (2, 'ded', 1.3),
-                            (457, 'bbb', .1), (5, 'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'aaa', 1.3), (2, 'ded', 1.3),
+                           (457, 'bbb', .1), (5, 'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4430,8 +4423,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -4445,10 +4438,10 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table.modify_coordinates([0, 3], columns)
 
         # Create the modified recarray
-        r1 = records.array([(55, b'dbe', 1.9), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (56, b'de1', 1.8)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(55, b'dbe', 1.9), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (56, b'de1', 1.8)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4471,8 +4464,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table = self.h5file.create_table(self.h5file.root, 'recarray', Rec)
 
         # append new rows
-        r = records.array([(456, b'dbe', 1.2), (
-                          2, b'ded', 1.3)], formats="i4,a3,f8")
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'ded', 1.3)], formats="i4,a3,f8")
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
 
@@ -4486,10 +4479,10 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table[[0, 3]] = columns
 
         # Create the modified recarray
-        r1 = records.array([(55, b'dbe', 1.9), (2, b'ded', 1.3),
-                            (457, b'db1', 1.2), (56, b'de1', 1.8)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(55, b'dbe', 1.9), (2, b'ded', 1.3),
+                           (457, b'db1', 1.2), (56, b'de1', 1.8)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4537,9 +4530,9 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test01_copy..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(456, b'dbe', 1.2), (2, b'de', 1.3)],
-                          names='col1,col2,col3', formats=('i4,S3,f8'),
-                          aligned=self.aligned)
+        r = np.rec.array(
+            [(456, b'dbe', 1.2), (2, b'de', 1.3)],
+            names='col1,col2,col3', formats=('i4,S3,f8'), aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -4614,9 +4607,9 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test02_copy..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(b'dbe', 456, 1.2), (b'de', 2, 1.3)],
-                          names='col1,col2,col3', formats="S3,i4,f8",
-                          aligned=self.aligned)
+        r = np.rec.array(
+            [(b'dbe', 456, 1.2), (b'de', 2, 1.3)],
+            names='col1,col2,col3', formats="S3,i4,f8", aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -4687,11 +4680,12 @@ class CopyTestCase(common.TempFileMixin, TestCase):
         # Create a recarray exceeding buffers capability
         # This works, but takes too much CPU for a test
         # It is better to reduce the buffer size (table1.nrowsinbuf)
-#         r=records.array(b'aaaabbbbccccddddeeeeffffgggg'*20000,
-#                         formats='2i2,i4, (2,3)u2, (1,)f4, f8',shape=700)
-        r = records.array(b'aaaabbbbccccddddeeeeffffgggg' * 200,
-                          formats='2i2,i4, (2,3)u2, (1,)f4, f8', shape=7,
-                          aligned=self.aligned)
+        # r=np.rec.array(b'aaaabbbbccccddddeeeeffffgggg'*20000,
+        #                 formats='2i2,i4, (2,3)u2, (1,)f4, f8',shape=700)
+        r = np.rec.array(
+            b'aaaabbbbccccddddeeeeffffgggg' * 200,
+            formats='2i2,i4, (2,3)u2, (1,)f4, f8', shape=7,
+            aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -4760,9 +4754,9 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test04_copy..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(1.2, b'dbe', 456), (1.3, b'de', 2)],
-                          names='col1,col2,col3', formats="f8,S3,i4",
-                          aligned=self.aligned)
+        r = np.rec.array([(1.2, b'dbe', 456), (1.3, b'de', 2)],
+                         names='col1,col2,col3', formats="f8,S3,i4",
+                         aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -4831,9 +4825,9 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test05_copy..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(456, b'dbe', 1.2), (2, b'de', 1.3)],
-                          names='col1,col2,col3', formats='i8,S3,f8',
-                          aligned=self.aligned)
+        r = np.rec.array([(456, b'dbe', 1.2), (2, b'de', 1.3)],
+                         names='col1,col2,col3', formats='i8,S3,f8',
+                         aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -4916,9 +4910,9 @@ class CopyTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test05b_copy..." % self.__class__.__name__)
 
         # Create a recarray
-        r = records.array([(456, b'dbe', 1.2), (2, b'de', 1.3)],
-                          names='col1,col2,col3', formats='i8,S3,f4',
-                          aligned=self.aligned)
+        r = np.rec.array([(456, b'dbe', 1.2), (2, b'de', 1.3)],
+                         names='col1,col2,col3', formats='i8,S3,f4',
+                         aligned=self.aligned)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -5025,11 +5019,11 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test01_index..." % self.__class__.__name__)
 
         # Create a recarray exceeding buffers capability
-        r = records.array(b'aaaabbbbccccddddeeeeffffgggg' * 200,
-                          formats='2i2, (1,)i4, (2,3)u2, (1,)f4, (1,)f8',
-                          shape=10)
-                          # The line below exposes a bug in numpy
-                          # formats='2i2, i4, (2,3)u2, f4, f8',shape=10)
+        r = np.rec.array(b'aaaabbbbccccddddeeeeffffgggg' * 200,
+                         formats='2i2, (1,)i4, (2,3)u2, (1,)f4, (1,)f8',
+                         shape=10)
+        # The line below exposes a bug in numpy
+        # formats='2i2, i4, (2,3)u2, f4, f8',shape=10)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -5073,8 +5067,8 @@ class CopyIndexTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test02_indexclosef..." % self.__class__.__name__)
 
         # Create a recarray exceeding buffers capability
-        r = records.array(b'aaaabbbbccccddddeeeeffffgggg' * 200,
-                          formats='2i2, i4, (2,3)u2, f4, f8', shape=10)
+        r = np.rec.array(b'aaaabbbbccccddddeeeeffffgggg' * 200,
+                         formats='2i2, i4, (2,3)u2, f4, f8', shape=10)
         # Save it in a table:
         table1 = self.h5file.create_table(self.h5file.root, 'table1', r,
                                           "title table1")
@@ -5217,7 +5211,7 @@ class LargeRowSize(common.TempFileMixin, TestCase):
         """Checking saving a Table with a moderately large rowsize"""
 
         # Create a recarray
-        r = records.array([(np.arange(100))*2])
+        r = np.rec.array([(np.arange(100)) * 2])
 
         # Save it in a table:
         self.h5file.create_table(self.h5file.root, 'largerow', r)
@@ -5287,7 +5281,7 @@ class DefaultValues(common.TempFileMixin, TestCase):
             values.append(1.-0.j)
             formats.append('c32')
 
-        r = records.array([tuple(values)]*nrows, formats=','.join(formats))
+        r = np.rec.array([tuple(values)] * nrows, formats=','.join(formats))
 
         # Assign the value exceptions
         r["f1"][3] = 2
@@ -5361,7 +5355,7 @@ class DefaultValues(common.TempFileMixin, TestCase):
             values.append(1.-0.j)
             formats.append('c32')
 
-        r = records.array([tuple(values)]*nrows, formats=','.join(formats))
+        r = np.rec.array([tuple(values)] * nrows, formats=','.join(formats))
 
         # Assign the value exceptions
         r["f1"][3] = 2
@@ -6004,7 +5998,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             if common.verbose:
                 print("NumPy selection:", a)
                 print("PyTables selection:", b)
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01b_read(self):
@@ -6019,7 +6013,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
                 print("Selection to test:", key, type(key))
             a = recarr[key]
             b = table[key]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01c_read(self):
@@ -6048,7 +6042,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
                 print("Selection to test:", key, type(key))
             a = recarr[key]
             b = table[key]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01e_read(self):
@@ -6063,7 +6057,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
                 print("Selection to test:", key, type(key))
             a = recarr[key]
             b = table[key]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01f_read(self):
@@ -6075,7 +6069,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
                 print("Selection to test:", key)
             a = recarr[key]
             b = table[key]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables selections does not match.")
 
     def test01g_read(self):
@@ -6106,7 +6100,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             table[key] = s
             a = recarr[:]
             b = table[:]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables modifications does not match.")
 
     def test02b_write(self):
@@ -6128,7 +6122,7 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             table[key] = s
             a = recarr[:]
             b = table[:]
-            npt.assert_array_equal(
+            np.testing.assert_array_equal(
                 a, b, "NumPy array and PyTables modifications does not match.")
 
 
@@ -6147,7 +6141,7 @@ class MDLargeColTestCase(common.TempFileMixin, TestCase):
         # Check the value
         if common.verbose:
             print("First row-->", tbl[0]['col1'])
-        npt.assert_array_equal(tbl[0]['col1'], np.zeros(N, 'i1'))
+        np.testing.assert_array_equal(tbl[0]['col1'], np.zeros(N, 'i1'))
 
 
 class MDLargeColNoReopen(MDLargeColTestCase):

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-from numpy import rec as records
 
 import tables
 from tables import (
@@ -1120,8 +1119,8 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Append new rows
         s0, s1, s2, s3 = ['dbe']*3, ['ded']*3, ['db1']*3, ['de1']*3
         f0, f1, f2, f3 = [[1.2]*2]*3, [[1.3]*2]*3, [[1.4]*2]*3, [[1.5]*2]*3
-        r = records.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
-                          formats="(2,)i4,(3,)a3,(3,2)f8")
+        r = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
+                         formats="(2,)i4,(3,)a3,(3,2)f8")
         table.append(r)
         table.append([([457, 458], s2, f2), ([5, 6], s3, f3)])
 
@@ -1129,10 +1128,10 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         table.cols.col1[1:] = [[[2, 3], [3, 4], [4, 5]]]
 
         # Create the modified recarray
-        r1 = records.array([ ([456, 457], s0, f0), ([2, 3], s1, f1),
-                             ([3, 4], s2, f2), ([4, 5], s3, f3)],
-                           formats="(2,)i4,(3,)a3,(3,2)f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([ ([456, 457], s0, f0), ([2, 3], s1, f1),
+                            ([3, 4], s2, f2), ([4, 5], s3, f3)],
+                          formats="(2,)i4,(3,)a3,(3,2)f8",
+                          names="col1,col2,col3")
 
         # Read the modified table
         r2 = table.read()
@@ -1155,21 +1154,21 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Append new rows
         s0, s1, s2, s3 = ['dbe']*3, ['ded']*3, ['db1']*3, ['de1']*3
         f0, f1, f2, f3 = [[1.2]*2]*3, [[1.3]*2]*3, [[1.4]*2]*3, [[1.5]*2]*3
-        r = records.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
-                          formats="(2,)i4,(3,)a3,(3,2)f8")
+        r = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
+                         formats="(2,)i4,(3,)a3,(3,2)f8")
         table.append(r)
         table.append([([457, 458], s2, f2), ([5, 6], s3, f3)])
 
         # Modify just one existing column
-        columns = records.fromarrays(
+        columns = np.rec.fromarrays(
             np.array([[[2, 3], [3, 4], [4, 5]]]), formats="i4")
         table.modify_columns(start=1, columns=columns, names=["col1"])
 
         # Create the modified recarray
-        r1 = records.array([([456, 457], s0, f0), ([2, 3], s1, f1),
-                            ([3, 4], s2, f2), ([4, 5], s3, f3)],
-                           formats="(2,)i4,(3,)a3,(3,2)f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1),
+                           ([3, 4], s2, f2), ([4, 5], s3, f3)],
+                          formats="(2,)i4,(3,)a3,(3,2)f8",
+                          names="col1,col2,col3")
 
         # Read the modified table
         r2 = table.read()
@@ -1193,21 +1192,21 @@ class RecArrayIO(common.TempFileMixin, TestCase):
         # Append new rows
         s0, s1, s2, s3 = ['dbe']*3, ['ded']*3, ['db1']*3, ['de1']*3
         f0, f1, f2, f3 = [[1.2]*2]*3, [[1.3]*2]*3, [[1.4]*2]*3, [[1.5]*2]*3
-        r = records.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
-                          formats="(2,)i4,(3,)a3,(3,2)f8")
+        r = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1)],
+                         formats="(2,)i4,(3,)a3,(3,2)f8")
         table.append(r)
         table.append([([457, 458], s2, f2), ([5, 6], s3, f3)])
 
         # Modify just one existing column
-        columns = records.fromarrays(
+        columns = np.rec.fromarrays(
             np.array([[[2, 3], [3, 4], [4, 5]]]), formats="i4")
         table.modify_column(start=1, column=columns, colname="col1")
 
         # Create the modified recarray
-        r1 = records.array([([456, 457], s0, f0), ([2, 3], s1, f1),
-                            ([3, 4], s2, f2), ([4, 5], s3, f3)],
-                           formats="(2,)i4,(3,)a3,(3,2)f8",
-                           names="col1,col2,col3")
+        r1 = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1),
+                           ([3, 4], s2, f2), ([4, 5], s3, f3)],
+                          formats="(2,)i4,(3,)a3,(3,2)f8",
+                          names="col1,col2,col3")
 
         # Read the modified table
         r2 = table.read()
@@ -1380,8 +1379,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1389,10 +1387,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table[2] = (456, 'db2', 1.2)
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (456, 'db2', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (456, 'db2', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -1412,8 +1410,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1421,10 +1418,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table[2] = (456, 'db2', 1.2)
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (456, 'db2', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (456, 'db2', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1445,21 +1442,19 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, 'db1', 1.2)],
-                             formats=formats)
+        rows = np.rec.array([(457, 'db1', 1.2)], formats=formats)
         table[1:3:2] = rows
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (457, 'db1', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (457, 'db1', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1480,23 +1475,22 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, 'db1', 1.2), (5, 'de1', 1.3)],
-                             formats=formats)
+        rows = np.rec.array(
+            [(457, 'db1', 1.2), (5, 'de1', 1.3)], formats=formats)
 
         # table.modify_rows(start=1, rows=rows)
         table[1:3] = rows
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (5, 'de1', 1.3), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (5, 'de1', 1.3), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1517,22 +1511,21 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
         # Modify two existing rows
-        rows = records.array([(457, 'db1', 1.2), (6, 'de2', 1.3)],
-                             formats=formats)
+        rows = np.rec.array([(457, 'db1', 1.2), (6, 'de2', 1.3)],
+                            formats=formats)
         # table[1:4:2] = rows
         table[1::2] = rows
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (457, 'db1', 1.2), (6, 'de2', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (457, 'db1', 1.2), (6, 'de2', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1553,8 +1546,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1562,10 +1554,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.cols.col1[1] = -1
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (-1, 'ded', 1.3),
-                            (457, 'db1', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (-1, 'ded', 1.3),
+                           (457, 'db1', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1586,8 +1578,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1595,10 +1586,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.cols.col1[1:4] = [(2, 2), (3, 3), (4, 4)]
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (3, 'db1', 1.2), (4, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (3, 'db1', 1.2), (4, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -1618,8 +1609,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1637,8 +1627,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          1, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (1, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1646,10 +1635,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.cols.col1[1:4:2] = [(2, 2), (3, 3)]
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (457, 'db1', 1.2), (3, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (457, 'db1', 1.2), (3, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1670,8 +1659,7 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1679,10 +1667,10 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         table.cols.col1[1:4:3] = [(2, 2)]
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (457, 'db1', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (457, 'db1', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1703,21 +1691,20 @@ class SetItemTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
         # Try to modify beyond the extend
         # This will silently exclude the non-fitting rows
-        rows = records.array([(457, 'db1', 1.2), (6, 'de2', 1.3)],
-                             formats=formats)
+        rows = np.rec.array([(457, 'db1', 1.2), (6, 'de2', 1.3)],
+                            formats=formats)
         table[1::2] = rows
 
         # How it should look like
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (457, 'db1', 1.2), (6, 'de2', 1.3)],
-                           formats=formats)
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (457, 'db1', 1.2), (6, 'de2', 1.3)],
+                          formats=formats)
 
         # Read the modified table
         if self.reopen:
@@ -1769,8 +1756,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)],
-                          formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)],
+                         formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1780,10 +1767,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (456, 'db2', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (456, 'db2', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1804,8 +1791,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1818,10 +1804,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (457, 'db1', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (457, 'db1', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1842,8 +1828,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1856,10 +1841,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (5, 'de1', 1.3), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (5, 'de1', 1.3), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1880,8 +1865,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1894,10 +1878,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
-                            (457, 'db1', 1.2), (6, 'de2', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (457, 'db1', 1.2),
+                           (457, 'db1', 1.2), (6, 'de2', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1918,8 +1902,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1929,10 +1912,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (-1, 'ded', 1.3),
-                            (457, 'db1', 1.2), (5, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (-1, 'ded', 1.3),
+                           (457, 'db1', 1.2), (5, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1953,8 +1936,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          2, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -1964,10 +1946,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
-                            (3, 'db1', 1.2), (4, 'de1', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ded', 1.3),
+                           (3, 'db1', 1.2), (4, 'de1', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -1988,8 +1970,7 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
         formats = table.description._v_nested_formats
 
         # append new rows
-        r = records.array([(456, 'dbe', 1.2), (
-                          1, 'ded', 1.3)], formats=formats)
+        r = np.rec.array([(456, 'dbe', 1.2), (1, 'ded', 1.3)], formats=formats)
         table.append(r)
         table.append([(457, 'db1', 1.2), (5, 'de1', 1.3)])
 
@@ -2001,10 +1982,10 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
                 row.update()
 
         # Create the modified recarray
-        r1 = records.array([(456, 'dbe', 1.2), (2, 'ada', 1.3),
-                            (457, 'db1', 1.2), (2, 'ada', 1.3)],
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'ada', 1.3),
+                           (457, 'db1', 1.2), (2, 'ada', 1.3)],
+                          formats=formats,
+                          names="col1,col2,col3")
 
         # Read the modified table
         if self.reopen:
@@ -2043,9 +2024,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats=formats, names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i
             r1['col2'][i] = 'b'+str(i)
@@ -2088,9 +2068,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             # row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats=formats, names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i-1
             r1['col2'][i] = 'a'+str(i-1)
@@ -2134,9 +2113,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
                 row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats=formats, names="col1,col2,col3")
         for i in range(nrows):
             r1['col1'][i] = i-1
             r1['col2'][i] = 'a'+str(i-1)
@@ -2184,9 +2162,8 @@ class UpdateRowTestCase(common.TempFileMixin, TestCase):
             row.update()
 
         # Create the modified recarray
-        r1 = records.array(None, shape=nrows,
-                           formats=formats,
-                           names="col1,col2,col3")
+        r1 = np.rec.array(
+            None, shape=nrows, formats=formats, names="col1,col2,col3")
         for i in range(nrows):
             if i % 10 > 0:
                 r1['col1'][i] = i-1

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -11,7 +11,7 @@
 """Unit test for the Time datatypes."""
 
 
-import numpy
+import numpy as np
 
 import tables
 from tables.tests import common
@@ -163,7 +163,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test00_Compare32VLArray(self):
         """Comparing written 32-bit time data with read data in a VLArray."""
 
-        wtime = numpy.array((1_234_567_890,) * 2, numpy.int32)
+        wtime = np.array((1_234_567_890,) * 2, np.int32)
 
         # Create test VLArray with data.
         vla = self.h5file.create_vlarray('/', 'test', self.myTime32Atom)
@@ -179,7 +179,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
     def test01_Compare64VLArray(self):
         """Comparing written 64-bit time data with read data in a VLArray."""
 
-        wtime = numpy.array((1_234_567_890.123456,) * 2, numpy.float64)
+        wtime = np.array((1_234_567_890.123456,) * 2, np.float64)
 
         # Create test VLArray with data.
         vla = self.h5file.create_vlarray('/', 'test', self.myTime64Atom)
@@ -214,8 +214,8 @@ class CompareTestCase(common.TempFileMixin, TestCase):
         arr = self.h5file.root.test.read()
         self.h5file.close()
 
-        arr = numpy.array(arr)
-        orig_val = numpy.arange(0, nrows * 2, dtype=numpy.int32) + 0.012
+        arr = np.array(arr)
+        orig_val = np.arange(0, nrows * 2, dtype=np.int32) + 0.012
         orig_val.shape = (nrows, 1, 2)
         if common.verbose:
             print("Original values:", orig_val)
@@ -243,8 +243,8 @@ class CompareTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(recarr['t32col'][0], int(wtime),
                          "Stored and retrieved values do not match.")
 
-        comp = (recarr['t64col'][0] == numpy.array((wtime, wtime)))
-        self.assertTrue(numpy.alltrue(comp),
+        comp = (recarr['t64col'][0] == np.array((wtime, wtime)))
+        self.assertTrue(np.alltrue(comp),
                         "Stored and retrieved values do not match.")
 
     def test02b_CompareTable(self):
@@ -273,20 +273,20 @@ class CompareTestCase(common.TempFileMixin, TestCase):
         self.h5file.close()
 
         # Time32 column.
-        orig_val = numpy.arange(nrows, dtype=numpy.int32)
+        orig_val = np.arange(nrows, dtype=np.int32)
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t32col'][:])
-        self.assertTrue(numpy.alltrue(recarr['t32col'][:] == orig_val),
+        self.assertTrue(np.alltrue(recarr['t32col'][:] == orig_val),
                         "Stored and retrieved values do not match.")
 
         # Time64 column.
-        orig_val = numpy.arange(0, nrows * 2, dtype=numpy.int32) + 0.012
+        orig_val = np.arange(0, nrows * 2, dtype=np.int32) + 0.012
         orig_val.shape = (nrows, 2)
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t64col'][:])
-        self.assertTrue(allequal(recarr['t64col'][:], orig_val, numpy.float64),
+        self.assertTrue(allequal(recarr['t64col'][:], orig_val, np.float64),
                         "Stored and retrieved values do not match.")
 
     def test03_Compare64EArray(self):
@@ -329,7 +329,7 @@ class CompareTestCase(common.TempFileMixin, TestCase):
         arr = self.h5file.root.test.read()
         self.h5file.close()
 
-        orig_val = numpy.arange(0, nrows * 2, dtype=numpy.int32) + 0.012
+        orig_val = np.arange(0, nrows * 2, dtype=np.int32) + 0.012
         orig_val.shape = (nrows, 2)
         if common.verbose:
             print("Original values:", orig_val)
@@ -375,28 +375,28 @@ class UnalignedTestCase(common.TempFileMixin, TestCase):
         self.h5file.close()
 
         # Int8 column.
-        orig_val = numpy.arange(nrows, dtype=numpy.int8)
+        orig_val = np.arange(nrows, dtype=np.int8)
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['i8col'][:])
-        self.assertTrue(numpy.alltrue(recarr['i8col'][:] == orig_val),
+        self.assertTrue(np.alltrue(recarr['i8col'][:] == orig_val),
                         "Stored and retrieved values do not match.")
 
         # Time32 column.
-        orig_val = numpy.arange(nrows, dtype=numpy.int32)
+        orig_val = np.arange(nrows, dtype=np.int32)
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t32col'][:])
-        self.assertTrue(numpy.alltrue(recarr['t32col'][:] == orig_val),
+        self.assertTrue(np.alltrue(recarr['t32col'][:] == orig_val),
                         "Stored and retrieved values do not match.")
 
         # Time64 column.
-        orig_val = numpy.arange(0, nrows * 2, dtype=numpy.int32) + 0.012
+        orig_val = np.arange(0, nrows * 2, dtype=np.int32) + 0.012
         orig_val.shape = (nrows, 2)
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t64col'][:])
-        self.assertTrue(allequal(recarr['t64col'][:], orig_val, numpy.float64),
+        self.assertTrue(allequal(recarr['t64col'][:], orig_val, np.float64),
                         "Stored and retrieved values do not match.")
 
 
@@ -421,12 +421,12 @@ class BigEndianTestCase(TestCase):
         # Generate the expected Time32 array.
         start = 1_178_896_298
         nrows = 10
-        orig_val = numpy.arange(start, start + nrows, dtype=numpy.int32)
+        orig_val = np.arange(start, start + nrows, dtype=np.int32)
 
         if common.verbose:
             print("Retrieved values:", earr)
             print("Should look like:", orig_val)
-        self.assertTrue(numpy.alltrue(earr == orig_val),
+        self.assertTrue(np.alltrue(earr == orig_val),
                         "Retrieved values do not match the expected values.")
 
     def test00b_Read64Array(self):
@@ -438,12 +438,12 @@ class BigEndianTestCase(TestCase):
         # Generate the expected Time64 array.
         start = 1_178_896_298.832258
         nrows = 10
-        orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
+        orig_val = np.arange(start, start + nrows, dtype=np.float64)
 
         if common.verbose:
             print("Retrieved values:", earr)
             print("Should look like:", orig_val)
-        self.assertTrue(numpy.allclose(earr, orig_val, rtol=1.e-15),
+        self.assertTrue(np.allclose(earr, orig_val, rtol=1.e-15),
                         "Retrieved values do not match the expected values.")
 
     def test01a_ReadPlainColumn(self):
@@ -456,12 +456,12 @@ class BigEndianTestCase(TestCase):
         # Generate the expected Time32 array.
         start = 1_178_896_298
         nrows = 10
-        orig_val = numpy.arange(start, start + nrows, dtype=numpy.int32)
+        orig_val = np.arange(start, start + nrows, dtype=np.int32)
 
         if common.verbose:
             print("Retrieved values:", t32)
             print("Should look like:", orig_val)
-        self.assertTrue(numpy.alltrue(t32 == orig_val),
+        self.assertTrue(np.alltrue(t32 == orig_val),
                         "Retrieved values do not match the expected values.")
 
     def test01b_ReadNestedColumn(self):
@@ -474,12 +474,12 @@ class BigEndianTestCase(TestCase):
         # Generate the expected Time64 array.
         start = 1_178_896_298.832258
         nrows = 10
-        orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
+        orig_val = np.arange(start, start + nrows, dtype=np.float64)
 
         if common.verbose:
             print("Retrieved values:", t64)
             print("Should look like:", orig_val)
-        self.assertTrue(numpy.allclose(t64, orig_val, rtol=1.e-15),
+        self.assertTrue(np.allclose(t64, orig_val, rtol=1.e-15),
                         "Retrieved values do not match the expected values.")
 
     def test02_ReadNestedColumnTwice(self):
@@ -494,12 +494,12 @@ class BigEndianTestCase(TestCase):
         # Generate the expected Time64 array.
         start = 1_178_896_298.832258
         nrows = 10
-        orig_val = numpy.arange(start, start + nrows, dtype=numpy.float64)
+        orig_val = np.arange(start, start + nrows, dtype=np.float64)
 
         if common.verbose:
             print("Retrieved values:", t64)
             print("Should look like:", orig_val)
-        self.assertTrue(numpy.allclose(t64, orig_val, rtol=1.e-15),
+        self.assertTrue(np.allclose(t64, orig_val, rtol=1.e-15),
                         "Retrieved values do not match the expected values.")
 
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -1,6 +1,6 @@
 import sys
 
-import numpy
+import numpy as np
 
 import tables
 from tables import (
@@ -155,14 +155,14 @@ class ReadFloatTestCase(common.TestFileMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        x = numpy.arange(self.ncols)
-        y = numpy.arange(self.nrows)
+        x = np.arange(self.ncols)
+        y = np.arange(self.nrows)
         y.shape = (self.nrows, 1)
         self.values = x + y
 
     def test01_read_float16(self):
         dtype = "float16"
-        if hasattr(numpy, dtype):
+        if hasattr(np, dtype):
             ds = getattr(self.h5file.root, dtype)
             self.assertNotIsInstance(ds, tables.UnImplemented)
             self.assertEqual(ds.shape, (self.nrows, self.ncols))
@@ -253,26 +253,26 @@ class AtomTestCase(TestCase):
         self.assertRaises(TypeError, atom1.copy, foobar=42)
 
     def test_from_dtype_01(self):
-        atom1 = Atom.from_dtype(numpy.dtype((numpy.int16, (2, 2))))
+        atom1 = Atom.from_dtype(np.dtype((np.int16, (2, 2))))
         atom2 = Int16Atom(shape=(2, 2), dflt=0)
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_02(self):
-        atom1 = Atom.from_dtype(numpy.dtype('S5'), dflt=b'hello')
+        atom1 = Atom.from_dtype(np.dtype('S5'), dflt=b'hello')
         atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_03(self):
         with self.assertWarns(Warning):
-            atom1 = Atom.from_dtype(numpy.dtype('U5'), dflt=b'hello')
+            atom1 = Atom.from_dtype(np.dtype('U5'), dflt=b'hello')
         atom2 = StringAtom(itemsize=5, shape=(), dflt=b'hello')
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))
 
     def test_from_dtype_04(self):
-        atom1 = Atom.from_dtype(numpy.dtype('float64'))
+        atom1 = Atom.from_dtype(np.dtype('float64'))
         atom2 = Float64Atom(shape=(), dflt=0.0)
         self.assertEqual(atom1, atom2)
         self.assertEqual(str(atom1), str(atom2))

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -1,7 +1,6 @@
 import sys
 
-import numpy
-import numpy.testing as npt
+import numpy as np
 
 import tables
 from tables import (
@@ -52,8 +51,8 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         # Fill it with 5 rows
         vlarray.append([1, 2])
         if self.flavor == "numpy":
-            vlarray.append(numpy.array([3, 4, 5], dtype='int32'))
-            vlarray.append(numpy.array([], dtype='int32'))     # Empty entry
+            vlarray.append(np.array([3, 4, 5], dtype='int32'))
+            vlarray.append(np.array([], dtype='int32'))     # Empty entry
         elif self.flavor == "python":
             vlarray.append((3, 4, 5))
             vlarray.append(())         # Empty entry
@@ -94,11 +93,11 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         nrows = 5
         self.assertEqual(nrows, vlarray.nrows)
         if self.flavor == "numpy":
-            self.assertEqual(type(row), numpy.ndarray)
+            self.assertEqual(type(row), np.ndarray)
             self.assertTrue(
-                allequal(row, numpy.array([1, 2], dtype='int32'), self.flavor))
+                allequal(row, np.array([1, 2], dtype='int32'), self.flavor))
             self.assertTrue(
-                allequal(row2, numpy.array([], dtype='int32'), self.flavor))
+                allequal(row2, np.array([], dtype='int32'), self.flavor))
         elif self.flavor == "python":
             self.assertEqual(row, [1, 2])
             self.assertEqual(row2, [])
@@ -157,7 +156,7 @@ class BasicTestCase(common.TempFileMixin, TestCase):
 
             if self.flavor == "numpy":
                 for val in rows1:
-                    rows1f.append(numpy.array(val, dtype='int32'))
+                    rows1f.append(np.array(val, dtype='int32'))
                 for i in range(len(rows1f)):
                     self.assertTrue(allequal(rows2[i], rows1f[i], self.flavor))
             elif self.flavor == "python":
@@ -179,9 +178,9 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.get_node("/vlarray1")
 
         # Get a numpy array of objects
-        rows = numpy.array(vlarray[:], dtype=object)
+        rows = np.array(vlarray[:], dtype=object)
 
-        for slc in [0, numpy.array(1), 2, numpy.array([3]), [4]]:
+        for slc in [0, np.array(1), 2, np.array([3]), [4]]:
             # Read the rows in slc
             rows2 = vlarray[slc]
             rows1 = rows[slc]
@@ -223,15 +222,13 @@ class BasicTestCase(common.TempFileMixin, TestCase):
         nrows = 6
         self.assertEqual(nrows, vlarray.nrows)
         if self.flavor == "numpy":
-            self.assertEqual(type(row1), type(numpy.array([1, 2])))
-            self.assertTrue(
-                allequal(row1, numpy.array([1, 2], dtype='int32'),
-                         self.flavor))
-            self.assertTrue(
-                allequal(row2, numpy.array([], dtype='int32'), self.flavor))
-            self.assertTrue(
-                allequal(row3, numpy.array([7, 8, 9, 10], dtype='int32'),
-                         self.flavor))
+            self.assertEqual(type(row1), type(np.array([1, 2])))
+            self.assertTrue(allequal(
+                row1, np.array([1, 2], dtype='int32'), self.flavor))
+            self.assertTrue(allequal(
+                row2, np.array([], dtype='int32'), self.flavor))
+            self.assertTrue(allequal(
+                row3, np.array([7, 8, 9, 10], dtype='int32'), self.flavor))
         elif self.flavor == "python":
             self.assertEqual(row1, [1, 2])
             self.assertEqual(row2, [])
@@ -385,8 +382,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                                              atom=StringAtom(itemsize=3),
                                              title="Ragged array of strings")
         vlarray.flavor = "numpy"
-        vlarray.append(numpy.array(["1", "12", "123", "1234", "12345"]))
-        vlarray.append(numpy.array(["1", "12345"]))
+        vlarray.append(np.array(["1", "12", "123", "1234", "12345"]))
+        vlarray.append(np.array(["1", "12345"]))
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -401,9 +398,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        npt.assert_array_equal(
-            row[0], numpy.array(["1", "12", "123", "123", "123"], 'S'))
-        npt.assert_array_equal(row[1], numpy.array(["1", "123"], 'S'))
+        np.testing.assert_array_equal(
+            row[0], np.array(["1", "12", "123", "123", "123"], 'S'))
+        np.testing.assert_array_equal(row[1], np.array(["1", "123"], 'S'))
         self.assertEqual(len(row[0]), 5)
         self.assertEqual(len(row[1]), 2)
 
@@ -419,8 +416,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                                              atom=StringAtom(itemsize=3),
                                              title="Ragged array of strings")
         vlarray.flavor = "numpy"
-        vlarray.append(numpy.array(["1", "12", "123", "1234", "12345"][::2]))
-        vlarray.append(numpy.array(["1", "12345", "2", "321"])[::3])
+        vlarray.append(np.array(["1", "12", "123", "1234", "12345"][::2]))
+        vlarray.append(np.array(["1", "12345", "2", "321"])[::3])
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -435,8 +432,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        npt.assert_array_equal(row[0], numpy.array(["1", "123", "123"], 'S'))
-        npt.assert_array_equal(row[1], numpy.array(["1", "321"], 'S'))
+        np.testing.assert_array_equal(row[0], np.array(["1", "123", "123"], 'S'))
+        np.testing.assert_array_equal(row[1], np.array(["1", "321"], 'S'))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
 
@@ -452,8 +449,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                                              atom=StringAtom(itemsize=3),
                                              title="Ragged array of strings")
         vlarray.flavor = "numpy"
-        vlarray.append(numpy.array(["1", "12", "123", "123"]))
-        vlarray.append(numpy.array(["1", "2", "321"]))
+        vlarray.append(np.array(["1", "12", "123", "123"]))
+        vlarray.append(np.array(["1", "2", "321"]))
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -468,9 +465,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        npt.assert_array_equal(
-            row[0], numpy.array(["1", "12", "123", "123"], 'S'))
-        npt.assert_array_equal(row[1], numpy.array(["1", "2", "321"], 'S'))
+        np.testing.assert_array_equal(
+            row[0], np.array(["1", "12", "123", "123"], 'S'))
+        np.testing.assert_array_equal(row[1], np.array(["1", "2", "321"], 'S'))
         self.assertEqual(len(row[0]), 4)
         self.assertEqual(len(row[1]), 3)
 
@@ -519,12 +516,12 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                                              atom=StringAtom(itemsize=3),
                                              title="Ragged array of strings")
         vlarray.flavor = "numpy"
-        vlarray.append(numpy.array(["1", "12", "123", "1234", "12345"]))
-        vlarray.append(numpy.array(["1", "12345"]))
+        vlarray.append(np.array(["1", "12", "123", "1234", "12345"]))
+        vlarray.append(np.array(["1", "12345"]))
 
         # Modify the rows
-        vlarray[0] = numpy.array(["1", "123", "12", "", "12345"])
-        vlarray[1] = numpy.array(["44", "4"])  # This should work as well
+        vlarray[0] = np.array(["1", "123", "12", "", "12345"])
+        vlarray[1] = np.array(["44", "4"])  # This should work as well
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -540,8 +537,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
         self.assertEqual(vlarray.nrows, 2)
         self.assertTrue(
-            allequal(row[0], numpy.array([b"1", b"123", b"12", b"", b"123"])))
-        self.assertTrue(allequal(row[1], numpy.array(["44", "4"], dtype="S3")))
+            allequal(row[0], np.array([b"1", b"123", b"12", b"", b"123"])))
+        self.assertTrue(allequal(row[1], np.array(["44", "4"], dtype="S3")))
         self.assertEqual(len(row[0]), 5)
         self.assertEqual(len(row[1]), 2)
 
@@ -607,8 +604,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(allequal(row[0], numpy.array([1, 0, 1], dtype='bool')))
-        self.assertTrue(allequal(row[1], numpy.array([1, 0], dtype='bool')))
+        self.assertTrue(allequal(row[0], np.array([1, 0, 1], dtype='bool')))
+        self.assertTrue(allequal(row[1], np.array([1, 0], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
 
@@ -641,8 +638,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(allequal(row[0], numpy.array([0, 1, 1], dtype='bool')))
-        self.assertTrue(allequal(row[1], numpy.array([0, 1], dtype='bool')))
+        self.assertTrue(allequal(row[0], np.array([0, 1, 1], dtype='bool')))
+        self.assertTrue(allequal(row[1], np.array([0, 1], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
 
@@ -683,10 +680,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[
-                            0], numpy.array([1, 2, 3], dtype=atype)))
-            self.assertTrue(allequal(row[
-                            1], numpy.array([-1, 0], dtype=atype)))
+            self.assertTrue(allequal(row[0], np.array([1, 2, 3], dtype=atype)))
+            self.assertTrue(allequal(row[1], np.array([-1, 0], dtype=atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -694,13 +689,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with integer atoms (byteorder swapped)"""
 
         ttypes = {
-            "int8": numpy.int8,
-            "uint8": numpy.uint8,
-            "int16": numpy.int16,
-            "uint16": numpy.uint16,
-            "int32": numpy.int32,
-            "uint32": numpy.uint32,
-            "int64": numpy.int64,
+            "int8": np.int8,
+            "uint8": np.uint8,
+            "int16": np.int16,
+            "uint16": np.uint16,
+            "int32": np.int32,
+            "uint32": np.uint32,
+            "int64": np.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -710,11 +705,11 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]))
-            a0 = numpy.array([1, 2, 3], dtype=atype)
+            a0 = np.array([1, 2, 3], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray.append(a0)
-            a1 = numpy.array([-1, 0], dtype=atype)
+            a1 = np.array([-1, 0], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray.append(a1)
@@ -734,9 +729,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
             self.assertEqual(vlarray.nrows, 2)
             self.assertTrue(
-                allequal(row[0], numpy.array([1, 2, 3], dtype=ttypes[atype])))
+                allequal(row[0], np.array([1, 2, 3], dtype=ttypes[atype])))
             self.assertTrue(
-                allequal(row[1], numpy.array([-1, 0], dtype=ttypes[atype])))
+                allequal(row[1], np.array([-1, 0], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -781,10 +776,8 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[
-                            0], numpy.array([3, 2, 1], dtype=atype)))
-            self.assertTrue(allequal(row[
-                            1], numpy.array([0, -1], dtype=atype)))
+            self.assertTrue(allequal(row[0], np.array([3, 2, 1], dtype=atype)))
+            self.assertTrue(allequal(row[1], np.array([0, -1], dtype=atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -792,13 +785,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with integer atoms (byteorder swapped)"""
 
         ttypes = {
-            "int8": numpy.int8,
-            "uint8": numpy.uint8,
-            "int16": numpy.int16,
-            "uint16": numpy.uint16,
-            "int32": numpy.int32,
-            "uint32": numpy.uint32,
-            "int64": numpy.int64,
+            "int8": np.int8,
+            "uint8": np.uint8,
+            "int16": np.int16,
+            "uint16": np.uint16,
+            "int32": np.int32,
+            "uint32": np.uint32,
+            "int64": np.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -808,17 +801,17 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]))
-            a0 = numpy.array([1, 2, 3], dtype=atype)
+            a0 = np.array([1, 2, 3], dtype=atype)
             vlarray.append(a0)
-            a1 = numpy.array([-1, 0], dtype=atype)
+            a1 = np.array([-1, 0], dtype=atype)
             vlarray.append(a1)
 
             # Modify rows
-            a0 = numpy.array([3, 2, 1], dtype=atype)
+            a0 = np.array([3, 2, 1], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray[0] = a0
-            a1 = numpy.array([0, -1], dtype=atype)
+            a1 = np.array([0, -1], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray[1] = a1
@@ -838,9 +831,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
 
             self.assertEqual(vlarray.nrows, 2)
             self.assertTrue(
-                allequal(row[0], numpy.array([3, 2, 1], dtype=ttypes[atype])))
+                allequal(row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
             self.assertTrue(
-                allequal(row[1], numpy.array([0, -1], dtype=ttypes[atype])))
+                allequal(row[1], np.array([0, -1], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -848,13 +841,13 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with integer atoms (another byteorder)"""
 
         ttypes = {
-            "int8": numpy.int8,
-            "uint8": numpy.uint8,
-            "int16": numpy.int16,
-            "uint16": numpy.uint16,
-            "int32": numpy.int32,
-            "uint32": numpy.uint32,
-            "int64": numpy.int64,
+            "int8": np.int8,
+            "uint8": np.uint8,
+            "int16": np.int16,
+            "uint16": np.uint16,
+            "int32": np.int32,
+            "uint32": np.uint32,
+            "int64": np.int64,
             #"UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
@@ -866,17 +859,17 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]),
                 byteorder=byteorder)
-            a0 = numpy.array([1, 2, 3], dtype=atype)
+            a0 = np.array([1, 2, 3], dtype=atype)
             vlarray.append(a0)
-            a1 = numpy.array([-1, 0], dtype=atype)
+            a1 = np.array([-1, 0], dtype=atype)
             vlarray.append(a1)
 
             # Modify rows
-            a0 = numpy.array([3, 2, 1], dtype=atype)
+            a0 = np.array([3, 2, 1], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray[0] = a0
-            a1 = numpy.array([0, -1], dtype=atype)
+            a1 = np.array([0, -1], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray[1] = a1
@@ -901,9 +894,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 self.assertEqual(vlarray.byteorder, byteorder)
             self.assertEqual(vlarray.nrows, 2)
             self.assertTrue(
-                allequal(row[0], numpy.array([3, 2, 1], dtype=ttypes[atype])))
+                allequal(row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
             self.assertTrue(
-                allequal(row[1], numpy.array([0, -1], dtype=ttypes[atype])))
+                allequal(row[1], np.array([0, -1], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -943,10 +936,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[
-                            0], numpy.array([1.3, 2.2, 3.3], atype)))
-            self.assertTrue(allequal(row[
-                            1], numpy.array([-1.3e34, 1.e-32], atype)))
+            self.assertTrue(allequal(row[0], np.array([1.3, 2.2, 3.3], atype)))
+            self.assertTrue(allequal(
+                row[1], np.array([-1.3e34, 1.e-32], atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -954,15 +946,15 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking vlarray with float atoms (byteorder swapped)"""
 
         ttypes = {
-            "float32": numpy.float32,
-            "float64": numpy.float64,
+            "float32": np.float32,
+            "float64": np.float64,
         }
         if hasattr(tables, "Float16Atom"):
-            ttypes["float16"] = numpy.float16
+            ttypes["float16"] = np.float16
         if hasattr(tables, "Float96Atom"):
-            ttypes["float96"] = numpy.float96
+            ttypes["float96"] = np.float96
         if hasattr(tables, "Float128Atom"):
-            ttypes["float128"] = numpy.float128
+            ttypes["float128"] = np.float128
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -971,11 +963,11 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]))
-            a0 = numpy.array([1.3, 2.2, 3.3], dtype=atype)
+            a0 = np.array([1.3, 2.2, 3.3], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray.append(a0)
-            a1 = numpy.array([-1.3e34, 1.e-32], dtype=atype)
+            a1 = np.array([-1.3e34, 1.e-32], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray.append(a1)
@@ -994,10 +986,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[0], numpy.array([1.3, 2.2, 3.3],
-                                                         dtype=ttypes[atype])))
-            self.assertTrue(allequal(row[1], numpy.array([-1.3e34, 1.e-32],
-                                                         dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[0], np.array([1.3, 2.2, 3.3], dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[1], np.array([-1.3e34, 1.e-32], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1041,10 +1033,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[
-                            0], numpy.array([4.3, 2.2, 4.3], atype)))
+            self.assertTrue(allequal(row[0], np.array([4.3, 2.2, 4.3], atype)))
             self.assertTrue(
-                allequal(row[1], numpy.array([-1.1e34, 1.3e-32], atype)))
+                allequal(row[1], np.array([-1.1e34, 1.3e-32], atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1052,15 +1043,15 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with float atoms (byteorder swapped)"""
 
         ttypes = {
-            "float32": numpy.float32,
-            "float64": numpy.float64,
+            "float32": np.float32,
+            "float64": np.float64,
         }
         if hasattr(tables, "Float16Atom"):
-            ttypes["float16"] = numpy.float16
+            ttypes["float16"] = np.float16
         if hasattr(tables, "Float96Atom"):
-            ttypes["float96"] = numpy.float96
+            ttypes["float96"] = np.float96
         if hasattr(tables, "Float128Atom"):
-            ttypes["float128"] = numpy.float128
+            ttypes["float128"] = np.float128
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -1069,17 +1060,17 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]))
-            a0 = numpy.array([1.3, 2.2, 3.3], dtype=atype)
+            a0 = np.array([1.3, 2.2, 3.3], dtype=atype)
             vlarray.append(a0)
-            a1 = numpy.array([-1, 0], dtype=atype)
+            a1 = np.array([-1, 0], dtype=atype)
             vlarray.append(a1)
 
             # Modify rows
-            a0 = numpy.array([4.3, 2.2, 4.3], dtype=atype)
+            a0 = np.array([4.3, 2.2, 4.3], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray[0] = a0
-            a1 = numpy.array([-1.1e34, 1.3e-32], dtype=atype)
+            a1 = np.array([-1.1e34, 1.3e-32], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray[1] = a1
@@ -1098,10 +1089,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[0], numpy.array([4.3, 2.2, 4.3],
-                                                         dtype=ttypes[atype])))
-            self.assertTrue(allequal(row[1], numpy.array([-1.1e34, 1.3e-32],
-                                                         dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[0], np.array([4.3, 2.2, 4.3], dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[1], np.array([-1.1e34, 1.3e-32], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1109,15 +1100,15 @@ class TypesTestCase(common.TempFileMixin, TestCase):
         """Checking updating vlarray with float atoms (another byteorder)"""
 
         ttypes = {
-            "float32": numpy.float32,
-            "float64": numpy.float64,
+            "float32": np.float32,
+            "float64": np.float64,
         }
         if hasattr(tables, "Float16Atom"):
-            ttypes["float16"] = numpy.float16
+            ttypes["float16"] = np.float16
         if hasattr(tables, "Float96Atom"):
-            ttypes["float96"] = numpy.float96
+            ttypes["float96"] = np.float96
         if hasattr(tables, "Float128Atom"):
-            ttypes["float128"] = numpy.float128
+            ttypes["float128"] = np.float128
 
         if common.verbose:
             print('\n', '-=' * 30)
@@ -1128,17 +1119,17 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             vlarray = self.h5file.create_vlarray(
                 '/', atype, atom=Atom.from_sctype(ttypes[atype]),
                 byteorder=byteorder)
-            a0 = numpy.array([1.3, 2.2, 3.3], dtype=atype)
+            a0 = np.array([1.3, 2.2, 3.3], dtype=atype)
             vlarray.append(a0)
-            a1 = numpy.array([-1, 0], dtype=atype)
+            a1 = np.array([-1, 0], dtype=atype)
             vlarray.append(a1)
 
             # Modify rows
-            a0 = numpy.array([4.3, 2.2, 4.3], dtype=atype)
+            a0 = np.array([4.3, 2.2, 4.3], dtype=atype)
             a0 = a0.byteswap()
             a0 = a0.newbyteorder()
             vlarray[0] = a0
-            a1 = numpy.array([-1.1e34, 1.3e-32], dtype=atype)
+            a1 = np.array([-1.1e34, 1.3e-32], dtype=atype)
             a1 = a1.byteswap()
             a1 = a1.newbyteorder()
             vlarray[1] = a1
@@ -1159,10 +1150,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             self.assertEqual(vlarray.byteorder, byteorder)
             self.assertEqual(byteorders[row[0].dtype.byteorder], sys.byteorder)
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(allequal(row[0], numpy.array([4.3, 2.2, 4.3],
-                                                         dtype=ttypes[atype])))
-            self.assertTrue(allequal(row[1], numpy.array([-1.1e34, 1.3e-32],
-                                                         dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[0], np.array([4.3, 2.2, 4.3], dtype=ttypes[atype])))
+            self.assertTrue(allequal(
+                row[1], np.array([-1.1e34, 1.3e-32], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1203,13 +1194,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                allequal(row[0],
-                         numpy.array([(1.3 + 0j), (0+2.2j), (3.3+3.3j)],
-                                     atype)))
-            self.assertTrue(
-                allequal(row[1],
-                         numpy.array([(0-1.3e34j), (1.e-32 + 0j)], atype)))
+            self.assertTrue(allequal(
+                row[0], np.array([(1.3 + 0j), (0+2.2j), (3.3+3.3j)], atype)))
+            self.assertTrue(allequal(
+                row[1], np.array([(0-1.3e34j), (1.e-32 + 0j)], atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1255,13 +1243,10 @@ class TypesTestCase(common.TempFileMixin, TestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                allequal(row[0],
-                         numpy.array([(1.4 + 0j), (0+4.2j), (3.3+4.3j)],
-                                     atype)))
-            self.assertTrue(
-                allequal(row[1],
-                         numpy.array([(4-1.3e34j), (1.e-32 + 4j)], atype)))
+            self.assertTrue(allequal(
+                row[0], np.array([(1.4 + 0j), (0+4.2j), (3.3+4.3j)], atype)))
+            self.assertTrue(allequal(
+                row[1], np.array([(4-1.3e34j), (1.e-32 + 4j)], atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -1436,9 +1421,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test06c_Object..." % self.__class__.__name__)
 
         vlarray = self.h5file.create_vlarray('/', "Object", atom=ObjectAtom())
-        vlarray.append(numpy.array([[1, 2], [0, 4]], 'i4'))
-        vlarray.append(numpy.array([0, 1, 2, 3], 'i8'))
-        vlarray.append(numpy.array(42, 'i1'))
+        vlarray.append(np.array([[1, 2], [0, 4]], 'i4'))
+        vlarray.append(np.array([0, 1, 2, 3], 'i8'))
+        vlarray.append(np.array(42, 'i1'))
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -1453,9 +1438,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertTrue(allequal(row[0], numpy.array([[1, 2], [0, 4]], 'i4')))
-        self.assertTrue(allequal(row[1], numpy.array([0, 1, 2, 3], 'i8')))
-        self.assertTrue(allequal(row[2], numpy.array(42, 'i1')))
+        self.assertTrue(allequal(row[0], np.array([[1, 2], [0, 4]], 'i4')))
+        self.assertTrue(allequal(row[1], np.array([0, 1, 2, 3], 'i8')))
+        self.assertTrue(allequal(row[2], np.array(42, 'i1')))
 
     def test06d_Object(self):
         """Checking updating vlarray with object atoms (numpy arrays)"""
@@ -1465,16 +1450,16 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("Running %s.test06d_Object..." % self.__class__.__name__)
 
         vlarray = self.h5file.create_vlarray('/', "Object", atom=ObjectAtom())
-        vlarray.append(numpy.array([[1, 2], [0, 4]], 'i4'))
-        vlarray.append(numpy.array([0, 1, 2, 3], 'i8'))
-        vlarray.append(numpy.array(42, 'i1'))
+        vlarray.append(np.array([[1, 2], [0, 4]], 'i4'))
+        vlarray.append(np.array([0, 1, 2, 3], 'i8'))
+        vlarray.append(np.array(42, 'i1'))
 
         # Modify the rows.  Since PyTables 2.2.1 we use a binary
         # pickle for arrays and ObjectAtoms, so the next should take
         # the same space than the above.
-        vlarray[0] = numpy.array([[1, 0], [0, 4]], 'i4')
-        vlarray[1] = numpy.array([0, 1, 0, 3], 'i8')
-        vlarray[2] = numpy.array(22, 'i1')
+        vlarray[0] = np.array([[1, 0], [0, 4]], 'i4')
+        vlarray[1] = np.array([0, 1, 0, 3], 'i8')
+        vlarray[2] = np.array(22, 'i1')
 
         if self.reopen:
             name = vlarray._v_pathname
@@ -1489,9 +1474,9 @@ class TypesTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertTrue(allequal(row[0], numpy.array([[1, 0], [0, 4]], 'i4')))
-        self.assertTrue(allequal(row[1], numpy.array([0, 1, 0, 3], 'i8')))
-        self.assertTrue(allequal(row[2], numpy.array(22, 'i1')))
+        self.assertTrue(allequal(row[0], np.array([[1, 0], [0, 4]], 'i4')))
+        self.assertTrue(allequal(row[1], np.array([0, 1, 0, 3], 'i8')))
+        self.assertTrue(allequal(row[2], np.array(22, 'i1')))
 
     def test07_VLUnicodeAtom(self):
         """Checking vlarray with variable length Unicode strings."""
@@ -1620,11 +1605,11 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             print("Second row in vlarray ==>", row[1])
 
         self.assertEqual(vlarray.nrows, 2)
-        npt.assert_array_equal(
-            row[0], numpy.array([["123", "45"], ["45", "123"]], 'S'))
-        npt.assert_array_equal(
-            row[1], numpy.array([["s", "abc"], ["abc", "f"],
-                                 ["s", "ab"], ["ab", "f"]], 'S'))
+        np.testing.assert_array_equal(
+            row[0], np.array([["123", "45"], ["45", "123"]], 'S'))
+        np.testing.assert_array_equal(
+            row[1], np.array([["s", "abc"], ["abc", "f"],
+                              ["s", "ab"], ["ab", "f"]], 'S'))
         self.assertEqual(len(row[0]), 2)
         self.assertEqual(len(row[1]), 4)
 
@@ -1672,11 +1657,11 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             root, 'stringAtom', StringAtom(itemsize=3, shape=(2,)),
             "Ragged array of strings")
         vlarray.flavor = "python"
-        a = numpy.array([["a", "b"], ["123", "45"], ["45", "123"]], dtype="S3")
+        a = np.array([["a", "b"], ["123", "45"], ["45", "123"]], dtype="S3")
         vlarray.append(a[1:])
-        a = numpy.array([["s", "a"], ["ab", "f"],
-                         ["s", "abc"], ["abc", "f"],
-                         ["s", "ab"], ["ab", "f"]])
+        a = np.array([["s", "a"], ["ab", "f"],
+                      ["s", "abc"], ["abc", "f"],
+                      ["s", "ab"], ["ab", "f"]])
         vlarray.append(a[2:])
 
         # Read all the rows:
@@ -1706,11 +1691,11 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             root, 'stringAtom', StringAtom(itemsize=3, shape=(2,)),
             "Ragged array of strings")
         vlarray.flavor = "python"
-        a = numpy.array([["a", "b"], ["123", "45"], ["45", "123"]], dtype="S3")
+        a = np.array([["a", "b"], ["123", "45"], ["45", "123"]], dtype="S3")
         vlarray.append(a[1::2])
-        a = numpy.array([["s", "a"], ["ab", "f"],
-                         ["s", "abc"], ["abc", "f"],
-                         ["s", "ab"], ["ab", "f"]])
+        a = np.array([["s", "a"], ["ab", "f"],
+                      ["s", "abc"], ["abc", "f"],
+                      ["s", "ab"], ["ab", "f"]])
         vlarray.append(a[::3])
 
         # Read all the rows:
@@ -1749,11 +1734,10 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             print("Second row in vlarray ==>", row[1])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(
-            allequal(row[0], numpy.array([[1, 0, 1], [1, 1, 1], [0, 0, 0]],
-                                         dtype='bool')))
-        self.assertTrue(
-            allequal(row[1], numpy.array([[1, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(
+            row[0], np.array([[1, 0, 1], [1, 1, 1], [0, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(
+            row[1], np.array([[1, 0, 0]], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 1)
 
@@ -1769,10 +1753,10 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray(root, 'BoolAtom',
                                              BoolAtom(shape=(3,)),
                                              "Ragged array of Booleans")
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (0, 0, 0)], dtype='bool')
+        a = np.array(
+            [(0, 0, 0), (1, 0, 3), (1, 1, 1), (0, 0, 0)], dtype='bool')
         vlarray.append(a[1:])  # Create an offset
-        a = numpy.array([(1, 1, 1), (-1, 0, 0)], dtype='bool')
+        a = np.array([(1, 1, 1), (-1, 0, 0)], dtype='bool')
         vlarray.append(a[1:])  # Create an offset
 
         # Read all the rows:
@@ -1783,11 +1767,9 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             print("Second row in vlarray ==>", row[1])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(
-            allequal(row[0], numpy.array([[1, 0, 1], [1, 1, 1], [0, 0, 0]],
-                                         dtype='bool')))
-        self.assertTrue(allequal(row[
-                        1], numpy.array([[1, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(
+            row[0], np.array([[1, 0, 1], [1, 1, 1], [0, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(row[1], np.array([[1, 0, 0]], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 1)
 
@@ -1803,10 +1785,10 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray(root, 'BoolAtom',
                                              BoolAtom(shape=(3,)),
                                              "Ragged array of Booleans")
-        a = numpy.array([(0, 0, 0), (1, 0, 3), (
-            1, 1, 1), (0, 0, 0)], dtype='bool')
+        a = np.array(
+            [(0, 0, 0), (1, 0, 3), (1, 1, 1), (0, 0, 0)], dtype='bool')
         vlarray.append(a[1::2])  # Create an strided array
-        a = numpy.array([(1, 1, 1), (-1, 0, 0), (0, 0, 0)], dtype='bool')
+        a = np.array([(1, 1, 1), (-1, 0, 0), (0, 0, 0)], dtype='bool')
         vlarray.append(a[::2])  # Create an strided array
 
         # Read all the rows:
@@ -1817,12 +1799,10 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
             print("Second row in vlarray ==>", row[1])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(
-            allequal(row[0],
-                     numpy.array([[1, 0, 1], [0, 0, 0]], dtype='bool')))
-        self.assertTrue(
-            allequal(row[1],
-                     numpy.array([[1, 1, 1], [0, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(
+            row[0], np.array([[1, 0, 1], [0, 0, 0]], dtype='bool')))
+        self.assertTrue(allequal(
+            row[1], np.array([[1, 1, 1], [0, 0, 0]], dtype='bool')))
         self.assertEqual(len(row[0]), 2)
         self.assertEqual(len(row[1]), 2)
 
@@ -1848,9 +1828,8 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 root, atype, atom=Atom.from_sctype(atype, (2, 3)))
-            vlarray.append([numpy.ones((2, 3), atype),
-                            numpy.zeros((2, 3), atype)])
-            vlarray.append([numpy.ones((2, 3), atype)*100])
+            vlarray.append([np.ones((2, 3), atype), np.zeros((2, 3), atype)])
+            vlarray.append([np.ones((2, 3), atype)*100])
 
             # Read all the rows:
             row = vlarray.read()
@@ -1860,12 +1839,10 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
                 print("Second row in vlarray ==>", repr(row[1]))
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                allequal(row[0], numpy.array([numpy.ones((2, 3)),
-                                              numpy.zeros((2, 3))],
-                                             atype)))
-            self.assertTrue(
-                allequal(row[1], numpy.array([numpy.ones((2, 3))*100], atype)))
+            self.assertTrue(allequal(
+                row[0], np.array([np.ones((2, 3)), np.zeros((2, 3))], atype)))
+            self.assertTrue(allequal(
+                row[1], np.array([np.ones((2, 3)) * 100], atype)))
             self.assertEqual(len(row[0]), 2)
             self.assertEqual(len(row[1]), 1)
 
@@ -1897,9 +1874,9 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
         for atype in ttypes:
             vlarray = self.h5file.create_vlarray(
                 root, atype, atom=Atom.from_sctype(atype, (5, 2, 6)))
-            vlarray.append([numpy.ones((5, 2, 6), atype)*1.3,
-                            numpy.zeros((5, 2, 6), atype)])
-            vlarray.append([numpy.ones((5, 2, 6), atype)*2.e4])
+            vlarray.append([np.ones((5, 2, 6), atype)*1.3,
+                            np.zeros((5, 2, 6), atype)])
+            vlarray.append([np.ones((5, 2, 6), atype)*2.e4])
 
             # Read all the rows:
             row = vlarray.read()
@@ -1909,13 +1886,11 @@ class MDTypesTestCase(common.TempFileMixin, TestCase):
                 print("Second row in vlarray ==>", row[1])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                allequal(row[0], numpy.array([numpy.ones((5, 2, 6))*1.3,
-                                              numpy.zeros((5, 2, 6))],
-                                             atype)))
-            self.assertTrue(
-                allequal(row[1], numpy.array([numpy.ones((5, 2, 6))*2.e4],
-                                             atype)))
+            self.assertTrue(allequal(
+                row[0], np.array(
+                    [np.ones((5, 2, 6)) * 1.3, np.zeros((5, 2, 6))], atype)))
+            self.assertTrue(allequal(
+                row[1], np.array([np.ones((5, 2, 6)) * 2.e4], atype)))
             self.assertEqual(len(row[0]), 2)
             self.assertEqual(len(row[1]), 1)
 
@@ -1949,7 +1924,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
         # All of the next should lead to the same rows
         vlarray.append((1, 2, 3))  # a tuple
         vlarray.append([1, 2, 3])  # a unique list
-        vlarray.append(numpy.array([1, 2, 3], dtype='int32'))  # and array
+        vlarray.append(np.array([1, 2, 3], dtype='int32'))  # and array
 
         if self.close:
             if common.verbose:
@@ -2011,7 +1986,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.create_vlarray(root, 'vlarray',
                                              Int32Atom(),
                                              "Ragged array of ints")
-        vlarray.append(numpy.zeros(dtype='int32', shape=(6, 0)))
+        vlarray.append(np.zeros(dtype='int32', shape=(6, 0)))
 
         if self.close:
             if common.verbose:
@@ -2027,7 +2002,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", repr(row))
 
         self.assertEqual(vlarray.nrows, 1)
-        self.assertTrue(allequal(row, numpy.zeros(dtype='int32', shape=(0,))))
+        self.assertTrue(allequal(row, np.zeros(dtype='int32', shape=(0,))))
         self.assertEqual(len(row), 0)
 
     def test03a_cast(self):
@@ -2043,7 +2018,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
                                              Int32Atom(),
                                              "Ragged array of ints")
         # This type has to be upgraded
-        vlarray.append(numpy.array([1, 2], dtype='int16'))
+        vlarray.append(np.array([1, 2], dtype='int16'))
 
         if self.close:
             if common.verbose:
@@ -2059,7 +2034,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", repr(row))
 
         self.assertEqual(vlarray.nrows, 1)
-        self.assertTrue(allequal(row, numpy.array([1, 2], dtype='int32')))
+        self.assertTrue(allequal(row, np.array([1, 2], dtype='int32')))
         self.assertEqual(len(row), 2)
 
     def test03b_cast(self):
@@ -2075,7 +2050,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
                                              Int32Atom(),
                                              "Ragged array of ints")
         # This type has to be downcasted
-        vlarray.append(numpy.array([1, 2], dtype='float64'))
+        vlarray.append(np.array([1, 2], dtype='float64'))
 
         if self.close:
             if common.verbose:
@@ -2091,7 +2066,7 @@ class AppendShapeTestCase(common.TempFileMixin, TestCase):
             print("First row in vlarray ==>", repr(row))
 
         self.assertEqual(vlarray.nrows, 1)
-        self.assertTrue(allequal(row, numpy.array([1, 2], dtype='int32')))
+        self.assertTrue(allequal(row, np.array([1, 2], dtype='int32')))
         self.assertEqual(len(row), 2)
 
 
@@ -2197,9 +2172,9 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
             arr2 = []
             arr3 = [1, 0]
         elif self.flavor == "numpy":
-            arr1 = numpy.array([1, 1, 1], dtype="bool")
-            arr2 = numpy.array([], dtype="bool")
-            arr3 = numpy.array([1, 0], dtype="bool")
+            arr1 = np.array([1, 1, 1], dtype="bool")
+            arr2 = np.array([], dtype="bool")
+            arr3 = np.array([1, 0], dtype="bool")
 
         if self.flavor == "numpy":
             self.assertTrue(allequal(row[0], arr1, self.flavor))
@@ -2257,9 +2232,9 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
                 arr2 = []
                 arr3 = [100, 0]
             elif self.flavor == "numpy":
-                arr1 = numpy.array([1, 2, 3], dtype=atype)
-                arr2 = numpy.array([], dtype=atype)
-                arr3 = numpy.array([100, 0], dtype=atype)
+                arr1 = np.array([1, 2, 3], dtype=atype)
+                arr2 = np.array([], dtype=atype)
+                arr3 = np.array([100, 0], dtype=atype)
 
             if self.flavor == "numpy":
                 self.assertTrue(allequal(row[0], arr1, self.flavor))
@@ -2320,9 +2295,9 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
                 arr2 = []
                 arr3 = [100, 0]
             elif self.flavor == "numpy":
-                arr1 = numpy.array([1, 2, 3], dtype=atype)
-                arr2 = numpy.array([], dtype=atype)
-                arr3 = numpy.array([100, 0], dtype=atype)
+                arr1 = np.array([1, 2, 3], dtype=atype)
+                arr2 = np.array([], dtype=atype)
+                arr3 = np.array([100, 0], dtype=atype)
 
             if self.flavor == "numpy":
                 self.assertTrue(allequal(row[0], arr1, self.flavor))
@@ -2381,13 +2356,13 @@ class FlavorTestCase(common.TempFileMixin, TestCase):
             self.assertEqual(len(row[1]), 0)
             self.assertEqual(len(row[2]), 2)
             if self.flavor == "python":
-                arr1 = list(numpy.array([1.3, 2.2, 3.3], atype))
-                arr2 = list(numpy.array([], atype))
-                arr3 = list(numpy.array([-1.3e34, 1.e-32], atype))
+                arr1 = list(np.array([1.3, 2.2, 3.3], atype))
+                arr2 = list(np.array([], atype))
+                arr3 = list(np.array([-1.3e34, 1.e-32], atype))
             elif self.flavor == "numpy":
-                arr1 = numpy.array([1.3, 2.2, 3.3], dtype=atype)
-                arr2 = numpy.array([], dtype=atype)
-                arr3 = numpy.array([-1.3e34, 1.e-32], dtype=atype)
+                arr1 = np.array([1.3, 2.2, 3.3], dtype=atype)
+                arr2 = np.array([], dtype=atype)
+                arr3 = np.array([-1.3e34, 1.e-32], dtype=atype)
 
             if self.flavor == "numpy":
                 self.assertTrue(allequal(row[0], arr1, self.flavor))
@@ -2455,9 +2430,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0], numpy.arange(0, dtype='int32')))
-        self.assertTrue(allequal(row[1], numpy.arange(10, dtype='int32')))
-        self.assertTrue(allequal(row[2], numpy.arange(99, dtype='int32')))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32')))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32')))
 
     def test01b_start(self):
         """Checking reads with only a start value in a slice"""
@@ -2481,9 +2456,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0], numpy.arange(0, dtype='int32')))
-        self.assertTrue(allequal(row[1], numpy.arange(10, dtype='int32')))
-        self.assertTrue(allequal(row[2], numpy.arange(99, dtype='int32')))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32')))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32')))
 
     def test01np_start(self):
         """Checking reads with only a start value in a slice (numpy indexes)"""
@@ -2496,9 +2471,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
 
         # Read some rows:
         row = []
-        row.append(vlarray[numpy.int8(0)])
-        row.append(vlarray[numpy.int32(10)])
-        row.append(vlarray[numpy.int64(99)])
+        row.append(vlarray[np.int8(0)])
+        row.append(vlarray[np.int32(10)])
+        row.append(vlarray[np.int64(99)])
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
             print("Second row in vlarray ==>", row[1])
@@ -2507,9 +2482,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0], numpy.arange(0, dtype='int32')))
-        self.assertTrue(allequal(row[1], numpy.arange(10, dtype='int32')))
-        self.assertTrue(allequal(row[2], numpy.arange(99, dtype='int32')))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32')))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32')))
 
     def test02_stop(self):
         """Checking reads with only a stop value"""
@@ -2536,13 +2511,13 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 1)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0][0], numpy.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[0][0], np.arange(0, dtype='int32')))
         for x in range(10):
             self.assertTrue(allequal(row[1][
-                            x], numpy.arange(x, dtype='int32')))
+                            x], np.arange(x, dtype='int32')))
         for x in range(99):
             self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+                            x], np.arange(x, dtype='int32')))
 
     def test02b_stop(self):
         """Checking reads with only a stop value in a slice"""
@@ -2570,14 +2545,11 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
         for x in range(1):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(0, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(allequal(row[1][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test03_startstop(self):
         """Checking reads with a start and stop values"""
@@ -2605,14 +2577,11 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(
-                allequal(row[1][x-5], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test03b_startstop(self):
         """Checking reads with a start and stop values in slices"""
@@ -2640,14 +2609,11 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(
-                allequal(row[1][x-5], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test04_startstopstep(self):
         """Checking reads with a start, stop & step values"""
@@ -2676,14 +2642,14 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
-            self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[0][x // 2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
-            self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[1][(x - 5) // 3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
-            self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[2][x // 20], np.arange(x, dtype='int32')))
 
     def test04np_startstopstep(self):
         """Checking reads with a start, stop & step values (numpy indices)"""
@@ -2700,10 +2666,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
 
         # Read some rows:
         row = []
-        row.append(vlarray.read(numpy.int8(0), numpy.int8(10), numpy.int8(2)))
-        row.append(vlarray.read(numpy.int8(5), numpy.int8(15), numpy.int8(3)))
-        row.append(vlarray.read(numpy.int8(
-            0), numpy.int8(100), numpy.int8(20)))
+        row.append(vlarray.read(np.int8(0), np.int8(10), np.int8(2)))
+        row.append(vlarray.read(np.int8(5), np.int8(15), np.int8(3)))
+        row.append(vlarray.read(np.int8(0), np.int8(100), np.int8(20)))
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
             print("Second row in vlarray ==>", row[1])
@@ -2713,14 +2678,14 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
-            self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[0][x // 2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
-            self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[1][(x - 5) // 3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
-            self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[2][x // 20], np.arange(x, dtype='int32')))
 
     def test04b_slices(self):
         """Checking reads with start, stop & step values in slices"""
@@ -2748,14 +2713,14 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
-            self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[0][x // 2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
-            self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[1][(x - 5) // 3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
-            self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(
+                row[2][x // 20], np.arange(x, dtype='int32')))
 
     def test04bnp_slices(self):
         """Checking reads with start, stop & step values in slices.
@@ -2775,9 +2740,9 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
 
         # Read some rows:
         row = []
-        row.append(vlarray[numpy.int16(0):numpy.int16(10):numpy.int32(2)])
-        row.append(vlarray[numpy.int16(5):numpy.int16(15):numpy.int64(3)])
-        row.append(vlarray[numpy.uint16(0):numpy.int32(100):numpy.int8(20)])
+        row.append(vlarray[np.int16(0):np.int16(10):np.int32(2)])
+        row.append(vlarray[np.int16(5):np.int16(15):np.int64(3)])
+        row.append(vlarray[np.uint16(0):np.int32(100):np.int8(20)])
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
             print("Second row in vlarray ==>", row[1])
@@ -2788,13 +2753,13 @@ class ReadRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
             self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+                allequal(row[0][x//2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
             self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+                allequal(row[1][(x-5)//3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
             self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+                allequal(row[2][x//20], np.arange(x, dtype='int32')))
 
     def test05_out_of_range(self):
         """Checking out of range reads"""
@@ -2854,7 +2819,7 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         row.append(vlarray[0])
 
         # rank-0 array should work as a regular index (see #303)
-        row.append(vlarray[numpy.array(10)])
+        row.append(vlarray[np.array(10)])
         row.append(vlarray[99])
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
@@ -2864,12 +2829,9 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')))
-        self.assertTrue(
-            allequal(row[2], numpy.arange(99, dtype='int32')))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32')))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32')))
 
     def test01b_start(self):
         """Checking reads with only a start value in a slice"""
@@ -2893,9 +2855,9 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0], numpy.arange(0, dtype='int32')))
-        self.assertTrue(allequal(row[1], numpy.arange(10, dtype='int32')))
-        self.assertTrue(allequal(row[2], numpy.arange(99, dtype='int32')))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32')))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32')))
 
     def test02_stop(self):
         """Checking reads with only a stop value"""
@@ -2923,13 +2885,11 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 1)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(allequal(row[0][0], numpy.arange(0, dtype='int32')))
+        self.assertTrue(allequal(row[0][0], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(allequal(row[1][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test02b_stop(self):
         """Checking reads with only a stop value in a slice"""
@@ -2957,14 +2917,11 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
         for x in range(1):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(0, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(allequal(row[1][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test03_startstop(self):
         """Checking reads with a start and stop values"""
@@ -2992,14 +2949,11 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(
-                allequal(row[1][x-5], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test03b_startstop(self):
         """Checking reads with a start and stop values in slices"""
@@ -3027,14 +2981,11 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(allequal(row[0][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(
-                allequal(row[1][x-5], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(allequal(row[2][
-                            x], numpy.arange(x, dtype='int32')))
+            self.assertTrue(allequal(row[2][x], np.arange(x, dtype='int32')))
 
     def test04_slices(self):
         """Checking reads with a start, stop & step values"""
@@ -3063,13 +3014,13 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
             self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+                allequal(row[0][x//2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
             self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+                allequal(row[1][(x-5)//3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
             self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+                allequal(row[2][x//20], np.arange(x, dtype='int32')))
 
     def test04bnp_slices(self):
         """Checking reads with start, stop & step values (numpy indices)"""
@@ -3085,9 +3036,9 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
 
         # Read some rows:
         row = []
-        row.append(vlarray[numpy.int8(0):numpy.int8(10):numpy.int8(2)])
-        row.append(vlarray[numpy.int8(5):numpy.int8(15):numpy.int8(3)])
-        row.append(vlarray[numpy.int8(0):numpy.int8(100):numpy.int8(20)])
+        row.append(vlarray[np.int8(0):np.int8(10):np.int8(2)])
+        row.append(vlarray[np.int8(5):np.int8(15):np.int8(3)])
+        row.append(vlarray[np.int8(0):np.int8(100):np.int8(20)])
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
             print("Second row in vlarray ==>", row[1])
@@ -3098,13 +3049,13 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[2]), 5)
         for x in range(0, 10, 2):
             self.assertTrue(
-                allequal(row[0][x//2], numpy.arange(x, dtype='int32')))
+                allequal(row[0][x//2], np.arange(x, dtype='int32')))
         for x in range(5, 15, 3):
             self.assertTrue(
-                allequal(row[1][(x-5)//3], numpy.arange(x, dtype='int32')))
+                allequal(row[1][(x-5)//3], np.arange(x, dtype='int32')))
         for x in range(0, 100, 20):
             self.assertTrue(
-                allequal(row[2][x//20], numpy.arange(x, dtype='int32')))
+                allequal(row[2][x//20], np.arange(x, dtype='int32')))
 
     def test05_out_of_range(self):
         """Checking out of range reads"""
@@ -3137,7 +3088,7 @@ class GetItemRangeTestCase(common.TempFileMixin, TestCase):
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
 
         with self.assertRaises(IndexError):
-            row = vlarray[numpy.int32(1000)]
+            row = vlarray[np.int32(1000)]
             print("row-->", row)
 
 
@@ -3193,12 +3144,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[2], numpy.arange(99, dtype='int32')*2 + 3))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32') * 2 + 3))
 
     def test01np_start(self):
         """Checking updates that modifies a complete row"""
@@ -3210,15 +3158,15 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.root.vlarray
 
         # Modify some rows:
-        vlarray[numpy.int8(0)] = vlarray[numpy.int16(0)]*2 + 3
-        vlarray[numpy.int8(10)] = vlarray[numpy.int8(10)]*2 + 3
-        vlarray[numpy.int32(99)] = vlarray[numpy.int64(99)]*2 + 3
+        vlarray[np.int8(0)] = vlarray[np.int16(0)]*2 + 3
+        vlarray[np.int8(10)] = vlarray[np.int8(10)]*2 + 3
+        vlarray[np.int32(99)] = vlarray[np.int64(99)]*2 + 3
 
         # Read some rows:
         row = []
-        row.append(vlarray.read(numpy.int8(0))[0])
-        row.append(vlarray.read(numpy.int8(10))[0])
-        row.append(vlarray.read(numpy.int8(99))[0])
+        row.append(vlarray.read(np.int8(0))[0])
+        row.append(vlarray.read(np.int8(10))[0])
+        row.append(vlarray.read(np.int8(99))[0])
         if common.verbose:
             print("Nrows in", vlarray._v_pathname, ":", vlarray.nrows)
             print("Second row in vlarray ==>", row[1])
@@ -3227,12 +3175,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[2], numpy.arange(99, dtype='int32')*2 + 3))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[2], np.arange(99, dtype='int32') * 2 + 3))
 
     def test02_partial(self):
         """Checking updates with only a part of a row"""
@@ -3261,11 +3206,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')*2 + 3))
-        a = numpy.arange(3, 99, dtype='int32')
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        a = np.arange(3, 99, dtype='int32')
         a = a * 2 + 3
         self.assertTrue(allequal(row[2], a))
 
@@ -3297,9 +3240,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
-        self.assertTrue(allequal(row[0], numpy.arange(3, dtype='int32')*2 + 3))
-        self.assertTrue(allequal(row[1], numpy.arange(4, dtype='int32')*2 + 3))
-        self.assertTrue(allequal(row[2], numpy.arange(5, dtype='int32')*2 + 3))
+        self.assertTrue(allequal(row[0], np.arange(3, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(4, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[2], np.arange(5, dtype='int32') * 2 + 3))
 
     def test03b_several_rows(self):
         """Checking updating several rows at once (list style)"""
@@ -3329,12 +3272,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[2], numpy.arange(96, dtype='int32')*2 + 3))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[2], np.arange(96, dtype='int32') * 2 + 3))
 
     def test03c_several_rows(self):
         """Checking updating several rows at once (NumPy's where style)"""
@@ -3347,9 +3287,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         vlarray = self.h5file.root.vlarray
 
         # Modify some rows:
-        vlarray[(numpy.array([0, 10, 96]),)] = (vlarray[0]*2 + 3,
-                                                vlarray[10]*2 + 3,
-                                                vlarray[96]*2 + 3)
+        vlarray[(np.array([0, 10, 96]),)] = (vlarray[0] * 2 + 3,
+                                             vlarray[10] * 2 + 3,
+                                             vlarray[96] * 2 + 3)
 
         # Read some rows:
         row = []
@@ -3364,12 +3304,9 @@ class SetRangeTestCase(common.TempFileMixin, TestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(
-            allequal(row[0], numpy.arange(0, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[1], numpy.arange(10, dtype='int32')*2 + 3))
-        self.assertTrue(
-            allequal(row[2], numpy.arange(96, dtype='int32')*2 + 3))
+        self.assertTrue(allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(allequal(row[2], np.arange(96, dtype='int32') * 2 + 3))
 
     def test04_out_of_range(self):
         """Checking out of range updates (first index)"""
@@ -3932,8 +3869,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
             self.h5file.root, 'array1', arr, "title array1")
 
         # Add a couple of rows
-        array1.append(numpy.array([456, 2], dtype='int16'))
-        array1.append(numpy.array([3], dtype='int16'))
+        array1.append(np.array([456, 2], dtype='int16'))
+        array1.append(np.array([3], dtype='int16'))
 
     def test00_truncate(self):
         """Checking VLArray.truncate() method (truncating to 0 rows)"""
@@ -3971,8 +3908,7 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
             print("array1-->", array1.read())
 
         self.assertEqual(array1.nrows, 1)
-        self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
+        self.assertTrue(allequal(array1[0], np.array([456, 2], dtype='int16')))
 
     def test02_truncate(self):
         """Checking VLArray.truncate() method (truncating to == self.nrows)"""
@@ -3992,8 +3928,8 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         self.assertEqual(array1.nrows, 2)
         self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
-        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='int16')))
+            allequal(array1[0], np.array([456, 2], dtype='int16')))
+        self.assertTrue(allequal(array1[1], np.array([3], dtype='int16')))
 
     def test03_truncate(self):
         """Checking VLArray.truncate() method (truncating to > self.nrows)"""
@@ -4015,12 +3951,12 @@ class TruncateTestCase(common.TempFileMixin, TestCase):
 
         # Check the original values
         self.assertTrue(
-            allequal(array1[0], numpy.array([456, 2], dtype='int16')))
-        self.assertTrue(allequal(array1[1], numpy.array([3], dtype='int16')))
+            allequal(array1[0], np.array([456, 2], dtype='int16')))
+        self.assertTrue(allequal(array1[1], np.array([3], dtype='int16')))
 
         # Check that the added rows are empty
-        self.assertTrue(allequal(array1[2], numpy.array([], dtype='int16')))
-        self.assertTrue(allequal(array1[3], numpy.array([], dtype='int16')))
+        self.assertTrue(allequal(array1[2], np.array([], dtype='int16')))
+        self.assertTrue(allequal(array1[3], np.array([], dtype='int16')))
 
 
 class TruncateOpenTestCase(TruncateTestCase):
@@ -4043,9 +3979,9 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
             [0, 2],                 # list
             [0, -2],                # negative values
             ([0, 2],),              # tuple of list
-            numpy.array([], dtype="i4"),       # empty array
-            numpy.array([1], dtype="i4"),      # single-entry array
-            numpy.array([True, False, True]),   # array of bools
+            np.array([], dtype="i4"),       # empty array
+            np.array([1], dtype="i4"),      # single-entry array
+            np.array([True, False, True]),   # array of bools
         ]
 
         # The next are invalid selections for VLArrays
@@ -4055,10 +3991,10 @@ class PointSelectionTestCase(common.TempFileMixin, TestCase):
         ]
 
         # Create a sample array
-        arr1 = numpy.array([5, 6], dtype="i4")
-        arr2 = numpy.array([5, 6, 7], dtype="i4")
-        arr3 = numpy.array([5, 6, 9, 8], dtype="i4")
-        self.nparr = numpy.array([arr1, arr2, arr3], dtype="object")
+        arr1 = np.array([5, 6], dtype="i4")
+        arr2 = np.array([5, 6, 7], dtype="i4")
+        arr3 = np.array([5, 6, 9, 8], dtype="i4")
+        self.nparr = np.array([arr1, arr2, arr3], dtype="object")
 
         # Create the VLArray
         self.vlarr = self.h5file.create_vlarray(
@@ -4112,7 +4048,7 @@ class SizeInMemoryPropertyTestCase(common.TempFileMixin, TestCase):
         self.array.flavor = flavor
         expected_size = 0
         for i in range(10):
-            row = numpy.arange((i + 1) * 10, dtype='i4')
+            row = np.arange((i + 1) * 10, dtype='i4')
             self.array.append(row)
             expected_size += row.nbytes
         return expected_size
@@ -4194,7 +4130,7 @@ class AccessClosedTestCase(common.TempFileMixin, TestCase):
 
 
 class TestCreateVLArrayArgs(common.TempFileMixin, TestCase):
-    obj = numpy.array([1, 2, 3])
+    obj = np.array([1, 2, 3])
     where = '/'
     name = 'vlarray'
     atom = Atom.from_dtype(obj.dtype)
@@ -4338,7 +4274,7 @@ class TestCreateVLArrayArgs(common.TempFileMixin, TestCase):
         self.assertTrue(allequal(self.obj, nparr))
 
     def test_kwargs_obj_atom_error(self):
-        atom = Atom.from_dtype(numpy.dtype('complex'))
+        atom = Atom.from_dtype(np.dtype('complex'))
         #shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_vlarray,

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -17,7 +17,7 @@ import warnings
 import subprocess
 from time import perf_counter as clock
 
-import numpy
+import numpy as np
 
 from .flavor import array_of_flavor
 
@@ -31,7 +31,7 @@ byteorders = {
 
 # The type used for size values: indexes, coordinates, dimension
 # lengths, row numbers, shapes, chunk shapes, byte counts...
-SizeType = numpy.int64
+SizeType = np.int64
 
 
 def correct_byteorder(ptype, byteorder):
@@ -61,10 +61,10 @@ def is_idx(index):
             return True
         except TypeError:
             return False
-    elif isinstance(index, numpy.integer):
+    elif isinstance(index, np.integer):
         return True
     # For Python 2.4 one should test 0-dim and 1-dim, 1-elem arrays as well
-    elif (isinstance(index, numpy.ndarray) and (index.shape == ()) and
+    elif (isinstance(index, np.ndarray) and (index.shape == ()) and
           index.dtype.str[1] == 'i'):
         return True
 
@@ -93,7 +93,7 @@ def convert_to_np_atom(arr, atom, copy=False):
     # dtype is not the correct one.
     if atom.shape == ():
         # Scalar atom case
-        nparr = numpy.array(nparr, dtype=atom.dtype, copy=copy)
+        nparr = np.array(nparr, dtype=atom.dtype, copy=copy)
     else:
         # Multidimensional atom case.  Addresses #133.
         # We need to use this strange way to obtain a dtype compliant
@@ -104,7 +104,7 @@ def convert_to_np_atom(arr, atom, copy=False):
         # All of this is done just to taking advantage of the NumPy
         # broadcasting rules.
         newshape = nparr.shape[:-len(atom.dtype.shape)]
-        nparr2 = numpy.empty(newshape, dtype=[('', atom.dtype)])
+        nparr2 = np.empty(newshape, dtype=[('', atom.dtype)])
         nparr2['f0'][:] = nparr
         # Return a view (i.e. get rid of the record type)
         nparr = nparr2.view(atom.dtype)
@@ -290,7 +290,7 @@ def quantize(data, least_significant_digit):
     exp = math.floor(exp) if exp < 0 else math.ceil(exp)
     bits = math.ceil(math.log2(10 ** -exp))
     scale = 2 ** bits
-    datout = numpy.around(scale * data) / scale
+    datout = np.around(scale * data) / scale
 
     return datout
 

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -12,7 +12,7 @@
 
 import operator
 import sys
-import numpy
+import numpy as np
 
 from . import hdf5extension
 from .atom import ObjectAtom, VLStringAtom, VLUnicodeAtom
@@ -331,7 +331,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
 
         # Check the chunkshape parameter
         if new and chunkshape is not None:
-            if isinstance(chunkshape, (int, numpy.integer)):
+            if isinstance(chunkshape, (int, np.integer)):
                 chunkshape = (chunkshape,)
             try:
                 chunkshape = tuple(chunkshape)
@@ -386,7 +386,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
         atom = self.atom
         self._v_version = obversion
         # Check for zero dims in atom shape (not allowed in VLArrays)
-        zerodims = numpy.sum(numpy.array(atom.shape) == 0)
+        zerodims = np.sum(np.array(atom.shape) == 0)
         if zerodims > 0:
             raise ValueError("When creating VLArrays, none of the dimensions "
                              "of the Atom instance can be zero.")
@@ -455,7 +455,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
         """Return the number of objects in a NumPy array."""
 
         # Check for zero dimensionality array
-        zerodims = numpy.sum(numpy.array(nparr.shape) == 0)
+        zerodims = np.sum(np.array(nparr.shape) == 0)
         if zerodims > 0:
             # No objects to be added
             return 0
@@ -678,7 +678,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
                 key.start, key.stop, key.step)
             return self.read(start, stop, step)
         # Try with a boolean or point selection
-        elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
+        elif type(key) in (list, tuple) or isinstance(key, np.ndarray):
             coords = self._point_selection(key)
             return self._read_coordinates(coords)
         else:
@@ -781,7 +781,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
                 key.start, key.stop, key.step)
             coords = range(start, stop, step)
         # Try with a boolean or point selection
-        elif type(key) in (list, tuple) or isinstance(key, numpy.ndarray):
+        elif type(key) in (list, tuple) or isinstance(key, np.ndarray):
             coords = self._point_selection(key)
         else:
             raise IndexError(f"Invalid index or slice: {key!r}")


### PR DESCRIPTION
In order to have a consistent import structure (and to discover deprecations like in #862 more easily) , replace all `import numpy` with `import numpy as np` and the `numpy.` with `np.` in the code.

Two usages of `np` as a variable have been replaced by `arr`.