### PR TITLE
Consistent imports

### DIFF
--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -1,10 +1,10 @@
 import sys
 from time import perf_counter as clock
 
+import numexpr as ne
 import numpy as np
+
 import tables as tb
-from numexpr.necompiler import (
-    getContext, getExprNames, getType, NumExpr)
 
 
 shape = (1000, 160_000)
@@ -78,8 +78,8 @@ def evaluate(ex, out=None, local_dict=None, global_dict=None, **kwargs):
     """Evaluate expression and return an array."""
 
     # First, get the signature for the arrays in expression
-    context = getContext(kwargs)
-    names, _ = getExprNames(ex, context)
+    context = ne.necompiler.getContext(kwargs)
+    names, _ = ne.necompiler.getExprNames(ex, context)
 
     # Get the arguments based on the names.
     call_frame = sys._getframe(1)
@@ -101,11 +101,14 @@ def evaluate(ex, out=None, local_dict=None, global_dict=None, **kwargs):
             types.append(a)
 
     # Create a signature
-    signature = [(name, getType(type_)) for (name, type_) in zip(names, types)]
+    signature = [
+        (name, ne.necompiler.getType(type_))
+        for (name, type_) in zip(names, types)
+    ]
     print("signature-->", signature)
 
     # Compile the expression
-    compiled_ex = NumExpr(ex, signature, [], **kwargs)
+    compiled_ex = ne.necompiler.NumExpr(ex, signature, [], **kwargs)
     print("fullsig-->", compiled_ex.fullsig)
 
     _compute(out, compiled_ex, arguments)

--- a/bench/expression.py
+++ b/bench/expression.py
@@ -1,5 +1,5 @@
+import os
 from time import perf_counter as clock
-import os.path
 
 import numpy as np
 import tables as tb
@@ -116,7 +116,6 @@ def do_bench(what, documpute, dowrite, complib, verbose):
 
 if __name__ == "__main__":
     import sys
-    import os
     import getopt
 
     usage = """usage: %s [-T] [-M] [-c] [-w] [-v] [-z complib]

--- a/bench/open_close-bench.py
+++ b/bench/open_close-bench.py
@@ -9,7 +9,7 @@ import sys
 import getopt
 import pstats
 import cProfile as prof
-import subprocess  # From Python 2.4 on
+import subprocess
 import tables
 from time import perf_counter as clock
 

--- a/bench/postgres_backend.py
+++ b/bench/postgres_backend.py
@@ -1,4 +1,4 @@
-import subprocess  # Needs Python 2.4
+import subprocess
 from indexed_search import DB
 import psycopg2 as db2
 

--- a/bench/sqlite-search-bench.py
+++ b/bench/sqlite-search-bench.py
@@ -4,7 +4,6 @@ import sqlite
 import random
 import sys
 import os
-import os.path
 from time import perf_counter as clock
 from time import process_time as cpuclock
 

--- a/bench/sqlite3-search-bench.py
+++ b/bench/sqlite3-search-bench.py
@@ -1,5 +1,4 @@
 import os
-import os.path
 from time import perf_counter as clock
 import numpy as np
 import random

--- a/doc/source/cookbook/custom_data_types.rst
+++ b/doc/source/cookbook/custom_data_types.rst
@@ -17,7 +17,6 @@ Submitted by Kevin R. Thornton.
 
 ::
 
-    from __future__ import print_function
     import numpy as np
 
     import tables

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -13,7 +13,6 @@
 # Imports
 # =======
 import re
-import sys
 import inspect
 import warnings
 

--- a/tables/conditions.py
+++ b/tables/conditions.py
@@ -29,10 +29,7 @@ Functions:
 """
 
 import re
-from numexpr.necompiler import typecode_to_kind
-from numexpr.necompiler import expressionToAST, typeCompileAst
-from numexpr.necompiler import stringToExpression, NumExpr, getExprNames
-from numexpr.expressions import ExpressionNode
+import numexpr as ne
 
 from .utilsextension import get_nested_field
 from .utils import lazyattr
@@ -52,7 +49,8 @@ def _unsupported_operation_error(exception):
     message = exception.args[0]
     op, types = _no_matching_opcode.search(message).groups()
     newmessage = "unsupported operand types for *%s*: " % op
-    newmessage += ', '.join([typecode_to_kind[t] for t in types[1:]])
+    newmessage += ', '.join(
+        ne.necompiler.typecode_to_kind[t] for t in types[1:])
     return exception.__class__(newmessage)
 
 
@@ -68,7 +66,8 @@ def _check_indexable_cmp(getidxcmp):
         result = getidxcmp(exprnode, indexedcols)
         if result[0] is not None:
             try:
-                typeCompileAst(expressionToAST(exprnode))
+                ne.necompiler.typeCompileAst(
+                    ne.necompiler.expressionToAST(exprnode))
             except NotImplementedError as nie:
                 # Try to make this Numexpr error less cryptic.
                 raise _unsupported_operation_error(nie)
@@ -151,12 +150,15 @@ def _equiv_expr_node(x, y):
     return a new ExpressionNode.
 
     """
-    if not isinstance(x, ExpressionNode) and not isinstance(y, ExpressionNode):
+    if (not isinstance(x, ne.expressions.ExpressionNode)
+            and not isinstance(y, ne.expressions.ExpressionNode)):
         return x == y
-    elif (type(x) is not type(y) or not isinstance(x, ExpressionNode)
-            or not isinstance(y, ExpressionNode)
-            or x.value != y.value or x.astKind != y.astKind
-            or len(x.children) != len(y.children)):
+    elif (type(x) is not type(y)
+          or not isinstance(x, ne.expressions.ExpressionNode)
+          or not isinstance(y, ne.expressions.ExpressionNode)
+          or x.value != y.value
+          or x.astKind != y.astKind
+          or len(x.children) != len(y.children)):
         return False
     for xchild, ychild in zip(x.children, y.children):
         if not _equiv_expr_node(xchild, ychild):
@@ -404,7 +406,7 @@ def compile_condition(condition, typemap, indexedcols):
     """
 
     # Get the expression tree and extract index conditions.
-    expr = stringToExpression(condition, typemap, {})
+    expr = ne.necompiler.stringToExpression(condition, typemap, {})
     if expr.astKind != 'bool':
         raise TypeError("condition ``%s`` does not have a boolean type"
                         % condition)
@@ -427,12 +429,12 @@ def compile_condition(condition, typemap, indexedcols):
         # See the comments in `numexpr.evaluate()` for the
         # reasons of inserting copy operators for unaligned,
         # *unidimensional* arrays.
-        func = NumExpr(expr, signature)
+        func = ne.necompiler.NumExpr(expr, signature)
     except NotImplementedError as nie:
         # Try to make this Numexpr error less cryptic.
         raise _unsupported_operation_error(nie)
 
-    _, ex_uses_vml = getExprNames(condition, {})
+    _, ex_uses_vml = ne.necompiler.getExprNames(condition, {})
     kwargs = {'ex_uses_vml': ex_uses_vml}
 
     params = varnames

--- a/tables/description.py
+++ b/tables/description.py
@@ -12,7 +12,6 @@
 
 # Imports
 # =======
-import sys
 import copy
 import warnings
 

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -13,10 +13,10 @@
 import sys
 import warnings
 
+import numexpr as ne
 import numpy as np
 import tables as tb
-from numexpr.necompiler import getContext, getExprNames, getType, NumExpr
-from numexpr.expressions import functions as numexpr_functions
+
 from .exceptions import PerformanceWarning
 from .parameters import IO_BUFFER_SIZE, BUFFER_TIMES
 
@@ -176,8 +176,8 @@ class Expr:
 
         # First, get the signature for the arrays in expression
         vars_ = self._required_expr_vars(expr, uservars)
-        context = getContext(kwargs)
-        self.names, _ = getExprNames(expr, context)
+        context = ne.necompiler.getContext(kwargs)
+        self.names, _ = ne.necompiler.getExprNames(expr, context)
 
         # Raise a ValueError in case we have unsupported objects
         for name, var in vars_.items():
@@ -222,11 +222,11 @@ class Expr:
             values.append(value)
 
         # Create a signature for the expression
-        signature = [(name, getType(type_))
+        signature = [(name, ne.necompiler.getType(type_))
                      for (name, type_) in zip(self.names, types_)]
 
         # Compile the expression
-        self._compiled_expr = NumExpr(expr, signature, **kwargs)
+        self._compiled_expr = ne.necompiler.NumExpr(expr, signature, **kwargs)
 
         # Guess the shape for the outcome and the maindim of inputs
         self.shape, self.maindim = self._guess_shape()
@@ -266,7 +266,7 @@ class Expr:
             cexpr = compile(expression, '<string>', 'eval')
             exprvars = [var for var in cexpr.co_names
                         if var not in ['None', 'False', 'True']
-                        and var not in numexpr_functions]
+                        and var not in ne.expressions.functions]
             exprvars_cache[expression] = exprvars
         else:
             exprvars = exprvars_cache[expression]

--- a/tables/file.py
+++ b/tables/file.py
@@ -18,12 +18,12 @@ nodes.
 
 """
 
-import collections
 import datetime
 import os
 import sys
 import weakref
 import warnings
+from collections import defaultdict
 
 import numexpr
 import numpy as np
@@ -83,7 +83,7 @@ compatible_formats = []  # Old format versions we can read
 
 class _FileRegistry:
     def __init__(self):
-        self._name_mapping = collections.defaultdict(set)
+        self._name_mapping = defaultdict(set)
         self._handlers = set()
 
     @property

--- a/tables/file.py
+++ b/tables/file.py
@@ -19,7 +19,7 @@ nodes.
 """
 
 import collections
-import datetime as dt
+import datetime
 import os
 import sys
 import weakref
@@ -2785,8 +2785,8 @@ class File(hdf5extension.File):
 
         # Print all the nodes (Group and Leaf objects) on object tree
         try:
-            date = dt.datetime.fromtimestamp(
-                os.stat(self.filename).st_mtime, dt.timezone.utc
+            date = datetime.datetime.fromtimestamp(
+                os.stat(self.filename).st_mtime, datetime.timezone.utc
             ).isoformat(timespec='seconds')
         except OSError:
             # in-memory file

--- a/tables/file.py
+++ b/tables/file.py
@@ -22,7 +22,6 @@ import collections
 import datetime as dt
 import os
 import sys
-import time
 import weakref
 import warnings
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -25,7 +25,7 @@ import weakref
 import warnings
 from collections import defaultdict
 
-import numexpr
+import numexpr as ne
 import numpy as np
 
 from . import hdf5extension
@@ -824,7 +824,7 @@ class File(hdf5extension.File):
             self.enable_undo()
 
         # Set the maximum number of threads for Numexpr
-        numexpr.set_vml_num_threads(params['MAX_NUMEXPR_THREADS'])
+        ne.set_vml_num_threads(params['MAX_NUMEXPR_THREADS'])
 
     def __get_root_group(self, root_uep, title, filters):
         """Returns a Group instance which will act as the root group in the

--- a/tables/group.py
+++ b/tables/group.py
@@ -11,7 +11,6 @@
 """Here is defined the Group class."""
 
 import os
-import re
 import weakref
 import warnings
 

--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -10,7 +10,6 @@
 
 """Utilities to be used mainly by the Index class."""
 
-import sys
 import math
 import numpy as np
 

--- a/tables/index.py
+++ b/tables/index.py
@@ -14,7 +14,6 @@
 import math
 import operator
 import os
-import os.path
 import sys
 import tempfile
 import warnings

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -21,7 +21,6 @@ from .node import Node
 from .filters import Filters
 from .utils import byteorders, lazyattr, SizeType
 from .exceptions import PerformanceWarning
-from . import utilsextension
 
 
 def csformula(expected_mb):

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -14,9 +14,9 @@ Pass the flag -h to this for help on usage.
 
 """
 
-import sys
-import os.path
 import argparse
+import os
+import sys
 import warnings
 from time import perf_counter as clock
 from time import process_time as cpuclock

--- a/tables/table.py
+++ b/tables/table.py
@@ -12,7 +12,7 @@
 
 import math
 import operator
-import os.path
+import os
 import sys
 import warnings
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -10,13 +10,13 @@
 
 """Here is defined the Table class."""
 
+import functools
 import math
 import operator
 import os
 import sys
 import warnings
 
-from functools import reduce as _reduce
 from time import perf_counter as clock
 
 import numpy as np
@@ -1145,7 +1145,8 @@ very small/large chunksize, you may want to increase/decrease it."""
         """
 
         try:
-            return _reduce(getattr, colpathname.split('/'), self.description)
+            return functools.reduce(
+                getattr, colpathname.split('/'), self.description)
         except AttributeError:
             raise KeyError("table ``%s`` does not have a column named ``%s``"
                            % (self._v_pathname, colpathname))

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -21,8 +21,8 @@ from distutils.version import LooseVersion
 
 import unittest
 
+import numexpr as ne
 import numpy as np
-import numexpr
 
 import tables
 from tables.utils import detect_number_of_cores
@@ -87,14 +87,14 @@ def print_versions():
     print("HDF5 version:        %s" % tables.which_lib_version("hdf5")[1])
     print("NumPy version:       %s" % np.__version__)
     tinfo = tables.which_lib_version("zlib")
-    if numexpr.use_vml:
+    if ne.use_vml:
         # Get only the main version number and strip out all the rest
-        vml_version = numexpr.get_vml_version()
+        vml_version = ne.get_vml_version()
         vml_version = re.findall("[0-9.]+", vml_version)[0]
         vml_avail = "using VML/MKL %s" % vml_version
     else:
         vml_avail = "not using Intel's VML/MKL"
-    print(f"Numexpr version:     {numexpr.__version__} ({vml_avail})")
+    print(f"Numexpr version:     {ne.__version__} ({vml_avail})")
     if tinfo is not None:
         print("Zlib version:        {} ({})".format(tinfo[1],
                                                 "in Python interpreter"))

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -16,7 +16,6 @@ import sys
 import locale
 import platform
 import tempfile
-import warnings
 from time import perf_counter as clock
 from distutils.version import LooseVersion
 

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -9,7 +9,6 @@ from tables.req_versions import min_hdf5_version, min_numpy_version
 from tables.tests import common
 from tables.tests.common import unittest
 from tables.tests.common import print_heavy, print_versions
-from tables.tests.test_suite import suite, test
 
 
 def get_tuple_version(hexversion):

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import tempfile
-import warnings
 
 import numpy as np
 

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -1,7 +1,7 @@
 """This test unit checks node attributes that are persistent (AttributeSet)."""
 
-import sys
 import datetime
+import sys
 import warnings
 from distutils.version import LooseVersion
 

--- a/tables/tests/test_enum.py
+++ b/tables/tests/test_enum.py
@@ -10,8 +10,8 @@
 
 """Test module for enumerated types under PyTables."""
 
-import operator
 import itertools
+import operator
 
 import tables
 from tables.tests import common

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -12,7 +12,6 @@
 
 import re
 import sys
-import types
 import warnings
 import functools
 

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1,7 +1,7 @@
+import itertools
 import os
 import sys
 import tempfile
-from itertools import groupby
 import struct
 import platform
 
@@ -6186,10 +6186,10 @@ class ExhaustedIter(common.TempFileMixin, TestCase):
 
     def test00_groupby(self):
         """Checking iterating an exhausted iterator (ticket #264)"""
-        from itertools import groupby
         rows = self.h5file.root.observations.where('(market_id == 3)')
         scenario_means = []
-        for scenario_id, rows_grouped in groupby(rows, self.f_scenario):
+        for scenario_id, rows_grouped in itertools.groupby(rows,
+                                                           self.f_scenario):
             vals = [row['value'] for row in rows_grouped]
             scenario_means.append(self.average(vals))
         if common.verbose:
@@ -6203,7 +6203,8 @@ class ExhaustedIter(common.TempFileMixin, TestCase):
 
         rows = self.h5file.root.observations.where('(market_id == 3)')
         scenario_means = []
-        for scenario_id, rows_grouped in groupby(rows, self.f_scenario):
+        for scenario_id, rows_grouped in itertools.groupby(rows,
+                                                           self.f_scenario):
             vals = [row['value'] for row in rows_grouped]
             scenario_means.append(self.average(vals))
         if common.verbose:

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -15,7 +15,7 @@ from tables import (
 from tables.utils import SizeType, byteorders
 from tables.tests import common
 from tables.tests.common import allequal, areArraysEqual
-from tables.tests.common import unittest, hdf5_version, blosc_version
+from tables.tests.common import unittest, blosc_version
 from tables.tests.common import test_filename
 from tables.tests.common import PyTablesTestCase as TestCase
 from tables.description import descr_from_dtype


### PR DESCRIPTION
This is the follow-up of #864 consolidating all `import` statements across the repo.

First, all unused imports are deleted, then the Python2 `__future__` imports and then the rest to have the same names in the whole codebase.

When this is approved, I'd squash all commits within this PR to a single one.

There's one big chapter missing: `import tables as tb` (it's my proposal to use the `tb` alias). But that would be a bigger separate PR.