### PR TITLE
Make flake8 happier

### DIFF
--- a/tables/array.py
+++ b/tables/array.py
@@ -841,9 +841,8 @@ class Array(hdf5extension.Array, Leaf):
             bytes_required = self.rowsize * nrowstoread
             # if buffer is too small, it will segfault
             if bytes_required != out.nbytes:
-                raise ValueError(('output array size invalid, got {} bytes, '
-                                  'need {} bytes').format(out.nbytes,
-                                                           bytes_required))
+                raise ValueError(f'output array size invalid, got {out.nbytes}'
+                                 f' bytes, need {bytes_required} bytes')
             if not out.flags['C_CONTIGUOUS']:
                 raise ValueError('output array not C contiguous')
             arr = out

--- a/tables/array.py
+++ b/tables/array.py
@@ -198,7 +198,7 @@ class Array(hdf5extension.Array, Leaf):
             # `Leaf._g_post_init_hook()` should be setting the flavor on disk.
             self._flavor = flavor = flavor_of(self._obj)
             nparr = array_as_internal(self._obj, flavor)
-        except:  # XXX
+        except Exception:  # XXX
             # Problems converting data. Close the node and re-raise exception.
             self.close(flush=0)
             raise
@@ -221,7 +221,7 @@ class Array(hdf5extension.Array, Leaf):
             # on
             (self._v_objectid, self.shape, self.atom) = self._create_array(
                 nparr, self._v_new_title, self.atom)
-        except:  # XXX
+        except Exception:  # XXX
             # Problems creating the Array on disk. Close node and re-raise.
             self.close(flush=0)
             raise

--- a/tables/array.py
+++ b/tables/array.py
@@ -113,7 +113,8 @@ class Array(hdf5extension.Array, Leaf):
 
     @property
     def rowsize(self):
-        """The size of the rows in bytes in dimensions orthogonal to *maindim*."""
+        """The size of the rows in bytes in dimensions orthogonal to
+        *maindim*."""
         maindim = self.maindim
         rowsize = self.atom.size
         for i, dim in enumerate(self.shape):
@@ -426,17 +427,6 @@ class Array(hdf5extension.Array, Leaf):
         # Compute the shape for the container properly. Fixes #1288792
         shape = []
         for dim in range(len(self.shape)):
-            # The negative division operates differently with python scalars
-            # and numpy scalars (which are similar to C conventions). See:
-            # http://www.python.org/doc/faq/programming.html#why-does-22-10-return-3
-            # and
-            # http://www.peterbe.com/Integer-division-in-programming-languages
-            # for more info on this issue.
-            # I've finally decided to rely on the len(xrange) function.
-            # F. Alted 2006-09-25
-            # Switch to `lrange` to allow long ranges (see #99).
-            # use xrange, since it supports large integers as of Python 2.6
-            # see github #181
             new_dim = len(range(startl[dim], stopl[dim], stepl[dim]))
             if not (new_dim == 1 and stop_None[dim]):
                 shape.append(new_dim)

--- a/tables/array.py
+++ b/tables/array.py
@@ -920,14 +920,12 @@ class Array(hdf5extension.Array, Leaf):
     def __repr__(self):
         """This provides more metainfo in addition to standard __str__"""
 
-        return """{}
-  atom := {!r}
-  maindim := {!r}
-  flavor := {!r}
-  byteorder := {!r}
-  chunkshape := {!r}""".format(self, self.atom, self.maindim,
-                         self.flavor, self.byteorder,
-                         self.chunkshape)
+        return f"""{self}
+  atom := {self.atom!r}
+  maindim := {self.maindim!r}
+  flavor := {self.flavor!r}
+  byteorder := {self.byteorder!r}
+  chunkshape := {self.chunkshape!r}"""
 
 
 class ImageArray(Array):

--- a/tables/array.py
+++ b/tables/array.py
@@ -22,7 +22,6 @@ from .utils import (is_idx, convert_to_np_atom2, SizeType, lazyattr,
                     byteorders, quantize)
 
 
-
 # default version for ARRAY objects
 # obversion = "1.0"    # initial version
 # obversion = "2.0"    # Added an optional EXTDIM attribute

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -1071,7 +1071,7 @@ class _BufferedAtom(PseudoAtom):
     def toarray(self, object_):
         buffer_ = self._tobuffer(object_)
         array = np.ndarray(buffer=buffer_, dtype=self.base.dtype,
-                              shape=len(buffer_))
+                           shape=len(buffer_))
         return array
 
     def _tobuffer(self, object_):

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -932,7 +932,7 @@ class EnumAtom(Atom):
                             "concrete values in the enumeration")
 
         # ...with some implementation limitations.
-        if not npvalues.dtype.kind in ['i', 'u']:
+        if npvalues.dtype.kind not in ['i', 'u']:
             raise NotImplementedError("only integer concrete values "
                                       "are supported for the moment, sorry")
         if len(npvalues.shape) > 1:

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -505,7 +505,6 @@ class Atom(metaclass=MetaAtom):
         .. versionadded:: 2.4"""
         return len(self.shape)
 
-
     def __init__(self, nptype, shape, dflt):
         if not hasattr(self, 'type'):
             raise NotImplementedError("``%s`` is an abstract class; "
@@ -935,7 +934,6 @@ class EnumAtom(Atom):
         if len(npvalues.shape) > 1:
             raise NotImplementedError("only scalar concrete values "
                                       "are supported for the moment, sorry")
-
 
     def _get_init_args(self):
         """Get a dictionary of instance constructor arguments."""

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -366,8 +366,8 @@ class Atom(metaclass=MetaAtom):
         warning is issued.
 
             >>> Atom.from_dtype(np.dtype('U20')) # doctest: +SKIP
-            Atom.py:392: FlavorWarning: support for unicode type is very limited,
-                and only works for strings that can be cast as ascii
+            Atom.py:392: FlavorWarning: support for unicode type is very
+                limited, and only works for strings that can be cast as ascii
             StringAtom(itemsize=20, shape=(), dflt=b'')
 
         """
@@ -383,10 +383,12 @@ class Atom(metaclass=MetaAtom):
             return cls.from_kind('string', itemsize, dtype.shape, dflt)
         elif basedtype.kind == 'U':
             # workaround for unicode type (standard string type in Python 3)
-            warnings.warn("support for unicode type is very limited, "
-                          "and only works for strings that can be cast as ascii", FlavorWarning)
+            warnings.warn("support for unicode type is very limited, and "
+                          "only works for strings that can be cast as ascii",
+                          FlavorWarning)
             itemsize = basedtype.itemsize // 4
-            assert str(itemsize) in basedtype.str, "something went wrong in handling unicode."
+            assert str(itemsize) in basedtype.str, (
+                "something went wrong in handling unicode.")
             return cls.from_kind('string', itemsize, dtype.shape, dflt)
         # Most NumPy types have direct correspondence with PyTables types.
         return cls.from_type(basedtype.name, dtype.shape, dflt)

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -590,7 +590,7 @@ class Atom(metaclass=MetaAtom):
         signature = inspect.signature(self.__init__)
         parameters = signature.parameters
         args = [arg for arg, p in parameters.items()
-            if p.kind is p.POSITIONAL_OR_KEYWORD]
+                if p.kind is p.POSITIONAL_OR_KEYWORD]
 
         return {arg: getattr(self, arg) for arg in args if arg != 'self'}
 

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -506,8 +506,6 @@ class Atom(metaclass=MetaAtom):
         return len(self.shape)
 
 
-    # Special methods
-    # ~~~~~~~~~~~~~~~
     def __init__(self, nptype, shape, dflt):
         if not hasattr(self, 'type'):
             raise NotImplementedError("``%s`` is an abstract class; "

--- a/tables/atom.py
+++ b/tables/atom.py
@@ -751,6 +751,8 @@ class _ComplexErrorAtom(ComplexAtom, metaclass=type):
             "please use ``ComplexAtom(itemsize=N)``, "
             "where N=8 for single precision complex atoms, "
             "and N=16 for double precision complex atoms")
+
+
 Complex32Atom = Complex64Atom = Complex128Atom = _ComplexErrorAtom
 if hasattr(np, 'complex192'):
     Complex192Atom = _ComplexErrorAtom

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -289,9 +289,9 @@ class AttributeSet(hdf5extension.AttributeSet):
         """Get the attribute named "name"."""
 
         # If attribute does not exist, raise AttributeError
-        if not name in self._v_attrnames:
-            raise AttributeError("Attribute '%s' does not exist in node: "
-                                 "'%s'" % (name, self._v__nodepath))
+        if name not in self._v_attrnames:
+            raise AttributeError(f"Attribute {name!r} does not exist "
+                                 f"in node: {self._v__nodepath!r}")
 
         # Read the attribute from disk. This is an optimization to read
         # quickly system attributes that are _string_ values, but it
@@ -435,7 +435,7 @@ class AttributeSet(hdf5extension.AttributeSet):
 
         # Finally, add this attribute to the list if not present
         attrnames = self._v_attrnames
-        if not name in attrnames:
+        if name not in attrnames:
             attrnames.append(name)
             attrnames.sort()
             if issysattrname(name):

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -25,7 +25,6 @@ from .undoredo import attr_to_shadow
 from .filters import Filters
 
 
-
 # System attributes
 SYS_ATTRS = ["CLASS", "VERSION", "TITLE", "NROWS", "EXTDIM",
              "ENCODING", "PYTABLES_FORMAT_VERSION",
@@ -259,7 +258,6 @@ class AttributeSet(hdf5extension.AttributeSet):
         # hdf5extension operations:
         self._g_new(node)
 
-
     def _f_list(self, attrset='user'):
         """Get a list of attribute names.
 
@@ -488,14 +486,12 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
     def _g_log_add(self, name):
         self._v__nodefile._log('ADDATTR', self._v__nodepath, name)
 
-
     def _g_del_and_log(self, name):
         nodefile = self._v__nodefile
         node_pathname = self._v__nodepath
         # Log *before* moving to use the right shadow name.
         nodefile._log('DELATTR', node_pathname, name)
         attr_to_shadow(nodefile, node_pathname, name)
-
 
     def _g__delattr(self, name):
         """Delete a PyTables attribute.
@@ -689,7 +685,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
 class NotLoggedAttributeSet(AttributeSet):
     def _g_log_add(self, name):
         pass
-
 
     def _g_del_and_log(self, name):
         self._g__delattr(name)

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -142,7 +142,8 @@ class AttributeSet(hdf5extension.AttributeSet):
 
     Note that this class overrides the __getattr__(), __setattr__(),
     __delattr__() and __dir__() special methods.  This allows you to
-    read, assign or delete attributes on disk by just using the next constructs::
+    read, assign or delete attributes on disk by just using the next
+    constructs::
 
         leaf.attrs.myattr = 'str attr'    # set a string (native support)
         leaf.attrs.myattr2 = 3            # set an integer (native support)
@@ -319,7 +320,10 @@ class AttributeSet(hdf5extension.AttributeSet):
                 retval = np.array(retval)
             except ImportError:
                 retval = None  # signal error avoiding exception
-        elif maybe_pickled and name == 'FILTERS' and format_version is not None and format_version < (2, 0):
+        elif (maybe_pickled and
+              name == 'FILTERS' and
+              format_version is not None and
+              format_version < (2, 0)):
             # This is a big hack, but we don't have other way to recognize
             # pickled filters of PyTables 1.x files.
             value = _old_filters_re.sub(_new_filters_sub, value, 1)
@@ -361,7 +365,9 @@ class AttributeSet(hdf5extension.AttributeSet):
             # Additional check for allowing a workaround for #307
             if isinstance(retval, str) and retval == '':
                 retval = np.array(retval)[()]
-        elif name == 'FILTERS' and format_version is not None and format_version >= (2, 0):
+        elif (name == 'FILTERS' and
+              format_version is not None and
+              format_version >= (2, 0)):
             try:
                 retval = Filters._unpack(value)
             except ValueError:
@@ -403,7 +409,9 @@ class AttributeSet(hdf5extension.AttributeSet):
             elif name == "NROWS":
                 stvalue = np.array(value, dtype=SizeType)
                 value = stvalue[()]
-            elif name == "FILTERS" and self._v__format_version is not None and self._v__format_version >= (2, 0):
+            elif (name == "FILTERS" and
+                  self._v__format_version is not None and
+                  self._v__format_version >= (2, 0)):
                 stvalue = value._pack()
                 # value will remain as a Filters instance here
         # Convert value from a Python scalar into a NumPy scalar

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -693,11 +693,3 @@ class NotLoggedAttributeSet(AttributeSet):
 
     def _g_del_and_log(self, name):
         self._g__delattr(name)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -347,11 +347,11 @@ class AttributeSet(hdf5extension.AttributeSet):
                 except TypeError:
                     try:
                         retval = pickle.loads(value, encoding='bytes')
-                    except:
+                    except Exception:
                         retval = value
-                except:
+                except Exception:
                     retval = value
-            except:
+            except Exception:
                 # catch other unpickling errors:
                 # ivb (2005-09-07): It is too hard to tell
                 # whether the unpickling failed

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -287,4 +287,3 @@ class CArray(Array):
         nbytes = np.prod(self.shape, dtype=SizeType) * self.atom.size
 
         return (object, nbytes)
-

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -205,9 +205,8 @@ class CArray(Array):
                         "`chunkshape` parameter must be a sequence "
                         "and you passed a %s" % type(chunkshape))
                 if len(shape) != len(chunkshape):
-                    raise ValueError("the shape (%s) and chunkshape (%s) "
-                                     "ranks must be equal." %
-                                    (shape, chunkshape))
+                    raise ValueError(f"the shape ({shape}) and chunkshape "
+                                     f"({chunkshape}) ranks must be equal.")
                 elif min(chunkshape) < 1:
                     raise ValueError("chunkshape parameter cannot have "
                                      "zero-dimensions.")

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -131,7 +131,6 @@ class CArray(Array):
     # Class identifier.
     _c_classid = 'CARRAY'
 
-
     def __init__(self, parentnode, name,
                  atom=None, shape=None,
                  title="", filters=None,

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -132,10 +132,6 @@ class CArray(Array):
     _c_classid = 'CARRAY'
 
 
-    # Properties
-    # ~~~~~~~~~~
-    # Special methods
-    # ~~~~~~~~~~~~~~~
     def __init__(self, parentnode, name,
                  atom=None, shape=None,
                  title="", filters=None,

--- a/tables/carray.py
+++ b/tables/carray.py
@@ -240,7 +240,7 @@ class CArray(Array):
             # needed for setting attributes in some descendants later
             # on
             self._v_objectid = self._create_carray(self._v_new_title)
-        except:  # XXX
+        except Exception:  # XXX
             # Problems creating the Array on disk. Close node and re-raise.
             self.close(flush=0)
             raise

--- a/tables/description.py
+++ b/tables/description.py
@@ -262,6 +262,7 @@ def _generate_col_classes():
         newclass = Col._subclass_from_prefix(cprefix)
         yield newclass
 
+
 # Create all column classes.
 # for _newclass in _generate_col_classes():
 #     exec('%s = _newclass' % _newclass.__name__)

--- a/tables/description.py
+++ b/tables/description.py
@@ -993,10 +993,3 @@ if __name__ == "__main__":
         pass
 
     assert 'c' in testDesc.columns
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/description.py
+++ b/tables/description.py
@@ -264,9 +264,9 @@ def _generate_col_classes():
         yield newclass
 
 # Create all column classes.
-#for _newclass in _generate_col_classes():
-#    exec('%s = _newclass' % _newclass.__name__)
-#del _newclass
+# for _newclass in _generate_col_classes():
+#     exec('%s = _newclass' % _newclass.__name__)
+# del _newclass
 
 StringCol = Col._subclass_from_prefix('String')
 BoolCol = Col._subclass_from_prefix('Bool')

--- a/tables/description.py
+++ b/tables/description.py
@@ -615,7 +615,7 @@ class Description:
                 'offsets': cols_offsets}
             itemsize = newdict.get('_v_itemsize', None)
             if itemsize is not None:
-              dtype_fields['itemsize'] = itemsize
+                dtype_fields['itemsize'] = itemsize
             dtype = np.dtype(dtype_fields)
         else:
             dtype = np.dtype(nestedDType)

--- a/tables/description.py
+++ b/tables/description.py
@@ -21,7 +21,6 @@ from . import atom
 from .path import check_name_validity
 
 
-
 # Public variables
 # ================
 __docformat__ = 'reStructuredText'
@@ -444,7 +443,6 @@ class Description:
            and attribute copies.
     """
 
-
     def __init__(self, classdict, nestedlvl=-1, validate=True, ptparams=None):
 
         if not classdict:
@@ -623,7 +621,6 @@ class Description:
         newdict['_v_itemsize'] = dtype.itemsize
         newdict['_v_offsets'] = [dtype.fields[name][1] for name in dtype.names]
 
-
     def _g_set_nested_names_descr(self):
         """Computes the nested names and descriptions for nested datatypes."""
 
@@ -640,7 +637,6 @@ class Description:
                 self._v_nested_descr[i] = (name, new_object._v_nested_descr)
                 # set the _v_is_nested flag
                 self._v_is_nested = True
-
 
     def _g_set_path_names(self):
         """Compute the pathnames for arbitrary nested descriptions.
@@ -718,7 +714,6 @@ class Description:
                     parentCols.extend(colPaths)
                 # (Nothing is pushed, we are done with this description.)
 
-
     def _f_walk(self, type='All'):
         """Iterate over nested columns.
 
@@ -781,7 +776,6 @@ class MetaIsDescription(type):
 
         # Return a new class with the "columns" attribute filled
         return type.__new__(mcs, classname, bases, newdict)
-
 
 
 class IsDescription(metaclass=MetaIsDescription):

--- a/tables/description.py
+++ b/tables/description.py
@@ -430,9 +430,9 @@ class Description:
 
     .. attribute:: _v_offsets
 
-        A list of offsets for all the columns.  If the list is empty, means that
-        there are no padding in the data structure.  However, the support for
-        offsets is currently limited to flat tables; for nested tables, the
+        A list of offsets for all the columns.  If the list is empty, means
+        that there are no padding in the data structure.  However, the support
+        for offsets is currently limited to flat tables; for nested tables, the
         potential padding is always removed (exactly the same as in pre-3.5
         versions), and this variable is set to empty.
 
@@ -502,7 +502,8 @@ class Description:
             # provided by the user will remain unchanged even if we
             # tamper with the values of ``_v_pos`` here.
             if columns is not None:
-                descr = Description(copy.copy(columns), self._v_nestedlvl, ptparams=ptparams)
+                descr = Description(copy.copy(columns), self._v_nestedlvl,
+                                    ptparams=ptparams)
             classdict[name] = descr
 
             pos = getattr(descr, '_v_pos', None)
@@ -573,19 +574,24 @@ class Description:
         #     traceback.print_stack()
 
         # Check whether we are gonna use padding or not.  Two possibilities:
-        #   1) Make padding True by default (except if ALLOW_PADDING is set to False)
-        #   2) Make padding False by default (except if ALLOW_PADDING is set to True)
-        # Currently we choose 1) because it favours honoring padding even on unhandled situations (should be very few).
-        # However, for development, option 2) is recommended as it catches most of the unhandled situations.
-        allow_padding = False if ptparams is not None and not ptparams['ALLOW_PADDING'] else True
-        # allow_padding = True if ptparams is not None and ptparams['ALLOW_PADDING'] else False
+        #   1) Make padding True by default (except if ALLOW_PADDING is set
+        #      to False)
+        #   2) Make padding False by default (except if ALLOW_PADDING is set
+        #       to True)
+        # Currently we choose 1) because it favours honoring padding even on
+        # unhandled situations (should be very few).
+        # However, for development, option 2) is recommended as it catches
+        # most of the unhandled situations.
+        allow_padding = ptparams is None or ptparams['ALLOW_PADDING']
+        # allow_padding = ptparams is not None and ptparams['ALLOW_PADDING']
         if (allow_padding and
                 len(cols_offsets) > 1 and
                 len(keys) == len(cols_with_pos) and
                 len(keys) == len(cols_offsets) and
                 not nested):  # TODO: support offsets with nested types
-            # We have to sort the offsets too, as they must follow the column order.
-            # As the offsets and the pos should be place in the same order, a single sort is enough here.
+            # We have to sort the offsets too, as they must follow the column
+            # order. As the offsets and the pos should be place in the same
+            # order, a single sort is enough here.
             cols_offsets.sort()
             valid_offsets = True
         else:

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -255,11 +255,3 @@ class EArray(CArray):
         nbytes = np.prod(self.shape, dtype=SizeType) * self.atom.itemsize
 
         return (object, nbytes)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -138,8 +138,6 @@ class EArray(CArray):
     _c_classid = 'EARRAY'
 
 
-    # Special methods
-    # ~~~~~~~~~~~~~~~
     def __init__(self, parentnode, name,
                  atom=None, shape=None, title="",
                  filters=None, expectedrows=None,

--- a/tables/earray.py
+++ b/tables/earray.py
@@ -137,7 +137,6 @@ class EArray(CArray):
     # Class identifier.
     _c_classid = 'EARRAY'
 
-
     def __init__(self, parentnode, name,
                  atom=None, shape=None, title="",
                  filters=None, expectedrows=None,
@@ -191,7 +190,6 @@ class EArray(CArray):
                 raise ValueError(("the shapes of the appended object and the "
                                   "``%s`` EArray differ in non-enlargeable "
                                   "dimension %d") % (self._v_pathname, i))
-
 
     def append(self, sequence):
         """Add a sequence of data to the end of the dataset.

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -10,13 +10,13 @@
 
 """Declare exceptions and warnings that are specific to PyTables."""
 
-__docformat__ = 'reStructuredText'
-"""The format of documentation strings in this module."""
-
-
 import os
 import warnings
 import traceback
+
+
+__docformat__ = 'reStructuredText'
+"""The format of documentation strings in this module."""
 
 
 class HDF5ExtError(RuntimeError):

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -374,12 +374,3 @@ class ExperimentalFeatureWarning(Warning):
 
     """
     pass
-
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/expression.py
+++ b/tables/expression.py
@@ -709,11 +709,3 @@ if __name__ == "__main__":
     # print(`d[:]`)
 
     f.close()
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/file.py
+++ b/tables/file.py
@@ -58,8 +58,6 @@ from .atom import Atom
 from .link import SoftLink, ExternalLink
 
 
-
-
 # format_version = "1.0"  # Initial format
 # format_version = "1.1"  # Changes in ucl compression
 # format_version = "1.2"  # Support for enlargeable arrays and VLA's
@@ -204,7 +202,6 @@ def copy_file(srcfilename, dstfilename, overwrite=False, **kwargs):
     finally:
         # Close the source file.
         srcfileh.close()
-
 
 
 if tuple(map(int, utilsextension.get_hdf5_version().split('-')[0].split('.'))) \
@@ -861,7 +858,6 @@ class File(hdf5extension.File):
         # create the object tree
         return RootGroup(self, root_uep, title=title, new=new, filters=filters)
 
-
     def _get_or_create_path(self, path, create):
         """Get the given `path` or create it if `create` is true.
 
@@ -874,7 +870,6 @@ class File(hdf5extension.File):
             return self._create_path(path)
         else:
             return self.get_node(path)
-
 
     def _create_path(self, path):
         """Create the groups needed for the `path` to exist.
@@ -897,7 +892,6 @@ class File(hdf5extension.File):
                 child = create_group(parent, pcomp)
             parent = child
         return parent
-
 
     def create_group(self, where, name, title="", filters=None,
                      createparents=False):
@@ -935,7 +929,6 @@ class File(hdf5extension.File):
         _checkfilters(filters)
         return Group(parentnode, name,
                      title=title, new=True, filters=filters)
-
 
     def create_table(self, where, name, description=None, title="",
                      filters=None, expectedrows=10_000,
@@ -1058,7 +1051,6 @@ class File(hdf5extension.File):
 
         return ptobj
 
-
     def create_array(self, where, name, obj=None, title="",
                      byteorder=None, createparents=False,
                      atom=None, shape=None, track_times=True):
@@ -1154,7 +1146,6 @@ class File(hdf5extension.File):
         return Array(parentnode, name,
                      obj=obj, title=title, byteorder=byteorder,
                      track_times=track_times)
-
 
     def create_carray(self, where, name, atom=None, shape=None, title="",
                       filters=None, chunkshape=None,
@@ -1266,7 +1257,6 @@ class File(hdf5extension.File):
             ptobj[...] = obj
 
         return ptobj
-
 
     def create_earray(self, where, name, atom=None, shape=None, title="",
                       filters=None, expectedrows=1000,
@@ -1385,7 +1375,6 @@ class File(hdf5extension.File):
 
         return ptobj
 
-
     def create_vlarray(self, where, name, atom=None, title="",
                        filters=None, expectedrows=None,
                        chunkshape=None, byteorder=None,
@@ -1498,7 +1487,6 @@ class File(hdf5extension.File):
 
         return ptobj
 
-
     def create_hard_link(self, where, name, target, createparents=False):
         """Create a hard link.
 
@@ -1519,7 +1507,6 @@ class File(hdf5extension.File):
         parentnode._g_add_children_names()
         # Return the target node
         return self.get_node(parentnode, name)
-
 
     def create_soft_link(self, where, name, target, createparents=False):
         """Create a soft link (aka symbolic link) to a `target` node.
@@ -1549,7 +1536,6 @@ class File(hdf5extension.File):
         parentnode._g_add_children_names()
         return slink
 
-
     def create_external_link(self, where, name, target, createparents=False):
         """Create an external link.
 
@@ -1578,7 +1564,6 @@ class File(hdf5extension.File):
         parentnode._g_add_children_names()
         return elink
 
-
     def _get_node(self, nodepath):
         # The root node is always at hand.
         if nodepath == '/':
@@ -1588,7 +1573,6 @@ class File(hdf5extension.File):
         assert node is not None, "unable to instantiate node ``%s``" % nodepath
 
         return node
-
 
     def get_node(self, where, name=None, classname=None):
         """Get the node under where with the given name.
@@ -1657,7 +1641,6 @@ class File(hdf5extension.File):
 
         return node
 
-
     def is_visible_node(self, path):
         """Is the node under `path` visible?
 
@@ -1667,7 +1650,6 @@ class File(hdf5extension.File):
 
         # ``util.isvisiblepath()`` is still recommended for internal use.
         return self.get_node(path)._f_isvisible()
-
 
     def rename_node(self, where, newname, name=None, overwrite=False):
         """Change the name of the node specified by where and name to newname.
@@ -1687,7 +1669,6 @@ class File(hdf5extension.File):
 
         obj = self.get_node(where, name=name)
         obj._f_rename(newname, overwrite)
-
 
     def move_node(self, where, newparent=None, newname=None, name=None,
                   overwrite=False, createparents=False):
@@ -1717,7 +1698,6 @@ class File(hdf5extension.File):
 
         obj = self.get_node(where, name=name)
         obj._f_move(newparent, newname, overwrite, createparents)
-
 
     def copy_node(self, where, newparent=None, newname=None, name=None,
                   overwrite=False, recursive=False, createparents=False,
@@ -1781,7 +1761,6 @@ class File(hdf5extension.File):
         return obj._f_copy(newparent, newname,
                            overwrite, recursive, createparents, **kwargs)
 
-
     def remove_node(self, where, name=None, recursive=False):
         """Remove the object node *name* under *where* location.
 
@@ -1802,7 +1781,6 @@ class File(hdf5extension.File):
         obj = self.get_node(where, name=name)
         obj._f_remove(recursive)
 
-
     def get_node_attr(self, where, attrname, name=None):
         """Get a PyTables attribute from the given node.
 
@@ -1819,7 +1797,6 @@ class File(hdf5extension.File):
 
         obj = self.get_node(where, name=name)
         return obj._f_getattr(attrname)
-
 
     def set_node_attr(self, where, attrname, attrvalue, name=None):
         """Set a PyTables attribute for the given node.
@@ -1849,7 +1826,6 @@ class File(hdf5extension.File):
         obj = self.get_node(where, name=name)
         obj._f_setattr(attrname, attrvalue)
 
-
     def del_node_attr(self, where, attrname, name=None):
         """Delete a PyTables attribute from the given node.
 
@@ -1866,7 +1842,6 @@ class File(hdf5extension.File):
 
         obj = self.get_node(where, name=name)
         obj._f_delattr(attrname)
-
 
     def copy_node_attrs(self, where, dstnode, name=None):
         """Copy PyTables attributes from one node to another.
@@ -1885,7 +1860,6 @@ class File(hdf5extension.File):
         srcobject = self.get_node(where, name=name)
         dstobject = self.get_node(dstnode)
         srcobject._v_attrs._f_copy(dstobject)
-
 
     def copy_children(self, srcgroup, dstgroup,
                       overwrite=False, recursive=False,
@@ -1919,7 +1893,6 @@ class File(hdf5extension.File):
 
         srcgroup._f_copy_children(
             dstgroup, overwrite, recursive, createparents, **kwargs)
-
 
     def copy_file(self, dstfilename, overwrite=False, **kwargs):
         """Copy the contents of this file to dstfilename.
@@ -1995,7 +1968,6 @@ class File(hdf5extension.File):
         finally:
             dstfileh.close()
 
-
     def list_nodes(self, where, classname=None):
         """Return a *list* with children nodes hanging from where.
 
@@ -2007,7 +1979,6 @@ class File(hdf5extension.File):
         self._check_group(group)  # Is it a group?
 
         return group._f_list_nodes(classname)
-
 
     def iter_nodes(self, where, classname=None):
         """Iterate over children nodes hanging from where.
@@ -2033,7 +2004,6 @@ class File(hdf5extension.File):
         self._check_group(group)  # Is it a group?
 
         return group._f_iter_nodes(classname)
-
 
     def __contains__(self, path):
         """Is there a node with that path?
@@ -2115,7 +2085,6 @@ class File(hdf5extension.File):
             for group in self.walk_groups(where):
                 yield from self.iter_nodes(group, classname)
 
-
     def walk_groups(self, where="/"):
         """Recursively iterate over groups (not leaves) hanging from where.
 
@@ -2133,7 +2102,6 @@ class File(hdf5extension.File):
         self._check_group(group)  # Is it a group?
         return group._f_walk_groups()
 
-
     def _check_open(self):
         """Check the state of the file.
 
@@ -2144,12 +2112,10 @@ class File(hdf5extension.File):
         if not self.isopen:
             raise ClosedFileError("the file object is closed")
 
-
     def _iswritable(self):
         """Is this file writable?"""
 
         return self.mode in ('w', 'a', 'r+')
-
 
     def _check_writable(self):
         """Check whether the file is writable.
@@ -2161,12 +2127,10 @@ class File(hdf5extension.File):
         if not self._iswritable():
             raise FileModeError("the file is not writable")
 
-
     def _check_group(self, node):
         # `node` must already be a node.
         if not isinstance(node, Group):
             raise TypeError(f"node ``{node._v_pathname}`` is not a group")
-
 
     def is_undo_enabled(self):
         """Is the Undo/Redo mechanism enabled?
@@ -2181,11 +2145,9 @@ class File(hdf5extension.File):
         self._check_open()
         return self._undoEnabled
 
-
     def _check_undo_enabled(self):
         if not self._undoEnabled:
             raise UndoRedoError("Undo/Redo feature is currently disabled!")
-
 
     def _create_transaction_group(self):
         tgroup = TransactionGroupG(
@@ -2195,18 +2157,15 @@ class File(hdf5extension.File):
         tgroup._v_attrs._g__setattr('FORMATVERSION', _trans_version)
         return tgroup
 
-
     def _create_transaction(self, troot, tid):
         return TransactionG(
             troot, _trans_name % tid,
             "Transaction number %d" % tid, new=True)
 
-
     def _create_mark(self, trans, mid):
         return MarkG(
             trans, _markName % mid,
             "Mark number %d" % mid, new=True)
-
 
     def enable_undo(self, filters=Filters(complevel=1)):
         """Enable the Undo/Redo mechanism.
@@ -2303,7 +2262,6 @@ class File(hdf5extension.File):
         # The Undo/Redo mechanism has been enabled.
         self._undoEnabled = True
 
-
     def disable_undo(self):
         """Disable the Undo/Redo mechanism.
 
@@ -2338,7 +2296,6 @@ class File(hdf5extension.File):
 
         # The Undo/Redo mechanism has been disabled.
         self._undoEnabled = False
-
 
     def mark(self, name=None):
         """Mark the state of the database.
@@ -2458,7 +2415,6 @@ class File(hdf5extension.File):
         # print("markid, self._nmarks:", markid, self._nmarks)
         return markid
 
-
     def _get_final_action(self, markid):
         """Get the action to go.
 
@@ -2476,7 +2432,6 @@ class File(hdf5extension.File):
             return 0
 
         return self._seqmarkers[markid]
-
 
     def _doundo(self, finalaction, direction):
         """Undo/Redo actions up to final action in the specificed direction."""
@@ -2665,7 +2620,6 @@ class File(hdf5extension.File):
         self._check_undo_enabled()
         return self._curmark
 
-
     def _shadow_name(self):
         """Compute and return a shadow name.
 
@@ -2680,7 +2634,6 @@ class File(hdf5extension.File):
         name = _shadow_name % (self._curaction,)
 
         return (parent, name)
-
 
     def flush(self):
         """Flush all the alive leaves in the object tree."""
@@ -2836,7 +2789,6 @@ class File(hdf5extension.File):
                     newnodeppath = split_path(newnodepath)[0]
                     descendent_node = self._get_node(nodepath)
                     descendent_node._g_update_location(newnodeppath)
-
 
 
 # If a user hits ^C during a run, it is wise to gracefully close the

--- a/tables/file.py
+++ b/tables/file.py
@@ -313,7 +313,6 @@ def open_file(filename, mode="r", title="", root_uep="/", filters=None,
     return File(filename, mode, title, root_uep, filters, **kwargs)
 
 
-
 # A dumb class that doesn't keep nothing at all
 class _NoCache:
     def __len__(self):

--- a/tables/file.py
+++ b/tables/file.py
@@ -73,7 +73,7 @@ from .link import SoftLink, ExternalLink
 # format_version = "1.6"  # Support for NumPy objects and new flavors for
 #                         # objects.
 #                         # 1.6 was introduced in pytables 1.3
-#format_version = "2.0"   # Pickles are not used anymore in system attrs
+# format_version = "2.0"  # Pickles are not used anymore in system attrs
 #                         # 2.0 was introduced in PyTables 2.0
 format_version = "2.1"  # Numeric and numarray flavors are gone.
 
@@ -92,7 +92,7 @@ class _FileRegistry:
 
     @property
     def handlers(self):
-        #return set(self._handlers)  # return a copy
+        # return set(self._handlers)  # return a copy
         return self._handlers
 
     def __len__(self):
@@ -114,7 +114,7 @@ class _FileRegistry:
         self._handlers.remove(handler)
 
     def get_handlers_by_name(self, filename):
-        #return set(self._name_mapping[filename])  # return a copy
+        # return set(self._name_mapping[filename])  # return a copy
         return self._name_mapping[filename]
 
     def close_all(self):
@@ -511,14 +511,14 @@ class NodeManager:
                         node._f_close()
                     del node
                 except ClosedNodeError:
-                    #import traceback
-                    #type_, value, tb = sys.exc_info()
-                    #exception_dump = ''.join(
-                    #    traceback.format_exception(type_, value, tb))
-                    #warnings.warn(
-                    #    "A '%s' exception occurred trying to close a node "
-                    #    "that was supposed to be open.\n"
-                    #    "%s" % (type_.__name__, exception_dump))
+                    # import traceback
+                    # type_, value, tb = sys.exc_info()
+                    # exception_dump = ''.join(
+                    #     traceback.format_exception(type_, value, tb))
+                    # warnings.warn(
+                    #     "A '%s' exception occurred trying to close a node "
+                    #     "that was supposed to be open.\n"
+                    #     "%s" % (type_.__name__, exception_dump))
                     pass
 
     def close_subtree(self, prefix='/'):
@@ -554,7 +554,7 @@ class NodeManager:
         registry = self.registry
         cache = self.cache
 
-        #self.close_subtree('/')
+        # self.close_subtree('/')
 
         keys = list(cache)  # copy
         for key in keys:

--- a/tables/file.py
+++ b/tables/file.py
@@ -32,13 +32,13 @@ from . import hdf5extension
 from . import utilsextension
 from . import parameters
 from .exceptions import (ClosedFileError, FileModeError, NodeError,
-                               NoSuchNodeError, UndoRedoError, ClosedNodeError,
-                               PerformanceWarning)
+                         NoSuchNodeError, UndoRedoError, ClosedNodeError,
+                         PerformanceWarning)
 from .registry import get_class_by_name
 from .path import join_path, split_path
 from . import undoredo
 from .description import (IsDescription, UInt8Col, StringCol,
-                                descr_from_dtype, dtype_from_descr)
+                          descr_from_dtype, dtype_from_descr)
 from .filters import Filters
 from .node import Node, NotLoggedMixin
 from .group import Group, RootGroup
@@ -752,7 +752,7 @@ class File(hdf5extension.File):
 
         # Get all the parameters in parameter file(s)
         params = {k: v for k, v in parameters.__dict__.items()
-                       if k.isupper() and not k.startswith('_')}
+                  if k.isupper() and not k.startswith('_')}
         # Update them with possible keyword arguments
         if [k for k in kwargs if k.isupper()]:
             warnings.warn("The use of uppercase keyword parameters is "

--- a/tables/file.py
+++ b/tables/file.py
@@ -18,6 +18,7 @@ nodes.
 
 """
 
+import atexit
 import datetime
 import sys
 import weakref
@@ -2793,5 +2794,4 @@ class File(hdf5extension.File):
 
 # If a user hits ^C during a run, it is wise to gracefully close the
 # opened files.
-import atexit
 atexit.register(_open_files.close_all)

--- a/tables/file.py
+++ b/tables/file.py
@@ -2169,7 +2169,6 @@ class File(hdf5extension.File):
             raise TypeError(f"node ``{node._v_pathname}`` is not a group")
 
 
-    # <Undo/Redo support>
     def is_undo_enabled(self):
         """Is the Undo/Redo mechanism enabled?
 
@@ -2683,8 +2682,6 @@ class File(hdf5extension.File):
 
         return (parent, name)
 
-
-    # </Undo/Redo support>
 
     def flush(self):
         """Flush all the alive leaves in the object tree."""

--- a/tables/file.py
+++ b/tables/file.py
@@ -2497,10 +2497,10 @@ class File(hdf5extension.File):
                 # undo/redo the action
                 if direction > 0:
                     # Uncomment this for debugging
-#                     print("redo-->", \
-#                           _code_to_op[actionlog['opcode'][i]],\
-#                           actionlog['arg1'][i],\
-#                           actionlog['arg2'][i])
+                    # print("redo-->", \
+                    #       _code_to_op[actionlog['opcode'][i]],\
+                    #       actionlog['arg1'][i],\
+                    #       actionlog['arg2'][i])
                     undoredo.redo(self,
                                   # _code_to_op[actionlog['opcode'][i]],
                                   # The next is a workaround for python < 2.5

--- a/tables/file.py
+++ b/tables/file.py
@@ -78,7 +78,7 @@ from .link import SoftLink, ExternalLink
 format_version = "2.1"  # Numeric and numarray flavors are gone.
 
 compatible_formats = []  # Old format versions we can read
-                         # Empty means that we support all the old formats
+#                        # Empty means that we support all the old formats
 
 
 class _FileRegistry:

--- a/tables/file.py
+++ b/tables/file.py
@@ -2744,7 +2744,7 @@ class File(hdf5extension.File):
             date = "<in-memory file>"
         lines = [f'{self.filename} (File) {self.title!r}',
                  f'Last modif.: {date!r}',
-                 f'Object Tree: ']
+                 'Object Tree: ']
 
         for group in self.walk_groups("/"):
             lines.append(f'{group}')

--- a/tables/file.py
+++ b/tables/file.py
@@ -2847,11 +2847,3 @@ class File(hdf5extension.File):
 # opened files.
 import atexit
 atexit.register(_open_files.close_all)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/file.py
+++ b/tables/file.py
@@ -205,11 +205,9 @@ def copy_file(srcfilename, dstfilename, overwrite=False, **kwargs):
         srcfileh.close()
 
 
-if tuple(map(int, utilsextension.get_hdf5_version().split('-')[0].split('.'))) \
-                                                                        < (1, 8, 7):
-    _FILE_OPEN_POLICY = 'strict'
-else:
-    _FILE_OPEN_POLICY = 'default'
+hdf5_version_str = utilsextension.get_hdf5_version()
+hdf5_version_tup = tuple(map(int, hdf5_version_str.split('-')[0].split('.')))
+_FILE_OPEN_POLICY = 'strict' if hdf5_version_tup < (1, 8, 7) else 'default'
 
 
 def open_file(filename, mode="r", title="", root_uep="/", filters=None,
@@ -709,7 +707,8 @@ class File(hdf5extension.File):
 
     @property
     def filters(self):
-        """Default filter properties for the root group (see :ref:`FiltersClassDescr`)."""
+        """Default filter properties for the root group
+        (see :ref:`FiltersClassDescr`)."""
         return self.root._v_filters
 
     @filters.setter
@@ -1030,7 +1029,8 @@ class File(hdf5extension.File):
 
             descr, _ = descr_from_dtype(obj.dtype, ptparams=self.params)
             if (description is not None and
-                    dtype_from_descr(description, ptparams=self.params) != obj.dtype):
+                    dtype_from_descr(description,
+                                     ptparams=self.params) != obj.dtype):
                 raise TypeError('the desctiption parameter is not consistent '
                                 'with the data type of the obj parameter')
             elif description is None:

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -367,10 +367,10 @@ class Filters:
 
         if (self.bitshuffle and
                 blosc_version < tb.req_versions.min_blosc_bitshuffle_version):
-            raise ValueError(
-                "This Blosc library does not have support for the bitshuffle "
-                "filter.  Please update to Blosc >= %s" % \
-                tb.req_versions)
+            raise ValueError(f"This Blosc library does not have support for "
+                             f"the bitshuffle filter.  Please update to "
+                             f"Blosc >= "
+                             f"{tb.req_versions.min_blosc_bitshuffle_version}")
 
         self.fletcher32 = fletcher32
         """Whether the *Fletcher32* filter is active or not."""

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -356,10 +356,10 @@ class Filters:
         self.bitshuffle = bitshuffle
         """Whether the *BitShuffle* filter is active or not."""
 
-        if (self.complib and self.bitshuffle and
-            not self.complib.startswith('blosc')):
-            raise ValueError(
-                "BitShuffle can only be used inside Blosc")
+        if (self.complib and
+                self.bitshuffle and
+                not self.complib.startswith('blosc')):
+            raise ValueError("BitShuffle can only be used inside Blosc")
 
         if self.shuffle and self.bitshuffle:
             # BitShuffle has priority in case both are specified

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -280,7 +280,7 @@ class Filters:
 
         # Byte 3: least significant digit.
         if self.least_significant_digit is not None:
-            #assert isinstance(self.least_significant_digit, numpy.int8)
+            # assert isinstance(self.least_significant_digit, numpy.int8)
             packed |= self.least_significant_digit
         packed <<= 8
 

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -345,6 +345,7 @@ _python_desc = ("homogeneous list or tuple, "
 def _is_python(array):
     return isinstance(array, (tuple, list, int, float, complex, bytes))
 
+
 _numpy_aliases = []
 _numpy_desc = "NumPy array, record or scalar"
 
@@ -423,6 +424,7 @@ def _conv_numpy_to_python(array):
         # 0-dim or scalar case
         array = array.item()
     return array
+
 
 # Now register everything related with *available* flavors.
 _register_all()

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -349,7 +349,6 @@ _numpy_aliases = []
 _numpy_desc = "NumPy array, record or scalar"
 
 
-
 if np.lib.NumpyVersion(np.__version__) >= np.lib.NumpyVersion('1.19.0'):
     def toarray(array, *args, **kwargs):
         with warnings.catch_warnings():

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -400,7 +400,9 @@ def _conv_numpy_to_numpy(array):
             # try to convert to basic 'S' type
             return nparr.astype('S')
         except UnicodeEncodeError:
-            pass  # pass on true Unicode arrays downstream in case it can be handled in the future
+            pass
+            # pass on true Unicode arrays downstream in case it can be
+            # handled in the future
     return nparr
 
 
@@ -413,7 +415,9 @@ def _conv_python_to_numpy(array):
             # try to convert to basic 'S' type
             return nparr.astype('S')
         except UnicodeEncodeError:
-            pass  # pass on true Unicode arrays downstream in case it can be handled in the future
+            pass
+            # pass on true Unicode arrays downstream in case it can be
+            # handled in the future
     return nparr
 
 

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -48,6 +48,8 @@ Variables
 # =======
 import warnings
 
+import numpy as np
+
 from .exceptions import FlavorError, FlavorWarning
 
 
@@ -229,7 +231,6 @@ def restrict_flavors(keep=('python',)):
 # The order in which flavors appear in `all_flavors` determines the
 # order in which they will be tested for by `flavor_of()`, so place
 # most frequent flavors first.
-import numpy as np
 all_flavors.append('numpy')  # this is the internal flavor
 
 all_flavors.append('python')  # this is always supported

--- a/tables/flavor.py
+++ b/tables/flavor.py
@@ -379,8 +379,8 @@ def _numpy_contiguous(convfunc):
     def conv_to_numpy(array):
         nparr = convfunc(array)
         if (hasattr(nparr, 'flags') and
-            not nparr.flags.contiguous and
-            sum(nparr.strides) != 0):
+                not nparr.flags.contiguous and
+                sum(nparr.strides) != 0):
             nparr = nparr.copy()  # copying the array makes it contiguous
         return nparr
     conv_to_numpy.__name__ = convfunc.__name__

--- a/tables/group.py
+++ b/tables/group.py
@@ -1099,7 +1099,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         return f'{self!s}\n  children := [{", ".join(rep)}]'
 
 
-
 # Special definition for group root
 class RootGroup(Group):
 

--- a/tables/group.py
+++ b/tables/group.py
@@ -641,7 +641,7 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         # Recursive version of children copy.
         # for srcchild in self._v_children.itervalues():
-        ##    srcchild._g_copy_as_child(newparent, **kwargs)
+        #     srcchild._g_copy_as_child(newparent, **kwargs)
 
         # Non-recursive version of children copy.
         use_hardlinks = kwargs.get('use_hardlinks', False)
@@ -1265,11 +1265,3 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         for attrname in attrs._v_attrnamesuser[:]:
             if shname.match(attrname):
                 attrs._g__delattr(attrname)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/group.py
+++ b/tables/group.py
@@ -18,7 +18,8 @@ from .misc.proxydict import ProxyDict
 from . import hdf5extension
 from . import utilsextension
 from .registry import class_id_dict
-from .exceptions import NodeError, NoSuchNodeError, NaturalNameWarning, PerformanceWarning
+from .exceptions import (NodeError, NoSuchNodeError, NaturalNameWarning,
+                         PerformanceWarning)
 from .filters import Filters
 from .registry import get_class_by_name
 from .path import check_name_validity, join_path, isvisiblename

--- a/tables/group.py
+++ b/tables/group.py
@@ -155,7 +155,6 @@ class Group(hdf5extension.Group, Node):
     # Class identifier.
     _c_classid = 'GROUP'
 
-
     # Children containers that should be loaded only in a lazy way.
     # These are documented in the ``Group._g_add_children_names`` method.
     _c_lazy_children_attrs = (
@@ -196,7 +195,6 @@ class Group(hdf5extension.Group, Node):
         instance (see :ref:`FiltersClassDescr`). When the group has no such
         attribute, a default Filters instance is used.
         """)
-
 
     def __init__(self, parentnode, name,
                  title="", new=False, filters=None,
@@ -260,7 +258,6 @@ class Group(hdf5extension.Group, Node):
             # We don't need to get more attributes from disk,
             # since the most important ones are defined as properties.
 
-
     def __del__(self):
         if (self._v_isopen and
             self._v_pathname in self._v_file._node_manager.registry and
@@ -293,7 +290,6 @@ class Group(hdf5extension.Group, Node):
             return class_id_dict[childCID]  # look up group class
         else:
             return Group  # default group class
-
 
     def _g_get_child_leaf_class(self, childname, warn=True):
         """Get the class of a not-yet-loaded leaf child.
@@ -332,7 +328,6 @@ class Group(hdf5extension.Group, Node):
                 return UnImplemented
             assert childCID2 in class_id_dict
             return class_id_dict[childCID2]  # look up leaf class
-
 
     def _g_add_children_names(self):
         """Add children names to this group taking into account their
@@ -380,7 +375,6 @@ class Group(hdf5extension.Group, Node):
                     # Hidden node.
                     hidden[childname] = None
 
-
     def _g_check_has_child(self, name):
         """Check whether 'name' is a children of 'self' and return its type."""
 
@@ -391,7 +385,6 @@ class Group(hdf5extension.Group, Node):
                 "group ``%s`` does not have a child named ``%s``"
                 % (self._v_pathname, name))
         return node_type
-
 
     def __iter__(self):
         """Iterate over the child nodes hanging directly from the group.
@@ -474,7 +467,6 @@ class Group(hdf5extension.Group, Node):
             for group in self._f_walk_groups():
                 yield from group._f_iter_nodes(classname)
 
-
     def _g_join(self, name):
         """Helper method to correctly concatenate a name child object with the
         pathname of this group."""
@@ -492,7 +484,6 @@ group ``%s`` is exceeding the recommended maximum number of children (%d); \
 be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
                       % (self._v_pathname, self._v_max_group_width),
                       PerformanceWarning)
-
 
     def _g_refnode(self, childnode, childname, validate=True):
         """Insert references to a `childnode` via a `childname`.
@@ -552,7 +543,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             # Hidden node.
             self._v_hidden[childname] = None  # insert node
 
-
     def _g_unrefnode(self, childname):
         """Remove references to a node.
 
@@ -581,7 +571,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             else:
                 # Hidden node.
                 del self._v_hidden[childname]  # remove node
-
 
     def _g_move(self, newparent, newname):
         # Move the node to the new location.
@@ -685,7 +674,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
                     if isinstance(srcchild, Group):
                         parentstack.append((srcchild, dstchild))
 
-
     def _f_get_child(self, childname):
         """Get the child called childname of this group.
 
@@ -705,7 +693,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         childpath = join_path(self._v_pathname, childname)
         return self._v_file._get_node(childpath)
 
-
     def _f_list_nodes(self, classname=None):
         """Return a *list* with children nodes.
 
@@ -714,7 +701,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
         """
 
         return list(self._f_iter_nodes(classname))
-
 
     def _f_iter_nodes(self, classname=None):
         """Iterate over children nodes.
@@ -755,7 +741,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
                 if isinstance(childnode, class_):
                     yield childnode
 
-
     def _f_walk_groups(self):
         """Recursively iterate over descendent groups (not leaves).
 
@@ -778,7 +763,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             for groupname in groupnames:
                 stack.append(objgroup._v_groups[groupname])
                 yield objgroup._v_groups[groupname]
-
 
     def __delattr__(self, name):
         """Delete a Python attribute called name.
@@ -881,7 +865,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
         node_manager = self._v_file._node_manager
         node_manager.close_subtree(self._v_pathname)
-
 
     def _g_close(self):
         """Close this (open) group."""
@@ -1059,7 +1042,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
             for child in self._v_children.values():
                 child._f_copy(dstparent, None, overwrite, recursive, **kwargs)
 
-
     def __str__(self):
         """Return a short string representation of the group.
 
@@ -1101,7 +1083,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O."""
 
 # Special definition for group root
 class RootGroup(Group):
-
 
     def __init__(self, ptfile, name, title, new, filters):
         mydict = self.__dict__
@@ -1194,7 +1175,6 @@ class RootGroup(Group):
         else:
             return UnImplemented(self, childname)
 
-
     def _f_rename(self, newname):
         raise NodeError("the root node can not be renamed")
 
@@ -1208,7 +1188,6 @@ class RootGroup(Group):
 class TransactionGroupG(NotLoggedMixin, Group):
     _c_classid = 'TRANSGROUP'
 
-
     def _g_width_warning(self):
         warnings.warn("""\
 the number of transactions is exceeding the recommended maximum (%d);\
@@ -1216,10 +1195,8 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
                       % (self._v_max_group_width,), PerformanceWarning)
 
 
-
 class TransactionG(NotLoggedMixin, Group):
     _c_classid = 'TRANSG'
-
 
     def _g_width_warning(self):
         warnings.warn("""\
@@ -1229,11 +1206,9 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
                       PerformanceWarning)
 
 
-
 class MarkG(NotLoggedMixin, Group):
     # Class identifier.
     _c_classid = 'MARKG'
-
 
     import re
     _c_shadow_name_re = re.compile(r'^a[0-9]+$')
@@ -1244,7 +1219,6 @@ mark ``%s`` is exceeding the recommended maximum action storage (%d nodes);\
 be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
                       % (self._v_pathname, self._v_max_group_width),
                       PerformanceWarning)
-
 
     def _g_reset(self):
         """Empty action storage (nodes and attributes).

--- a/tables/idxutils.py
+++ b/tables/idxutils.py
@@ -494,11 +494,3 @@ def nextafter(x, direction, dtype, itemsize):
     #        return PyNextAfter(x,x + 1)
 
     raise TypeError("data type ``%s`` is not supported" % dtype)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/index.py
+++ b/tables/index.py
@@ -49,7 +49,7 @@ from .lrucacheextension import ObjectCache
 # obversion = "1.0"    # Version of indexes in PyTables 1.x series
 # obversion = "2.0"    # Version of indexes in PyTables Pro 2.0 series
 obversion = "2.1"     # Version of indexes in PyTables Pro 2.1 and up series,
-                      # including the join 2.3 Std + Pro version
+#                     # including the join 2.3 Std + Pro version
 
 
 debug = False

--- a/tables/index.py
+++ b/tables/index.py
@@ -170,13 +170,13 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
     @property
     def dirty(self):
-       """Whether the index is dirty or not.
-       Dirty indexes are out of sync with column data, so they exist but they
-       are not usable.
-       """
+        """Whether the index is dirty or not.
+        Dirty indexes are out of sync with column data, so they exist but they
+        are not usable.
+        """
 
-       # If there is no ``DIRTY`` attribute, index should be clean.
-       return getattr(self._v_attrs, 'DIRTY', False)
+        # If there is no ``DIRTY`` attribute, index should be clean.
+        return getattr(self._v_attrs, 'DIRTY', False)
 
     @dirty.setter
     def dirty(self, dirty):

--- a/tables/index.py
+++ b/tables/index.py
@@ -10,7 +10,6 @@
 
 """Here is defined the Index class."""
 
-
 import math
 import operator
 import os
@@ -43,14 +42,11 @@ from .utilsextension import (nan_aware_gt, nan_aware_ge,
                              bisect_left, bisect_right)
 from .lrucacheextension import ObjectCache
 
-
-
 # default version for INDEX objects
 # obversion = "1.0"    # Version of indexes in PyTables 1.x series
 # obversion = "2.0"    # Version of indexes in PyTables Pro 2.0 series
 obversion = "2.1"     # Version of indexes in PyTables Pro 2.1 and up series,
 #                     # including the join 2.3 Std + Pro version
-
 
 debug = False
 # debug = True  # Uncomment this for printing sizes purposes
@@ -58,7 +54,6 @@ profile = False
 # profile = True  # Uncomment for profiling
 if profile:
     from .utils import show_stats
-
 
 # The default method for sorting
 # defsort = "quicksort"
@@ -154,7 +149,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
     """
 
     _c_classid = 'INDEX'
-
 
     @property
     def kind(self):
@@ -547,7 +541,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         if self.temp_required:
             self.create_temp()
 
-
     def initial_append(self, xarr, nrow, reduction):
         """Compute an initial indices arrays for data to be indexed."""
 
@@ -759,7 +752,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         self.dirtycache = True   # the cache is dirty now
         if profile:
             show_stats("Exiting appendLR", tref)
-
 
     def optimize(self, verbose=False):
         """Optimize an index so as to allow faster searches.
@@ -1261,7 +1253,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         stepl = np.array([1], dtype=np.uint64)
         where._g_write_slice(startl, stepl, countl, buffer)
 
-
     def reorder_slice(self, nslice, sorted, indices, ssorted, sindices,
                       tmp_sorted, tmp_indices):
         """Copy & reorder the slice in source to final destination."""
@@ -1719,7 +1710,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
         return self.read_sorted_indices('sorted', start, stop, step)
 
-
     def read_indices(self, start=None, stop=None, step=None):
         """Return the indices values of index in the specified range.
 
@@ -1729,7 +1719,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         """
 
         return self.read_sorted_indices('indices', start, stop, step)
-
 
     def _process_range(self, start, stop, step):
         """Get a range specifc for the index usage."""
@@ -1750,7 +1739,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
         else:
             step = idx2long(step)
         return (start, stop, step)
-
 
     def __getitem__(self, key):
         """Return the indices values of index in the specified range.
@@ -1991,7 +1979,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             stop = 0
         return (start, stop)
 
-
     def get_chunkmap(self):
         """Compute a map with the interesting chunks in index."""
 
@@ -2100,7 +2087,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 
         return range_
 
-
     def _f_remove(self, recursive=False):
         """Remove this Index object."""
 
@@ -2150,7 +2136,6 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
 class IndexesDescG(NotLoggedMixin, Group):
     _c_classid = 'DINDEX'
 
-
     def _g_width_warning(self):
         warnings.warn(
             "the number of indexed columns on a single description group "
@@ -2160,10 +2145,8 @@ class IndexesDescG(NotLoggedMixin, Group):
             PerformanceWarning)
 
 
-
 class IndexesTableG(NotLoggedMixin, Group):
     _c_classid = 'TINDEX'
-
 
     @property
     def auto(self):
@@ -2187,12 +2170,10 @@ class IndexesTableG(NotLoggedMixin, Group):
             "and possibly slow I/O" % self._v_max_group_width,
             PerformanceWarning)
 
-
     def _g_check_name(self, name):
         if not name.startswith('_i_'):
             raise ValueError(
                 "names of index groups must start with ``_i_``: %s" % name)
-
 
     @property
     def table(self):

--- a/tables/index.py
+++ b/tables/index.py
@@ -198,7 +198,8 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
     @property
     def table(self):
         """Accessor for the `Table` object of this index."""
-        tablepath, columnpath = _table_column_pathname_of_index(self._v_pathname)
+        tablepath, columnpath = _table_column_pathname_of_index(
+            self._v_pathname)
         table = self._v_file._get_node(tablepath)
         return table
 
@@ -255,7 +256,9 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
     @property
     def temp_required(self):
         """Whether a temporary file for indexes is required or not."""
-        return self.indsize > 1 and self.optlevel > 0 and self.table.nrows > self.slicesize
+        return (self.indsize > 1 and
+                self.optlevel > 0 and
+                self.table.nrows > self.slicesize)
 
     @property
     def want_complete_sort(self):
@@ -2177,7 +2180,8 @@ class IndexesTableG(NotLoggedMixin, Group):
 
     @property
     def table(self):
-        """Accessor for the `Table` object of this `IndexesTableG` container."""
+        """Accessor for the `Table` object of this `IndexesTableG`
+        container."""
         names = self._v_pathname.split("/")
         tablename = names.pop()[3:]   # "_i_" is at the beginning
         parentpathname = "/".join(names)

--- a/tables/index.py
+++ b/tables/index.py
@@ -349,12 +349,12 @@ class Index(NotLoggedMixin, Group, indexesextension.Index):
             self.dtype = atom.dtype.base
             self.type = atom.type
             """The datatypes to be stored by the sorted index array."""
-            ############### Important note ###########################
+            # ############## Important note ###########################
             # The datatypes saved as index values are NumPy native
             # types, so we get rid of type metainfo like Time* or Enum*
             # that belongs to HDF5 types (actually, this metainfo is
             # not needed for sorting and looking-up purposes).
-            ##########################################################
+            # #########################################################
             indsize = {
                 'ultralight': 1, 'light': 2, 'medium': 4, 'full': 8}[kind]
             assert indsize in (1, 2, 4, 8), "indsize should be 1, 2, 4 or 8!"
@@ -2209,12 +2209,3 @@ class OldIndex(NotLoggedMixin, Group):
     """This is meant to hide indexes of PyTables 1.x files."""
 
     _c_classid = 'CINDEX'
-
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/index.py
+++ b/tables/index.py
@@ -25,7 +25,7 @@ from time import process_time as cpuclock
 import numpy as np
 
 from .idxutils import (calc_chunksize, calcoptlevels,
-                             get_reduction_level, nextafter, inftype)
+                       get_reduction_level, nextafter, inftype)
 
 from . import indexesextension
 from .node import NotLoggedMixin
@@ -39,8 +39,8 @@ from .path import join_path
 from .exceptions import PerformanceWarning
 from .utils import is_idx, idx2long, lazyattr
 from .utilsextension import (nan_aware_gt, nan_aware_ge,
-                                   nan_aware_lt, nan_aware_le,
-                                   bisect_left, bisect_right)
+                             nan_aware_lt, nan_aware_le,
+                             bisect_left, bisect_right)
 from .lrucacheextension import ObjectCache
 
 

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -182,10 +182,3 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
   chunksize = {self.chunksize}
   slicesize = {self.slicesize}
   byteorder = {self.byteorder!r}"""
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -411,9 +411,9 @@ very small/large chunksize, you may want to increase/decrease it."""
         if warn_negstep and step and step < 0:
             raise ValueError("slice step cannot be negative")
 
-        #if start is not None: start = long(start)
-        #if stop is not None: stop = long(stop)
-        #if step is not None: step = long(step)
+        # if start is not None: start = long(start)
+        # if stop is not None: stop = long(stop)
+        # if step is not None: step = long(step)
 
         return slice(start, stop, step).indices(int(nrows))
 

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -136,7 +136,8 @@ class Leaf(Node):
     # ```````````````````````````````
     @property
     def name(self):
-        """The name of this node in its parent group (This is an easier-to-write alias of :attr:`Node._v_name`)."""
+        """The name of this node in its parent group (This is an
+        easier-to-write alias of :attr:`Node._v_name`)."""
         return self._v_name
 
     @property

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -279,7 +279,6 @@ class Leaf(Node):
         # Existing filters need not be read since `filters`
         # is a lazy property that automatically handles their loading.
 
-
         super().__init__(parentnode, name, _log)
 
     def __len__(self):

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -764,11 +764,3 @@ very small/large chunksize, you may want to increase/decrease it."""
         """
 
         self._f_close(flush)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/link.py
+++ b/tables/link.py
@@ -419,11 +419,3 @@ class ExternalLink(linkextension.ExternalLink, Link):
         """
 
         return f"{self._v_pathname} ({self.__class__.__name__}) -> {self.target}"
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/link.py
+++ b/tables/link.py
@@ -231,8 +231,8 @@ class SoftLink(linkextension.SoftLink, Link):
     def __getattribute__(self, attrname):
 
         # get attribute of the SoftLink itself
-        if (attrname in SoftLink._link_attrnames
-            or attrname[:3] in SoftLink._link_attrprefixes):
+        if (attrname in SoftLink._link_attrnames or
+                attrname[:3] in SoftLink._link_attrprefixes):
             return object.__getattribute__(self, attrname)
 
         # get attribute of the target node
@@ -252,8 +252,8 @@ class SoftLink(linkextension.SoftLink, Link):
     def __setattr__(self, attrname, value):
 
         # set attribute of the SoftLink itself
-        if (attrname in SoftLink._link_attrnames
-            or attrname[:3] in SoftLink._link_attrprefixes):
+        if (attrname in SoftLink._link_attrnames or
+                attrname[:3] in SoftLink._link_attrprefixes):
             object.__setattr__(self, attrname, value)
 
         # set attribute of the target node

--- a/tables/link.py
+++ b/tables/link.py
@@ -41,7 +41,6 @@ def _g_get_link_class(parent_id, name):
     return linkextension._get_link_class(parent_id, name)
 
 
-
 class Link(Node):
     """Abstract base class for all PyTables links.
 
@@ -191,14 +190,12 @@ class SoftLink(linkextension.SoftLink, Link):
     # Class identifier.
     _c_classid = 'SOFTLINK'
 
-
     # attributes with these names/prefixes are treated as attributes of the
     # SoftLink rather than the target node
     _link_attrnames = ('target', 'dereference', 'is_dangling', 'copy', 'move',
                        'remove', 'rename', '__init__', '__str__', '__repr__',
                        '__unicode__', '__class__', '__dict__')
     _link_attrprefixes = ('_f_', '_c_', '_g_', '_v_')
-
 
     def __call__(self):
         """Dereference `self.target` and return the object.
@@ -289,7 +286,6 @@ class SoftLink(linkextension.SoftLink, Link):
     def is_dangling(self):
         return not (self.dereference() in self._v_file)
 
-
     def __str__(self):
         """Return a short string representation of the link.
 
@@ -334,7 +330,6 @@ class ExternalLink(linkextension.ExternalLink, Link):
 
     # Class identifier.
     _c_classid = 'EXTERNALLINK'
-
 
     def __init__(self, parentnode, name, target=None, _log=False):
         self.extfile = None

--- a/tables/link.py
+++ b/tables/link.py
@@ -413,4 +413,5 @@ class ExternalLink(linkextension.ExternalLink, Link):
 
         """
 
-        return f"{self._v_pathname} ({self.__class__.__name__}) -> {self.target}"
+        return (f"{self._v_pathname} ({self.__class__.__name__}) -> "
+                f"{self.target}")

--- a/tables/misc/enum.py
+++ b/tables/misc/enum.py
@@ -444,11 +444,3 @@ def _test():
 
 if __name__ == '__main__':
     _test()
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/misc/proxydict.py
+++ b/tables/misc/proxydict.py
@@ -66,4 +66,3 @@ class ProxyDict(dict):
         if container is None:
             raise ValueError("the container object does no longer exist")
         return container
-

--- a/tables/misc/proxydict.py
+++ b/tables/misc/proxydict.py
@@ -15,7 +15,6 @@ import weakref
 class ProxyDict(dict):
     """A dictionary which uses a container object to store its values."""
 
-
     def __init__(self, container):
         self.containerref = weakref.ref(container)
         """A weak reference to the container object.

--- a/tables/node.py
+++ b/tables/node.py
@@ -266,7 +266,7 @@ class Node(metaclass=MetaNode):
 
             # This allows extra operations after creating the node.
             self._g_post_init_hook()
-        except:
+        except Exception:
             # If anything happens, the node must be closed
             # to undo every possible registration made so far.
             # We do *not* rely on ``__del__()`` doing it later,

--- a/tables/node.py
+++ b/tables/node.py
@@ -922,12 +922,3 @@ class NotLoggedMixin:
 
     def _g_remove_and_log(self, recursive, force):
         self._g_remove(recursive, force)
-
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/node.py
+++ b/tables/node.py
@@ -869,7 +869,6 @@ you may want to use the ``overwrite`` argument""".format(parent._v_pathname, nam
                 "node name starts with reserved prefix ``_i_``: %s" % name)
 
 
-    # <attribute handling>
     def _f_getattr(self, name):
         """Get a PyTables attribute from this node.
 

--- a/tables/node.py
+++ b/tables/node.py
@@ -834,9 +834,10 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
     def _g_maybe_remove(self, parent, name, overwrite):
         if name in parent:
             if not overwrite:
-                raise NodeError("""\
-destination group ``{}`` already has a node named ``{}``; \
-you may want to use the ``overwrite`` argument""".format(parent._v_pathname, name))
+                raise NodeError(
+                    f"destination group ``{parent._v_pathname}`` already "
+                    f"has a node named ``{name}``; you may want to use the "
+                    f"``overwrite`` argument")
             parent._f_get_child(name)._f_remove(True)
 
     def _g_check_name(self, name):

--- a/tables/node.py
+++ b/tables/node.py
@@ -187,7 +187,6 @@ class Node(metaclass=MetaNode):
     _v_isopen = False
     """Whehter this node is open or not."""
 
-
     # The ``_log`` argument is only meant to be used by ``_g_copy_as_child()``
     # to avoid logging the creation of children nodes of a copied sub-tree.
     def __init__(self, parentnode, name, _log=True):
@@ -278,7 +277,6 @@ class Node(metaclass=MetaNode):
     def _g_log_create(self):
         self._v_file._log('CREATE', self._v_pathname)
 
-
     def __del__(self):
         # Closed `Node` instances can not be killed and revived.
         # Instead, accessing a closed and deleted (from memory, not
@@ -318,7 +316,6 @@ class Node(metaclass=MetaNode):
         """Code to be called before killing the node."""
         pass
 
-
     def _g_create(self):
         """Create a new HDF5 node and return its object identifier."""
         raise NotImplementedError
@@ -337,7 +334,6 @@ class Node(metaclass=MetaNode):
         if not self._v_isopen:
             raise ClosedNodeError("the node object is closed")
         assert self._v_file.isopen, "found an open node in a closed file"
-
 
     def _g_set_location(self, parentnode, name):
         """Set location-dependent attributes.
@@ -385,7 +381,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         if self._v_pathname != '/':
             file_._node_manager.cache_node(self, self._v_pathname)
 
-
     def _g_update_location(self, newparentpath):
         """Update location-dependent attributes.
 
@@ -420,7 +415,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # Tell dependent objects about the new location of this node.
         self._g_update_dependent()
 
-
     def _g_del_location(self):
         """Clear location-dependent attributes.
 
@@ -443,11 +437,9 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         self._v_name = None
         self._v_depth = None
 
-
     def _g_post_init_hook(self):
         """Code to be run after node creation and before creation logging."""
         pass
-
 
     def _g_update_dependent(self):
         """Update dependent objects after a location change.
@@ -459,7 +451,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
 
         if '_v_attrs' in self.__dict__:
             self._v_attrs._g_update_node_location(self)
-
 
     def _f_close(self):
         """Close this node in the tree.
@@ -549,7 +540,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         # Log *before* moving to use the right shadow name.
         file_._log('REMOVE', oldpathname)
         move_to_shadow(file_, oldpathname)
-
 
     def _g_move(self, newparent, newname):
         """Move this node in the hierarchy.
@@ -689,7 +679,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
     def _g_log_move(self, oldpathname):
         self._v_file._log('MOVE', oldpathname, self._v_pathname)
 
-
     def _g_copy(self, newparent, newname, recursive, _log=True, **kwargs):
         """Copy this node and return the new one.
 
@@ -719,7 +708,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
 
         return self._g_copy(newparent, self._v_name,
                             recursive=False, _log=False, **kwargs)
-
 
     def _f_copy(self, newparent=None, newname=None,
                 overwrite=False, recursive=False, createparents=False,
@@ -823,7 +811,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
         self._g_check_open()
         return isvisiblepath(self._v_pathname)
 
-
     def _g_check_group(self, node):
         # Node must be defined in order to define a Group.
         # However, we need to know Group here.
@@ -835,7 +822,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
             raise TypeError("new parent node ``%s`` is not a group"
                             % node._v_pathname)
 
-
     def _g_check_not_contains(self, pathname):
         # The not-a-TARDIS test. ;)
         mypathname = self._v_pathname
@@ -845,7 +831,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
             raise NodeError("can not move or recursively copy node ``%s`` "
                             "into itself" % mypathname)
 
-
     def _g_maybe_remove(self, parent, name, overwrite):
         if name in parent:
             if not overwrite:
@@ -853,7 +838,6 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
 destination group ``{}`` already has a node named ``{}``; \
 you may want to use the ``overwrite`` argument""".format(parent._v_pathname, name))
             parent._f_get_child(name)._f_remove(True)
-
 
     def _g_check_name(self, name):
         """Check validity of name for this particular kind of node.
@@ -868,7 +852,6 @@ you may want to use the ``overwrite`` argument""".format(parent._v_pathname, nam
             raise ValueError(
                 "node name starts with reserved prefix ``_i_``: %s" % name)
 
-
     def _f_getattr(self, name):
         """Get a PyTables attribute from this node.
 
@@ -878,7 +861,6 @@ you may want to use the ``overwrite`` argument""".format(parent._v_pathname, nam
         """
 
         return getattr(self._v_attrs, name)
-
 
     def _f_setattr(self, name, value):
         """Set a PyTables attribute for this node.
@@ -890,7 +872,6 @@ you may want to use the ``overwrite`` argument""".format(parent._v_pathname, nam
 
         setattr(self._v_attrs, name, value)
 
-
     def _f_delattr(self, name):
         """Delete a PyTables attribute from this node.
 
@@ -900,7 +881,6 @@ you may want to use the ``overwrite`` argument""".format(parent._v_pathname, nam
         """
 
         delattr(self._v_attrs, name)
-
 
     # </attribute handling>
 
@@ -914,10 +894,8 @@ class NotLoggedMixin:
     def _g_log_create(self):
         pass
 
-
     def _g_log_move(self, oldpathname):
         pass
-
 
     def _g_remove_and_log(self, recursive, force):
         self._g_remove(recursive, force)

--- a/tables/node.py
+++ b/tables/node.py
@@ -15,7 +15,7 @@ import functools
 
 from .registry import class_name_dict, class_id_dict
 from .exceptions import (ClosedNodeError, NodeError, UndoRedoWarning,
-                               PerformanceWarning)
+                         PerformanceWarning)
 from .path import join_path, split_path, isvisiblepath
 from .utils import lazyattr
 from .undoredo import move_to_shadow

--- a/tables/nodes/__init__.py
+++ b/tables/nodes/__init__.py
@@ -22,10 +22,3 @@ Package modules:
 
 # The list of names to be exported to the importing module.
 __all__ = ['filenode']
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -875,10 +875,3 @@ def read_from_filenode(h5file, filename, where, name=None, overwrite=False,
     del data
     if new_h5file:
         f.close()
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -82,14 +82,14 @@ class RawPyTablesIO(io.RawIOBase):
 
         return self._mode
 
-    #def tell(self) -> int:
+    # def tell(self) -> int:
     def tell(self):
         """Return current stream position."""
 
         self._checkClosed()
         return self._pos
 
-    #def seek(self, pos: int, whence: int = 0) -> int:
+    # def seek(self, pos: int, whence: int = 0) -> int:
     def seek(self, pos, whence=0):
         """Change stream position.
 
@@ -108,8 +108,8 @@ class RawPyTablesIO(io.RawIOBase):
         self._checkClosed()
         try:
             pos = pos.__index__()
-        #except AttributeError as err:
-            #raise TypeError("an integer is required") from err
+        # except AttributeError as err:
+        #     raise TypeError("an integer is required") from err
         except AttributeError:
             raise TypeError("an integer is required")
         if whence == 0:
@@ -124,7 +124,7 @@ class RawPyTablesIO(io.RawIOBase):
             raise ValueError("invalid whence value")
         return self._pos
 
-    #def seekable(self) -> bool:
+    # def seekable(self) -> bool:
     def seekable(self):
         """Return whether object supports random access.
 
@@ -135,7 +135,7 @@ class RawPyTablesIO(io.RawIOBase):
 
         return True
 
-    #def fileno(self) -> int:
+    # def fileno(self) -> int:
     def fileno(self):
         """Returns underlying file descriptor if one exists.
 
@@ -147,7 +147,7 @@ class RawPyTablesIO(io.RawIOBase):
         self._checkClosed()
         return self._node._v_file.fileno()
 
-    #def close(self) -> None:
+    # def close(self) -> None:
     def close(self):
         """Flush and close the IO object.
 
@@ -175,7 +175,7 @@ class RawPyTablesIO(io.RawIOBase):
         self._checkClosed()
         self._node.flush()
 
-    #def truncate(self, pos: int = None) -> int:
+    # def truncate(self, pos: int = None) -> int:
     def truncate(self, pos=None):
         """Truncate file to size bytes.
 
@@ -201,7 +201,7 @@ class RawPyTablesIO(io.RawIOBase):
 
         return self.seek(pos)
 
-    #def readable(self) -> bool:
+    # def readable(self) -> bool:
     def readable(self):
         """Return whether object was opened for reading.
 
@@ -212,7 +212,7 @@ class RawPyTablesIO(io.RawIOBase):
         mode = self._mode
         return 'r' in mode or '+' in mode
 
-    #def writable(self) -> bool:
+    # def writable(self) -> bool:
     def writable(self):
         """Return whether object was opened for writing.
 
@@ -223,7 +223,7 @@ class RawPyTablesIO(io.RawIOBase):
         mode = self._mode
         return 'w' in mode or 'a' in mode or '+' in mode
 
-    #def readinto(self, b: bytearray) -> int:
+    # def readinto(self, b: bytearray) -> int:
     def readinto(self, b):
         """Read up to len(b) bytes into b.
 
@@ -243,10 +243,10 @@ class RawPyTablesIO(io.RawIOBase):
         stop = self._pos + n
 
         # XXX optimized path
-        #if stop <= self._node.nrows and isinstance(b, np.ndarray):
-        #    self._node.read(start, stop, out=b)
-        #    self._pos += n
-        #    return n
+        # if stop <= self._node.nrows and isinstance(b, np.ndarray):
+        #     self._node.read(start, stop, out=b)
+        #     self._pos += n
+        #     return n
 
         if stop > self._node.nrows:
             stop = self._node.nrows
@@ -259,7 +259,7 @@ class RawPyTablesIO(io.RawIOBase):
 
         return n
 
-    #def readline(self, limit: int = -1) -> bytes:
+    # def readline(self, limit: int = -1) -> bytes:
     def readline(self, limit=-1):
         """Read and return a line from the stream.
 
@@ -340,7 +340,7 @@ class RawPyTablesIO(io.RawIOBase):
 
         return b''.join(partial)
 
-    #def write(self, b: bytes) -> int:
+    # def write(self, b: bytes) -> int:
     def write(self, b):
         """Write the given buffer to the IO stream.
 
@@ -405,7 +405,7 @@ class RawPyTablesIO(io.RawIOBase):
         reading = "r" in modes
         writing = "w" in modes
         appending = "a" in modes
-        #updating = "+" in modes
+        # updating = "+" in modes
         text = "t" in modes
         binary = "b" in modes
 
@@ -425,12 +425,12 @@ class RawPyTablesIO(io.RawIOBase):
 
     def _cross_check_mode(self, mode, h5filemode):
         # XXX: check
-        #readable = bool('r' in mode or '+' in mode)
-        #h5readable = bool('r' in h5filemode or '+' in h5filemode)
+        # readable = bool('r' in mode or '+' in mode)
+        # h5readable = bool('r' in h5filemode or '+' in h5filemode)
         #
-        #if readable and not h5readable:
-        #    raise ValueError("RawPyTablesIO can't be open in read mode if "
-        #                     "the underlying hdf5 file is not readable")
+        # if readable and not h5readable:
+        #     raise ValueError("RawPyTablesIO can't be open in read mode if "
+        #                      "the underlying hdf5 file is not readable")
 
         writable = bool('w' in mode or 'a' in mode or '+' in mode)
         h5writable = bool('w' in h5filemode or 'a' in h5filemode or
@@ -492,7 +492,7 @@ class FileNodeMixin:
     def _get_attrs(self):
         """Returns the attribute set of the file node."""
 
-        #sefl._checkClosed()
+        # sefl._checkClosed()
         return self._node.attrs
 
 

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -460,7 +460,6 @@ class RawPyTablesIO(io.RawIOBase):
             raise ValueError(
                 f"unsupported type version of node object: {ltypever}")
 
-
     def _append_zeros(self, size):
         """_append_zeros(size) -> None.  Appends a string of zeros.
 
@@ -495,18 +494,15 @@ class FileNodeMixin:
         # sefl._checkClosed()
         return self._node.attrs
 
-
     def _set_attrs(self, value):
         """set_attrs(string) -> None.  Raises ValueError."""
 
         raise ValueError("changing the whole attribute set is not allowed")
 
-
     def _del_attrs(self):
         """del_attrs() -> None.  Raises ValueError."""
 
         raise ValueError("deleting the whole attribute set is not allowed")
-
 
     # The attribute set property.
     attrs = property(
@@ -653,7 +649,6 @@ class RAFileNode(FileNodeMixin, RawPyTablesIO):
         attrs.NODE_TYPE_VERSION = NodeTypeVersions[-1]
 
 
-
 def new_node(h5file, **kwargs):
     """Creates a new file node object in the specified PyTables file object.
 
@@ -667,8 +662,6 @@ def new_node(h5file, **kwargs):
     """
 
     return RAFileNode(None, h5file, **kwargs)
-
-
 
 
 def open_node(node, mode='r'):
@@ -688,8 +681,6 @@ def open_node(node, mode='r'):
         return RAFileNode(node, None)
     else:
         raise OSError(f"invalid mode: {mode}")
-
-
 
 
 def save_to_filenode(h5file, filename, where, name=None, overwrite=False,

--- a/tables/nodes/filenode.py
+++ b/tables/nodes/filenode.py
@@ -753,7 +753,7 @@ def save_to_filenode(h5file, filename, where, name=None, overwrite=False,
 
     # check for already existing filenode
     try:
-        n = f.get_node(where=where, name=name)
+        f.get_node(where=where, name=name)
         if not overwrite:
             if new_h5file:
                 f.close()

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -316,7 +316,6 @@ class OpenFileTestCase(TempFileMixin, TestCase):
         self.assertRaises(
             IOError, filenode.open_node, self.h5file.get_node('/test'), 'w')
 
-
     # This no longer works since type and type version attributes
     # are now system attributes.  ivb(2004-12-29)
     # def test03_OpenFileNoAttrs(self):
@@ -957,7 +956,6 @@ class DirectReadWriteTestCase(TempFileMixin, TestCase):
         # cleanup
         Path(self.testfname).unlink()
         Path(self.testh5fname).unlink()
-
 
     def test02_WriteToHDF5File(self):
         # write contents of datafname to h5 testfile

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -320,13 +320,13 @@ class OpenFileTestCase(TempFileMixin, TestCase):
     # This no longer works since type and type version attributes
     # are now system attributes.  ivb(2004-12-29)
     # def test03_OpenFileNoAttrs(self):
-    ##      "Opening a node with no type attributes."
-    ##
-    ##      node = self.h5file.get_node('/test')
-    ##      self.h5file.del_node_attr('/test', '_type')
-    ##      # Another way to get the same result is changing the value.
-    ##      ##self.h5file.set_node_attr('/test', '_type', 'foobar')
-    ##      self.assertRaises(ValueError, filenode.open_node, node)
+    #      "Opening a node with no type attributes."
+    #
+    #      node = self.h5file.get_node('/test')
+    #      self.h5file.del_node_attr('/test', '_type')
+    #      # Another way to get the same result is changing the value.
+    #      ##self.h5file.set_node_attr('/test', '_type', 'foobar')
+    #      self.assertRaises(ValueError, filenode.open_node, node)
 
 
 class ReadFileTestCase(TempFileMixin, TestCase):
@@ -672,11 +672,11 @@ class AttrsTestCase(TempFileMixin, TestCase):
     # This no longer works since type and type version attributes
     # are now system attributes.  ivb(2004-12-29)
     # def test00_GetTypeAttr(self):
-    ##      "Getting the type attribute of a file node."
-    ##
-    ##      self.assertEqual(
-    ##          getattr(self.fnode.attrs, '_type', None), filenode.NodeType,
-    ##          "File node has no '_type' attribute.")
+    #      "Getting the type attribute of a file node."
+    #
+    #      self.assertEqual(
+    #          getattr(self.fnode.attrs, '_type', None), filenode.NodeType,
+    #          "File node has no '_type' attribute.")
     def test00_MangleTypeAttrs(self):
         """Mangling the type attributes on a file node."""
 
@@ -692,11 +692,11 @@ class AttrsTestCase(TempFileMixin, TestCase):
 
         # System attributes are now writable.  ivb(2004-12-30)
         # self.assertRaises(
-        ##      AttributeError,
-        ##      setattr, self.fnode.attrs, 'NODE_TYPE', 'foobar')
+        #      AttributeError,
+        #      setattr, self.fnode.attrs, 'NODE_TYPE', 'foobar')
         # self.assertRaises(
-        ##      AttributeError,
-        ##      setattr, self.fnode.attrs, 'NODE_TYPE_VERSION', 'foobar')
+        #      AttributeError,
+        #      setattr, self.fnode.attrs, 'NODE_TYPE_VERSION', 'foobar')
 
         # System attributes are now removables.  F. Alted (2007-03-06)
 #         self.assertRaises(
@@ -708,9 +708,9 @@ class AttrsTestCase(TempFileMixin, TestCase):
 
     # System attributes are now writable.  ivb(2004-12-30)
     # def test01_SetSystemAttr(self):
-    ##      "Setting a system attribute on a file node."
-    ##
-    ##      self.assertRaises(
+    #      "Setting a system attribute on a file node."
+    #
+    #      self.assertRaises(
     # AttributeError, setattr, self.fnode.attrs, 'CLASS', 'foobar')
     def test02_SetGetDelUserAttr(self):
         """Setting a user attribute on a file node."""
@@ -735,7 +735,7 @@ class AttrsTestCase(TempFileMixin, TestCase):
             "User attribute was not deleted.")
         # Another way is looking up the attribute in the attribute list.
         # if 'userAttr' in self.fnode.attrs._f_list():
-        ##      self.fail("User attribute was not deleted.")
+        #      self.fail("User attribute was not deleted.")
 
     def test03_AttrsOnClosedFile(self):
         """Accessing attributes on a closed file node."""
@@ -1045,10 +1045,3 @@ if __name__ == '__main__':
     parse_argv(sys.argv)
     print_versions()
     unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/nodes/tests/test_filenode.py
+++ b/tables/nodes/tests/test_filenode.py
@@ -429,7 +429,7 @@ class ReadlineTestCase(TempFileMixin, TestCase):
 
         # Fill the node file with some text.
         fnode = filenode.new_node(self.h5file, where='/', name='test')
-        #fnode.line_separator = linesep
+        # fnode.line_separator = linesep
         fnode.write(linesep)
         data = 'short line%sshort line%s%s' % ((linesep.decode('ascii'),) * 3)
         data = data.encode('ascii')
@@ -440,7 +440,7 @@ class ReadlineTestCase(TempFileMixin, TestCase):
 
         # Re-open it for reading.
         self.fnode = filenode.open_node(self.h5file.get_node('/test'))
-        #self.fnode.line_separator = linesep
+        # self.fnode.line_separator = linesep
 
     def tearDown(self):
         """tearDown() -> None
@@ -564,10 +564,10 @@ class ReadlineTestCase(TempFileMixin, TestCase):
         data = '%sshort line%sshort' % ((linesep.decode('ascii'),) * 2)
         data = data.encode('ascii')
         lines = self.fnode.readlines(len(data))
-        #self.assertEqual(lines, [linesep, b'short line' + linesep, b'short'])
+        # self.assertEqual(lines, [linesep, b'short line' + linesep, b'short'])
         #
-        #line = self.fnode.readline()
-        #self.assertEqual(line, b' line' + linesep)
+        # line = self.fnode.readline()
+        # self.assertEqual(line, b' line' + linesep)
 
         # NOTE: the test is relaxed because the *hint* parameter of
         # io.BaseIO.readlines controls the amout of read data in a coarse way
@@ -583,13 +583,13 @@ class MonoReadlineTestCase(ReadlineTestCase):
     line_separator = b'\n'
 
 
-#class MultiReadlineTestCase(ReadlineTestCase):
+# class MultiReadlineTestCase(ReadlineTestCase):
 #    "Tests reading multibyte-separated text lines from an existing file node."
 #
 #    line_separator = b'<br/>'
 
 
-#class LineSeparatorTestCase(TempFileMixin, TestCase):
+# class LineSeparatorTestCase(TempFileMixin, TestCase):
 #    "Tests text line separator manipulation in a file node."
 #
 #    def setUp(self):
@@ -838,7 +838,7 @@ class OldVersionTestCase(TestCase):
     def test00_Read(self):
         """Reading an old version file node."""
 
-        #self.fnode.line_separator = '\n'
+        # self.fnode.line_separator = '\n'
 
         line = self.fnode.readline()
         self.assertEqual(line, 'This is only\n')
@@ -859,7 +859,7 @@ class OldVersionTestCase(TestCase):
     def test01_Write(self):
         """Writing an old version file node."""
 
-        #self.fnode.line_separator = '\n'
+        # self.fnode.line_separator = '\n'
 
         self.fnode.write('foobar\n')
         self.fnode.seek(-7, 2)
@@ -1031,8 +1031,8 @@ def suite():
     theSuite.addTest(unittest.makeSuite(OpenFileTestCase))
     theSuite.addTest(unittest.makeSuite(ReadFileTestCase))
     theSuite.addTest(unittest.makeSuite(MonoReadlineTestCase))
-    #theSuite.addTest(unittest.makeSuite(MultiReadlineTestCase))
-    #theSuite.addTest(unittest.makeSuite(LineSeparatorTestCase))
+    # theSuite.addTest(unittest.makeSuite(MultiReadlineTestCase))
+    # theSuite.addTest(unittest.makeSuite(LineSeparatorTestCase))
     theSuite.addTest(unittest.makeSuite(AttrsTestCase))
     theSuite.addTest(unittest.makeSuite(ClosedH5FileTestCase))
     theSuite.addTest(unittest.makeSuite(DirectReadWriteTestCase))

--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -356,26 +356,26 @@ A value of 0 (zero) means to use HDF5 Library’s default value.
 """
 
 # DRIVER_LOG_FLAGS = 0x0001ffff
-#"""Flags specifying the types of logging activity.
+# """Flags specifying the types of logging activity.
 #
-#.. versionadded:: 3.0
+# .. versionadded:: 3.0
 #
-#.. seeealso::
-#    http://www.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetFaplLog
+# .. seeealso::
+#     http://www.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetFaplLog
 #
-#"""
+# """
 #
-# DRIVER_LOG_BUF_SIZE = 4 * _KB
-#"""The size of the logging buffers, in bytes.
+#  DRIVER_LOG_BUF_SIZE = 4 * _KB
+# """The size of the logging buffers, in bytes.
 #
-# One buffer of size DRIVER_LOG_BUF_SIZE will be created for each of
-# H5FD_LOG_FILE_READ, H5FD_LOG_FILE_WRITE and H5FD_LOG_FLAVOR when those
-# flags are set; these buffers will not grow as the file increases in
-# size.
+#  One buffer of size DRIVER_LOG_BUF_SIZE will be created for each of
+#  H5FD_LOG_FILE_READ, H5FD_LOG_FILE_WRITE and H5FD_LOG_FLAVOR when those
+#  flags are set; these buffers will not grow as the file increases in
+#  size.
 #
-#.. versionadded:: 3.0
+# .. versionadded:: 3.0
 #
-#"""
+# """
 
 DRIVER_CORE_INCREMENT = 64 * _KB
 """Core driver memory increment.

--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -449,11 +449,3 @@ by replacing '%s' with the name passed as the first parameter instead.
 .. versionadded:: 3.1
 
 """
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/path.py
+++ b/tables/path.py
@@ -68,6 +68,7 @@ _warnInfo = (
 # Public functions
 # ================
 
+
 def check_attribute_name(name):
     """Check the validity of the `name` of an attribute in AttributeSet.
 
@@ -233,9 +234,6 @@ def isvisiblepath(path):
     return _hidden_path_re.search(path) is None
 
 
-
-# Main part
-# =========
 def _test():
     """Run ``doctest`` on this module."""
 

--- a/tables/path.py
+++ b/tables/path.py
@@ -162,10 +162,6 @@ def check_name_validity(name):
                          "in object names: %r" % name)
 
 
-
-
-
-
 def join_path(parentpath, name):
     """Join a *canonical* `parentpath` with a *non-empty* `name`.
 
@@ -196,7 +192,6 @@ def join_path(parentpath, name):
     return pstr
 
 
-
 def split_path(path):
     """Split a *canonical* `path` into a parent path and a node name.
 
@@ -220,12 +215,10 @@ def split_path(path):
     return (ppath, name)
 
 
-
 def isvisiblename(name):
     """Does this `name` make the named node a visible one?"""
 
     return _hidden_name_re.match(name) is None
-
 
 
 def isvisiblepath(path):

--- a/tables/registry.py
+++ b/tables/registry.py
@@ -86,12 +86,3 @@ def get_class_by_name(classname):
                         % (classname,))
 
     return class_name_dict[classname]
-
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -10,9 +10,9 @@
 
 from distutils.version import LooseVersion
 
-#**********************************************************************
-#  Keep these in sync with requirements.txt and user's guide
-#**********************************************************************
+# **********************************************************************
+#   Keep these in sync with requirements.txt and user's guide
+# **********************************************************************
 
 # Minimum recommended versions for mandatory packages
 min_numpy_version = LooseVersion('1.9.3')

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -517,5 +517,6 @@ def main():
     else:
         Path(ns.output).write_text(targ)
 
+
 if __name__ == '__main__':
     main()

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -338,7 +338,8 @@ old2newnames = dict([
     ('_whereCondition', '_where_condition'),            # attr (private)
     ('_conditionCache', '_condition_cache'),            # attr (private)
     # ('_exprvarsCache', '_exprvars_cache'),
-    ('_enabledIndexingInQueries', '_enabled_indexing_in_queries'),  # attr (private)
+    ('_enabledIndexingInQueries',
+     '_enabled_indexing_in_queries'),  # attr (private)
     ('_emptyArrayCache', '_empty_array_cache'),         # attr (private)
     ('_getTypeColNames', '_get_type_col_names'),
     ('_getEnumMap', '_get_enum_map'),

--- a/tables/scripts/pt2to3.py
+++ b/tables/scripts/pt2to3.py
@@ -45,7 +45,7 @@ old2newnames = dict([
     ('_v__nodeFile', '_v__nodefile'),                   # attr (private)
     ('_v__nodePath', '_v__nodepath'),                   # attr (private)
     # from carray.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     # from description.py
     ('_g_setNestedNamesDescr', '_g_set_nested_names_descr'),
     ('_g_setPathNames', '_g_set_path_names'),
@@ -57,7 +57,7 @@ old2newnames = dict([
     ('joinPaths', 'join_paths'),
     ('metaIsDescription', 'MetaIsDescription'),
     # from earray.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('_checkShapeAppend', '_check_shape_append'),
     # from expression.py
     ('_exprvarsCache', '_exprvars_cache'),              # attr (private)
@@ -129,8 +129,8 @@ old2newnames = dict([
     ('getCurrentMark', 'get_current_mark'),
     ('_updateNodeLocations', '_update_node_locations'),
     # from group.py
-    #('parentNode', 'parentnode'),                       # kwarg
-    #('ptFile', 'ptfile'),                               # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
+    # ('ptFile', 'ptfile'),                               # kwarg
     ('_getValueFromContainer', '_get_value_from_container'),
     ('_g_postInitHook', '_g_post_init_hook'),
     ('_g_getChildGroupClass', '_g_get_child_group_class'),
@@ -187,7 +187,7 @@ old2newnames = dict([
     ('IntTypeNextAfter', 'int_type_next_after'),
     ('BoolTypeNextAfter', 'bool_type_next_after'),
     # from index.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('defaultAutoIndex', 'default_auto_index'),         # data
     ('defaultIndexFilters', 'default_index_filters'),   # data
     ('_tableColumnPathnameOfIndex', '_table_column_pathname_of_index'),
@@ -202,7 +202,7 @@ old2newnames = dict([
     ('getLookupRange', 'get_lookup_range'),
     ('_g_checkName', '_g_check_name'),
     # from indexes.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('_searchBin', '_search_bin'),
     # from indexesextension
     ('indexesExtension', 'indexesextension'),
@@ -227,7 +227,7 @@ old2newnames = dict([
     ('_searchBinNA_d', '_search_bin_na_d'),
     ('_searchBinNA_g', '_search_bin_na_g'),
     # from leaf.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('objectID', 'object_id'),                          # property
     ('_processRangeRead', '_process_range_read'),
     ('_pointSelection', '_point_selection'),
@@ -236,7 +236,7 @@ old2newnames = dict([
     ('setAttr', 'set_attr'),
     ('delAttr', 'del_attr'),
     # from link.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('_g_getLinkClass', '_g_get_link_class'),
     # from linkextension
     ('linkExtension', 'linkextension'),
@@ -250,7 +250,7 @@ old2newnames = dict([
     # from misc/proxydict.py
     ('containerRef', 'containerref'),                   # attr
     # from node.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('_g_logCreate', '_g_log_create'),
     ('_g_preKillHook', '_g_pre_kill_hook'),
     ('_g_checkOpen', '_g_check_open'),
@@ -275,10 +275,10 @@ old2newnames = dict([
     ('openNode', 'open_node'),
     ('_lineChunkSize', '_line_chunksize'),              # attr (private)
     ('_lineSeparator', '_line_separator'),              # attr (private)
-    #('getLineSeparator', 'get_line_separator'),        # dropped
-    #('setLineSeparator', 'set_line_separator'),        # dropped
-    #('delLineSeparator', 'del_line_separator'),        # dropped
-    #('lineSeparator', 'line_separator'),                # property -- dropped
+    # ('getLineSeparator', 'get_line_separator'),        # dropped
+    # ('setLineSeparator', 'set_line_separator'),        # dropped
+    # ('delLineSeparator', 'del_line_separator'),        # dropped
+    # ('lineSeparator', 'line_separator'),                # property -- dropped
     ('_notReadableError', '_not_readable_error'),
     ('_appendZeros', '_append_zeros'),
     ('getAttrs', '_get_attrs'),
@@ -316,7 +316,7 @@ old2newnames = dict([
     ('recreateIndexes', 'recreate_indexes'),
     ('copyLeaf', 'copy_leaf'),
     # from table.py
-    #('parentNode', 'parentnode'),                       # kwarg
+    # ('parentNode', 'parentnode'),                       # kwarg
     ('_nxTypeFromNPType', '_nxtype_from_nptype'),       # data (private)
     ('_npSizeType', '_npsizetype'),                     # data (private)
     ('_indexNameOf', '_index_name_of'),
@@ -337,7 +337,7 @@ old2newnames = dict([
     ('_useIndex', '_use_index'),
     ('_whereCondition', '_where_condition'),            # attr (private)
     ('_conditionCache', '_condition_cache'),            # attr (private)
-    #('_exprvarsCache', '_exprvars_cache'),
+    # ('_exprvarsCache', '_exprvars_cache'),
     ('_enabledIndexingInQueries', '_enabled_indexing_in_queries'),  # attr (private)
     ('_emptyArrayCache', '_empty_array_cache'),         # attr (private)
     ('_getTypeColNames', '_get_type_col_names'),
@@ -347,7 +347,7 @@ old2newnames = dict([
     ('_checkColumn', '_check_column'),
     ('_disableIndexingInQueries', '_disable_indexing_in_queries'),
     ('_enableIndexingInQueries', '_enable_indexing_in_queries'),
-    #('_requiredExprVars', '_required_expr_vars'),
+    # ('_requiredExprVars', '_required_expr_vars'),
     ('_getConditionKey', '_get_condition_key'),
     ('_compileCondition', '_compile_condition'),
     ('willQueryUseIndexing', 'will_query_use_indexing'),
@@ -458,9 +458,9 @@ old2newnames = dict([
     # from unimlemented.py
     ('_openUnImplemented', '_open_unimplemented'),
     # from vlarray.py
-    #('parentNode', 'parentnode'),                       # kwarg
-    #('expectedsizeinMB', 'expected_mb'),                # --> expectedrows
-    #('_v_expectedsizeinMB', '_v_expected_mb'),          # --> expectedrows
+    # ('parentNode', 'parentnode'),                       # kwarg
+    # ('expectedsizeinMB', 'expected_mb'),                # --> expectedrows
+    # ('_v_expectedsizeinMB', '_v_expected_mb'),          # --> expectedrows
 ])
 
 new2oldnames = {v: k for k, v in old2newnames.items()}

--- a/tables/scripts/ptdump.py
+++ b/tables/scripts/ptdump.py
@@ -181,4 +181,3 @@ def main():
         else:
             # This should never happen
             print("Unrecognized object:", nodeobject)
-

--- a/tables/scripts/ptdump.py
+++ b/tables/scripts/ptdump.py
@@ -77,7 +77,6 @@ def dump_leaf(leaf):
                 print(repr(idx))
 
 
-
 def dump_group(pgroup, sort=False):
     node_kinds = pgroup._v_file._node_kinds[1:]
     what = pgroup._f_walk_groups()
@@ -93,8 +92,6 @@ def dump_group(pgroup, sort=False):
                     dump_leaf(node)
                 else:
                     print(str(node))
-
-
 
 
 def _get_parser():

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -105,7 +105,7 @@ def copy_leaf(srcfile, dstfile, srcnode, dstnode, title,
                                 allow_padding=allow_padding)
         try:
             dstgroup = dstfileh.get_node(dstgroup)
-        except:
+        except Exception:
             # The dstgroup does not seem to exist. Try creating it.
             dstgroup = newdst_group(dstfileh, dstgroup, title, filters)
         else:
@@ -140,7 +140,7 @@ def copy_leaf(srcfile, dstfile, srcnode, dstnode, title,
             stats=stats, start=start, stop=stop, step=step,
             chunkshape=chunkshape,
             sortby=sortby, check_CSI=check_CSI, propindexes=propindexes)
-    except:
+    except Exception:
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcnode, dstfile, dstnode))
@@ -233,7 +233,7 @@ def copy_children(srcfile, dstfile, srcgroup, dstgroup, title,
             chunkshape=chunkshape,
             sortby=sortby, check_CSI=check_CSI, propindexes=propindexes,
             use_hardlinks=use_hardlinks)
-    except:
+    except Exception:
         (type_, value, traceback) = sys.exc_info()
         print("Problems doing the copy from '%s:%s' to '%s:%s'" %
               (srcfile, srcgroup, dstfile, dstgroup))

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -510,8 +510,7 @@ def main():
             print("Forcing a CSI creation:", args.checkCSI)
         if args.propindexes:
             print("Recreating indexes in copied table(s)")
-        print("Start copying {}:{} to {}:{}".format(srcfile, srcnode,
-                                                dstfile, dstnode))
+        print(f"Start copying {srcfile}:{srcnode} to {dstfile}:{dstnode}")
         print("+=+" * 20)
 
     allow_padding = not args.dont_allow_padding

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -341,7 +341,7 @@ def _get_parser():
     )
     parser.add_argument(
         '--bitshuffle', type=int, choices=(0, 1),
-        help='''activate or not the bitshuffle filter (not active by default)''',
+        help='activate or not the bitshuffle filter (not active by default)',
     )
     parser.add_argument(
         '--fletcher32', type=int, choices=(0, 1),

--- a/tables/scripts/pttree.py
+++ b/tables/scripts/pttree.py
@@ -458,11 +458,8 @@ def make_test_file(prefix='/tmp'):
 
     g2 = f.create_group('/', 'group2')
 
-    softlink = f.create_soft_link(g2, 'softlink_g1_z128',
-                                  '/group1/group1a/zeros128b')
-    hardlink = f.create_hard_link(g2, 'hardlink_g1a_z128',
-                                  '/group1/group1a/zeros128b')
-
-    hlgroup = f.create_hard_link(g2, 'hardlink_g1a', '/group1/group1a')
+    f.create_soft_link(g2, 'softlink_g1_z128', '/group1/group1a/zeros128b')
+    f.create_hard_link(g2, 'hardlink_g1a_z128', '/group1/group1a/zeros128b')
+    f.create_hard_link(g2, 'hardlink_g1a', '/group1/group1a')
 
     return f

--- a/tables/table.py
+++ b/tables/table.py
@@ -1609,7 +1609,7 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         if not hasattr(sequence, '__getitem__'):
             raise TypeError("Wrong 'sequence' parameter type. Only sequences "
-                             "are suported.")
+                            "are suported.")
         # start, stop and step are necessary for the new iterator for
         # coordinates, and perhaps it would be useful to add them as
         # parameters in the future (not now, because I've just removed
@@ -1813,15 +1813,14 @@ very small/large chunksize, you may want to increase/decrease it."""
             # have different byteorders
             if not out.dtype.isnative:
                 raise ValueError("output array must be in system's byteorder "
-                                  "or results will be incorrect")
+                                 "or results will be incorrect")
             if field:
                 bytes_required = dtype_field.itemsize * nrows
             else:
                 bytes_required = self.rowsize * nrows
             if bytes_required != out.nbytes:
-                raise ValueError(('output array size invalid, got {} bytes, '
-                                  'need {} bytes').format(out.nbytes,
-                                                           bytes_required))
+                raise ValueError(f'output array size invalid, got {out.nbytes}'
+                                 f' bytes, need {bytes_required} bytes')
             if not out.flags['C_CONTIGUOUS']:
                 raise ValueError('output array not C contiguous')
             result = out
@@ -2444,7 +2443,7 @@ very small/large chunksize, you may want to increase/decrease it."""
             raise ValueError("'start' must have a positive value.")
         if step < 1:
             raise ValueError("'step' must have a value greater or "
-                              "equal than 1.")
+                             "equal than 1.")
         descr = []
         for colname in names:
             objcol = self._get_column_instance(colname)

--- a/tables/table.py
+++ b/tables/table.py
@@ -3692,11 +3692,3 @@ class Column:
         """A detailed string representation for this object."""
 
         return str(self)
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/table.py
+++ b/tables/table.py
@@ -642,10 +642,9 @@ class Table(tableextension.Table, Leaf):
     @property
     def colindexes(self):
         """A dictionary with the indexes of the indexed columns."""
-        return _ColIndexes(
-            (_colpname, self.cols._f_col(_colpname).index)
-                for _colpname in self.colpathnames
-                if self.colindexed[_colpname])
+        return _ColIndexes((_colpname, self.cols._f_col(_colpname).index)
+                           for _colpname in self.colpathnames
+                           if self.colindexed[_colpname])
 
     @property
     def _dirtyindexes(self):

--- a/tables/table.py
+++ b/tables/table.py
@@ -637,7 +637,9 @@ class Table(tableextension.Table, Leaf):
     @property
     def indexedcolpathnames(self):
         """List of pathnames of indexed columns in the table."""
-        return [_colpname for _colpname in self.colpathnames if self.colindexed[_colpname]]
+        return [_colpname
+                for _colpname in self.colpathnames
+                if self.colindexed[_colpname]]
 
     @property
     def colindexes(self):
@@ -761,12 +763,14 @@ class Table(tableextension.Table, Leaf):
         # Try purely descriptive description objects.
         if new and isinstance(description, dict):
             # Dictionary case
-            self.description = Description(description, ptparams=parentnode._v_file.params)
+            self.description = Description(description,
+                                           ptparams=parentnode._v_file.params)
         elif new and (type(description) == type(IsDescription)
                       and issubclass(description, IsDescription)):
             # IsDescription subclass case
             descr = description()
-            self.description = Description(descr.columns, ptparams=parentnode._v_file.params)
+            self.description = Description(descr.columns,
+                                           ptparams=parentnode._v_file.params)
         elif new and isinstance(description, Description):
             # It is a Description instance already
             self.description = description
@@ -775,8 +779,9 @@ class Table(tableextension.Table, Leaf):
         if new and self.description is None:
             # Try NumPy dtype instances
             if isinstance(description, np.dtype):
-                self.description, self._rabyteorder = \
-                    descr_from_dtype(description, ptparams=parentnode._v_file.params)
+                tup = descr_from_dtype(description,
+                                       ptparams=parentnode._v_file.params)
+                self.description, self._rabyteorder = tup
 
         # No description yet?
         if new and self.description is None:
@@ -795,8 +800,9 @@ class Table(tableextension.Table, Leaf):
                 # initial buffer.
                 if nrows > 0:
                     self._v_recarray = nparray
-                self.description, self._rabyteorder = \
-                    descr_from_dtype(nparray.dtype, ptparams=parentnode._v_file.params)
+                tup = descr_from_dtype(nparray.dtype,
+                                       ptparams=parentnode._v_file.params)
+                self.description, self._rabyteorder = tup
 
         # No description yet?
         if new and self.description is None:
@@ -948,7 +954,8 @@ very small/large chunksize, you may want to increase/decrease it."""
             return arr
 
     def _get_container(self, shape):
-        """Get the appropriate buffer for data depending on table nestedness."""
+        """Get the appropriate buffer for data depending on table
+        nestedness."""
 
         # This is *much* faster than the numpy.rec.array counterpart
         return np.empty(shape=shape, dtype=self._v_dtype)
@@ -1039,7 +1046,8 @@ very small/large chunksize, you may want to increase/decrease it."""
 
         # 2. Create an instance description to host the record fields.
         validate = not self._v_file._isPTFile  # only for non-PyTables files
-        self.description = Description(description, validate=validate, ptparams=self._v_file.params)
+        self.description = Description(description, validate=validate,
+                                       ptparams=self._v_file.params)
 
         # 3. Compute or get chunk shape and buffer size parameters.
         if chunksize == 0:
@@ -3229,7 +3237,8 @@ class Cols:
         if descpathname:
             descpathname = "." + descpathname
         return (f"{self._v__tablePath}.cols{descpathname} "
-                f"({self.__class__.__name__}), {len(self._v_colnames)} columns")
+                f"({self.__class__.__name__}), "
+                f"{len(self._v_colnames)} columns")
 
     def __repr__(self):
         """A detailed string representation for this object."""

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -10,7 +10,7 @@ trel = tref
 def show_mem(explain):
     global tref, trel
 
-    for line in Path(f"/proc/self/status").read_text().splitlines():
+    for line in Path("/proc/self/status").read_text().splitlines():
         if line.startswith("VmSize:"):
             vmsize = int(line.split()[1])
         elif line.startswith("VmRSS:"):

--- a/tables/tests/check_leaks.py
+++ b/tables/tests/check_leaks.py
@@ -78,13 +78,13 @@ def read_array(filename, nchildren, niter):
             data = node[:]  # Read data
             assert data is not None
         show_mem("After reading data. Iter %s" % i)
-#         for child in range(nchildren):
-#             node = fileh.get_node(fileh.root, 'array' + str(child))
-#             flavor = node._v_attrs.FLAVOR
-            # flavor = node._v_attrs
-#         for child in fileh.walk_nodes():
-#             pass
-#         show_mem("After reading metadata. Iter %s" % i)
+        # for child in range(nchildren):
+        #     node = fileh.get_node(fileh.root, 'array' + str(child))
+        #     flavor = node._v_attrs.FLAVOR
+        #     # flavor = node._v_attrs
+        # for child in fileh.walk_nodes():
+        #     pass
+        # show_mem("After reading metadata. Iter %s" % i)
         fileh.close()
         show_mem("After close")
 

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -372,11 +372,3 @@ class ShowMemTime(PyTablesTestCase):
         print(f"VmSize: {vmsize:>7} kB\tVmRSS: {vmrss:>7} kB")
         print(f"VmData: {vmdata:>7} kB\tVmStk: {vmstk:>7} kB")
         print(f"VmExe:  {vmexe:>7} kB\tVmLib: {vmlib:>7} kB")
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -330,7 +330,7 @@ class TempFileMixin:
 
         self.h5file.close()
         self.h5file = None
-        Path(self.h5fname).unlink()   # comment this for debugging purposes only
+        Path(self.h5fname).unlink()   # comment this for debug only
         super().tearDown()
 
     def _reopen(self, mode='r', **kwargs):

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -122,9 +122,9 @@ def print_versions():
         pass
     print('Python version:      %s' % sys.version)
     print('Platform:            %s' % platform.platform())
-    #if os.name == 'posix':
-    #    (sysname, nodename, release, version, machine) = os.uname()
-    #    print('Platform:          %s-%s' % (sys.platform, machine))
+    # if os.name == 'posix':
+    #     (sysname, nodename, release, version, machine) = os.uname()
+    #     print('Platform:          %s-%s' % (sys.platform, machine))
     print('Byte-ordering:       %s' % sys.byteorder)
     print('Detected cores:      %s' % tb.utils.detect_number_of_cores())
     print('Default encoding:    %s' % sys.getdefaultencoding())

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -95,8 +95,7 @@ def print_versions():
         vml_avail = "not using Intel's VML/MKL"
     print(f"Numexpr version:     {ne.__version__} ({vml_avail})")
     if tinfo is not None:
-        print("Zlib version:        {} ({})".format(tinfo[1],
-                                                "in Python interpreter"))
+        print(f"Zlib version:        {tinfo[1]} (in Python interpreter)")
     tinfo = tb.which_lib_version("lzo")
     if tinfo is not None:
         print("LZO version:         {} ({})".format(tinfo[1], tinfo[2]))

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -118,7 +118,7 @@ def print_versions():
     try:
         from Cython import __version__ as cython_version
         print('Cython version:      %s' % cython_version)
-    except:
+    except Exception:
         pass
     print('Python version:      %s' % sys.version)
     print('Platform:            %s' % platform.platform())

--- a/tables/tests/create_backcompat_indexes.py
+++ b/tables/tests/create_backcompat_indexes.py
@@ -10,6 +10,7 @@ class Descr(tb.IsDescription):
     var3 = tb.Int32Col(shape=(), dflt=0, pos=2)
     var4 = tb.Float64Col(shape=(), dflt=0.0, pos=3)
 
+
 # Parameters for the table and index creation
 small_chunkshape = (2,)
 small_blocksizes = (64, 32, 16, 8)

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -607,7 +607,8 @@ class ReadOutArgumentTests(common.TempFileMixin, common.PyTablesTestCase):
             self.assertIn('output array size invalid, got', str(exc))
 
 
-class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin,
+                                         common.PyTablesTestCase):
 
     def setUp(self):
         super().setUp()
@@ -620,7 +621,8 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         self.assertEqual(self.array.size_in_memory, 10 * 10 * 4)
 
 
-class UnalignedAndComplexTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class UnalignedAndComplexTestCase(common.TempFileMixin,
+                                  common.PyTablesTestCase):
     """Basic test for all the supported typecodes present in numpy.
 
     Most of them are included on PyTables.
@@ -675,7 +677,8 @@ class UnalignedAndComplexTestCase(common.TempFileMixin, common.PyTablesTestCase)
         if a.dtype.byteorder != "|":
             self.assertEqual(a.dtype, b.dtype)
             self.assertEqual(a.dtype, self.root.somearray.atom.dtype)
-            self.assertEqual(tb.utils.byteorders[b.dtype.byteorder], sys.byteorder)
+            self.assertEqual(tb.utils.byteorders[b.dtype.byteorder],
+                             sys.byteorder)
             self.assertEqual(self.root.somearray.byteorder, byteorder)
 
         self.assertTrue(common.allequal(c, b))
@@ -2672,10 +2675,14 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(
             SizeOnDiskInMemoryPropertyTestCase))
         theSuite.addTest(common.unittest.makeSuite(GroupsArrayTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ComplexNotReopenNotEndianTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ComplexReopenNotEndianTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ComplexNotReopenEndianTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ComplexReopenEndianTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            ComplexNotReopenNotEndianTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            ComplexReopenNotEndianTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            ComplexNotReopenEndianTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            ComplexReopenEndianTestCase))
         theSuite.addTest(common.unittest.makeSuite(CloseCopyTestCase))
         theSuite.addTest(common.unittest.makeSuite(OpenCopyTestCase))
         theSuite.addTest(common.unittest.makeSuite(CopyIndex1TestCase))

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -7,7 +7,7 @@ import tables as tb
 from tables.tests import common
 
 
-#warnings.resetwarnings()
+# warnings.resetwarnings()
 
 
 class BasicTestCase(common.PyTablesTestCase):
@@ -2236,9 +2236,9 @@ class FancySelectionTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Using booleans instead of ints is deprecated since numpy 1.8
         # Tests for keys that have to support the __index__ attribute
-        #self.working_keyset.append(
-        #    (False, True),  # equivalent to (0,1) ;-)
-        #)
+        # self.working_keyset.append(
+        #     (False, True),  # equivalent to (0,1) ;-)
+        # )
 
         # Valid selections for NumPy, but not for PyTables (yet)
         # The next should raise an IndexError
@@ -2527,7 +2527,7 @@ class TestCreateArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
         ptarr = self.h5file.create_array(self.where, self.name,
                                          title=self.title,
                                          atom=self.atom, shape=self.shape)
-        #ptarr[...] = self.obj
+        # ptarr[...] = self.obj
         self.h5file.close()
 
         self.h5file = tb.open_file(self.h5fname)
@@ -2594,7 +2594,7 @@ class TestCreateArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_error(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,
                           self.where,
@@ -2604,7 +2604,7 @@ class TestCreateArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           atom=atom)
 
     def test_kwargs_obj_shape_error(self):
-        #atom = Atom.from_dtype(numpy.dtype('complex'))
+        # atom = Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,
@@ -2616,7 +2616,7 @@ class TestCreateArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_shape_error_01(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,
                           self.where,
@@ -2627,7 +2627,7 @@ class TestCreateArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           shape=self.shape)
 
     def test_kwargs_obj_atom_shape_error_02(self):
-        #atom = Atom.from_dtype(numpy.dtype('complex'))
+        # atom = Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_array,

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -2442,7 +2442,7 @@ class BroadcastTest(common.TempFileMixin, common.PyTablesTestCase):
         dtype = np.dtype((np.int, element_shape))
         atom = tb.Atom.from_dtype(dtype)
         h5arr = self.h5file.create_array(self.h5file.root, 'array',
-                                          atom=atom, shape=array_shape)
+                                         atom=atom, shape=array_shape)
 
         size = np.prod(element_shape)
         nparr = np.arange(size).reshape(element_shape)

--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -2217,15 +2217,15 @@ class FancySelectionTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
 
-        M, N, O = self.shape
+        m, n, o = self.shape
 
         # The next are valid selections for both NumPy and PyTables
         self.working_keyset = [
-            ([1, 3], slice(1, N-1), 2),
-            ([M-1, 1, 3, 2], slice(None), 2),  # unordered lists supported
-            (slice(M), [N-1, 1, 0], slice(None)),
-            (slice(1, M, 3), slice(1, N), [O-1, 1, 0]),
-            (M-1, [2, 1], 1),
+            ([1, 3], slice(1, n-1), 2),
+            ([m-1, 1, 3, 2], slice(None), 2),  # unordered lists supported
+            (slice(m), [n-1, 1, 0], slice(None)),
+            (slice(1, m, 3), slice(1, n), [o-1, 1, 0]),
+            (m-1, [2, 1], 1),
             (1, 2, 1),              # regular selection
             ([1, 2], -2, -1),     # negative indices
             ([1, -2], 2, -1),     # more negative indices
@@ -2268,8 +2268,8 @@ class FancySelectionTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Create a sample array
         nparr = np.empty(self.shape, dtype=np.int32)
-        data = np.arange(N * O, dtype=np.int32).reshape(N, O)
-        for i in range(M):
+        data = np.arange(n * o, dtype=np.int32).reshape(n, o)
+        for i in range(m):
             nparr[i] = data * i
         self.nparr = nparr
         self.tbarr = self.h5file.create_array(self.h5file.root, 'array', nparr)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -616,20 +616,17 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         completions = dir(attrset)
 
-        ## Check some regular attributes.
-        #
+        # Check some regular attributes.
         self.assertIn('__class__', completions)
         self.assertIn('_f_copy', completions)
         self.assertEqual(completions.count('_f_copy'), 1)
 
-        ## Check SYS attrs.
-        #
+        # Check SYS attrs.
         self.assertNotIn(bad_sys, completions)
         self.assertIn(sys_attr, completions)
         self.assertEqual(completions.count(sys_attr), 1)
 
-        ## Check USER attrs.
-        #
+        # Check USER attrs.
         self.assertIn(user_attr, completions)
         self.assertNotIn(bad_user, completions)
         self.assertEqual(completions.count(user_attr), 1)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -74,7 +74,6 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertNotIn(name, self.root.atable.attrs)
         self.assertNotIn(name, self.root.anarray.attrs)
 
-
     def check_name(self, name, val=''):
         """Check validity of attribute name filtering"""
         self.check_missing(name)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -122,9 +122,9 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.check_missing(name)
 
         # Using dict []
-        self.root.agroup._v_attrs[name]=val
-        self.root.atable.attrs[name]=val
-        self.root.anarray.attrs[name]=val
+        self.root.agroup._v_attrs[name] = val
+        self.root.atable.attrs[name] = val
+        self.root.anarray.attrs[name] = val
         # Check dict []
         self.reopen()
         self.assertEqual(self.root.agroup._v_attrs[name], val)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -82,7 +82,7 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.h5file.set_node_attr(self.root.agroup, name, val)
         self.h5file.set_node_attr(self.root.atable, name, val)
         self.h5file.set_node_attr(self.root.anarray, name, val)
-         # Check File methods
+        # Check File methods
         self.reopen()
         self.assertEqual(self.h5file.get_node_attr(self.root.agroup, name),val)
         self.assertEqual(self.h5file.get_node_attr(self.root.atable, name),val)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -83,9 +83,12 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.h5file.set_node_attr(self.root.anarray, name, val)
         # Check File methods
         self.reopen()
-        self.assertEqual(self.h5file.get_node_attr(self.root.agroup, name), val)
-        self.assertEqual(self.h5file.get_node_attr(self.root.atable, name), val)
-        self.assertEqual(self.h5file.get_node_attr(self.root.anarray, name), val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.agroup, name),
+                         val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.atable, name),
+                         val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.anarray, name),
+                         val)
         # Remove, file methods
         self.h5file.del_node_attr(self.root.agroup, name)
         self.h5file.del_node_attr(self.root.atable, name)
@@ -590,7 +593,8 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         np.testing.assert_array_equal(self.array.attrs['a'], data)
         np.testing.assert_array_equal(self.array.attrs['b'], data.T)
-        np.testing.assert_array_equal(self.array.attrs['c'], data.T)  # AssertionError!
+        # AssertionError:
+        np.testing.assert_array_equal(self.array.attrs['c'], data.T)
 
     def test12_dir(self):
         """Checking AttributeSet.__dir__"""
@@ -890,7 +894,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             if common.verbose:
                 print("type, value-->", dtype,
                       getattr(self.array.attrs, dtype))
-            np.testing.assert_array_equal(getattr(self.array.attrs, dtype), arr)
+            np.testing.assert_array_equal(getattr(self.array.attrs, dtype),
+                                          arr)
 
     def test01e_setIntAttributes(self):
         """Checking setting Int attributes (bidimensional NumPy case)"""
@@ -1545,7 +1550,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                                       np.array([(([1, 3], 2),)], dt))
 
     def test08_setRecArrayNotAllowPadding(self):
-        """Checking setting aligned RecArray (NumPy) attributes with `allow_aligned` param set to False when reopen."""
+        """Checking setting aligned RecArray (NumPy) attributes with
+        `allow_aligned` param set to False when reopen."""
 
         dt = np.dtype('i4,f8', align=self.aligned)
         # Set some attrs
@@ -1706,7 +1712,8 @@ class CompatibilityTestCase(common.TestFileMixin, common.PyTablesTestCase):
             self.h5file.get_node_attr('/', 'py2_pickled_unicode'), 'abc')
 
 
-class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, common.PyTablesTestCase):
+class PicklePy2UnpicklePy3TestCase(common.TestFileMixin,
+                                   common.PyTablesTestCase):
     h5fname = common.test_filename('issue_560.h5')
 
     def test_pickled_datetime_object(self):
@@ -1811,7 +1818,8 @@ class VlenStrAttrTestCase(common.PyTablesTestCase):
                 self.assertEqual(item, value.encode('ascii'))
 
 
-class UnsupportedAttrTypeTestCase(common.TestFileMixin, common.PyTablesTestCase):
+class UnsupportedAttrTypeTestCase(common.TestFileMixin,
+                                  common.PyTablesTestCase):
     h5fname = common.test_filename('attr-u16.h5')
 
     def test00_unsupportedType(self):
@@ -1855,18 +1863,23 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(DictCacheCloseCreate))
         theSuite.addTest(common.unittest.makeSuite(NotCloseTypesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CloseTypesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CloseNotAlignedPaddedTypesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(NoCloseAlignedTypesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            CloseNotAlignedPaddedTypesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            NoCloseAlignedTypesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CloseAlignedTypesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CloseAlignedPaddedTypesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            CloseAlignedPaddedTypesTestCase))
         theSuite.addTest(common.unittest.makeSuite(NoSysAttrsNotClose))
         theSuite.addTest(common.unittest.makeSuite(NoSysAttrsClose))
         theSuite.addTest(common.unittest.makeSuite(CompatibilityTestCase))
-        theSuite.addTest(common.unittest.makeSuite(PicklePy2UnpicklePy3TestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            PicklePy2UnpicklePy3TestCase))
         theSuite.addTest(common.unittest.makeSuite(SegFaultPythonTestCase))
         theSuite.addTest(common.unittest.makeSuite(EmbeddedNullsTestCase))
         theSuite.addTest(common.unittest.makeSuite(VlenStrAttrTestCase))
-        theSuite.addTest(common.unittest.makeSuite(UnsupportedAttrTypeTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            UnsupportedAttrTypeTestCase))
         theSuite.addTest(common.unittest.makeSuite(SpecificAttrsTestCase))
 
     return theSuite

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -68,7 +68,7 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self._reopen(mode='r+', node_cache_slots=self.node_cache_slots)
             self.root = self.h5file.root
 
-    def check_missing(self,name):
+    def check_missing(self, name):
         self.reopen()
         self.assertNotIn(name, self.root.agroup._v_attrs)
         self.assertNotIn(name, self.root.atable.attrs)
@@ -84,9 +84,9 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.h5file.set_node_attr(self.root.anarray, name, val)
         # Check File methods
         self.reopen()
-        self.assertEqual(self.h5file.get_node_attr(self.root.agroup, name),val)
-        self.assertEqual(self.h5file.get_node_attr(self.root.atable, name),val)
-        self.assertEqual(self.h5file.get_node_attr(self.root.anarray, name),val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.agroup, name), val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.atable, name), val)
+        self.assertEqual(self.h5file.get_node_attr(self.root.anarray, name), val)
         # Remove, file methods
         self.h5file.del_node_attr(self.root.agroup, name)
         self.h5file.del_node_attr(self.root.atable, name)
@@ -116,7 +116,7 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(getattr(self.root.agroup._v_attrs, name), val)
         self.assertEqual(getattr(self.root.atable.attrs, name), val)
         self.assertEqual(getattr(self.root.anarray.attrs, name), val)
-        delattr(self.root.agroup._v_attrs,name)
+        delattr(self.root.agroup._v_attrs, name)
         delattr(self.root.atable.attrs, name)
         delattr(self.root.anarray.attrs, name)
         self.check_missing(name)

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -1605,6 +1605,7 @@ class CloseAlignedTypesTestCase(TypesTestCase):
     aligned = True
     close = True
 
+
 class CloseAlignedPaddedTypesTestCase(TypesTestCase):
     allow_padding = True
     aligned = True
@@ -1729,6 +1730,7 @@ class PicklePy2UnpicklePy3TestCase(common.TestFileMixin, common.PyTablesTestCase
         d = self.h5file.get_node_attr('/', 'py2_pickled_dict')
         self.assertIsInstance(d, dict)
         self.assertEqual(d['s'], 'just a string')
+
 
 class SegFaultPythonTestCase(common.TempFileMixin, common.PyTablesTestCase):
 

--- a/tables/tests/test_attributes.py
+++ b/tables/tests/test_attributes.py
@@ -75,7 +75,7 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertNotIn(name, self.root.anarray.attrs)
 
 
-    def check_name(self, name, val = ''):
+    def check_name(self, name, val=''):
         """Check validity of attribute name filtering"""
         self.check_missing(name)
         # Using File methods

--- a/tables/tests/test_aux.py
+++ b/tables/tests/test_aux.py
@@ -2,7 +2,6 @@ import unittest
 import numpy as np
 
 import tables as tb
-from tables.tests import common
 
 
 class TestAuxiliaryFunctions(unittest.TestCase):

--- a/tables/tests/test_aux.py
+++ b/tables/tests/test_aux.py
@@ -29,5 +29,6 @@ def suite():
     theSuite.addTest(unittest.makeSuite(TestAuxiliaryFunctions))
     return theSuite
 
+
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1214,7 +1214,8 @@ class CheckFileTestCase(common.TempFileMixin, common.PyTablesTestCase):
         """Identifying a nonexistent HDF5 file."""
         self.assertRaises(IOError,  tb.is_hdf5_file, 'nonexistent')
 
-    @common.unittest.skipUnless(hasattr(os, 'getuid') and os.getuid() != 0, "no UID")
+    @common.unittest.skipUnless(hasattr(os, 'getuid') and os.getuid() != 0,
+                                "no UID")
     def test01x_isHDF5File_unreadable(self):
         """Identifying an unreadable HDF5 file."""
 
@@ -1898,7 +1899,8 @@ class FlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
             tb.flavor.description_map.update(description_map)
 
 
-@common.unittest.skipIf('win' in platform.system().lower(), 'known bug: gh-389')
+@common.unittest.skipIf('win' in platform.system().lower(),
+                        'known bug: gh-389')
 @common.unittest.skipIf(sys.getfilesystemencoding() != 'utf-8',
                         'need utf-8 file-system encoding')
 class UnicodeFilename(common.TempFileMixin, common.PyTablesTestCase):
@@ -1989,7 +1991,8 @@ class PathLikeFilename(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(test[:], [1, 2], "Values does not match.")
 
     def test02(self):
-        """Checking  tables.is_hdf5_file with a PathLike object as the filename."""
+        """Checking tables.is_hdf5_file with a PathLike object as the
+        filename."""
 
         self.h5file.close()
         if common.verbose:
@@ -2129,7 +2132,8 @@ def _worker(fn, qout=None):
 @common.unittest.skipIf(not multiprocessing_imported,
                         'multiprocessing module not available')
 @common.unittest.skipIf(platform.system().lower() in ('gnu', 'gnu/kfreebsd'),
-                        "multiprocessing module is not supported on Hurd/kFreeBSD")
+                        "multiprocessing module is not "
+                        "supported on Hurd/kFreeBSD")
 @common.unittest.skipIf(not common.blosc_avail, 'Blosc not available')
 class BloscSubprocess(common.PyTablesTestCase):
     def test_multiprocess(self):
@@ -2364,7 +2368,8 @@ class TestDescription(common.PyTablesTestCase):
     def test_dtype_from_descr_dict(self):
         # See gh-152
         dtype = np.dtype([('col1', 'int16'), ('col2', float)])
-        t = tb.description.dtype_from_descr({'col1': tb.Int16Col(), 'col2': tb.FloatCol()})
+        t = tb.description.dtype_from_descr(
+            {'col1': tb.Int16Col(), 'col2': tb.FloatCol()})
 
         self.assertEqual(t, dtype)
 

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1285,11 +1285,11 @@ class CheckFileTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def test04b_UnImplementedOnLoading(self):
         """Checking failure loading resulting in an ``UnImplemented`` node."""
 
-        ############### Note for developers ###############################
+        # ############## Note for developers ##############################
         # This test fails if you have the line:                           #
         # ##return ChildClass(self, childname)  # uncomment for debugging #
         # uncommented in Group.py!                                        #
-        ###################################################################
+        # #################################################################
 
         h5fname = common.test_filename('smpl_unsupptype.h5')
         with tb.open_file(h5fname) as h5file:
@@ -1734,7 +1734,7 @@ class StateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         node._f_close()
         self.assertRaises(tb.ClosedNodeError, getattr, node, '_v_attrs')
         # The design of ``AttributeSet`` does not yet allow this test.
-        ## self.assertRaises(ClosedNodeError, getattr, nodeAttrs, 'test')
+        # self.assertRaises(ClosedNodeError, getattr, nodeAttrs, 'test')
 
         self.assertEqual(self.h5file.get_node_attr('/test', 'test'), attr)
 
@@ -2498,7 +2498,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-## Local Variables:
-## mode: python
-## End:

--- a/tables/tests/test_basics.py
+++ b/tables/tests/test_basics.py
@@ -1676,16 +1676,16 @@ class StateTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Already open nodes should be closed now, but not the new ones.
         self.assertIs(g2._v_isopen, False,
-                        "open child of closed group has not been closed")
+                      "open child of closed group has not been closed")
         self.assertIs(g2_._v_isopen, True,
-                        "open child of closed group has not been closed")
+                      "open child of closed group has not been closed")
 
         # And existing closed ones should remain closed, but not the new ones.
         g1_ = self.h5file.get_node('/g1')
         self.assertIs(g1._v_isopen, False,
-                        "already closed group is not closed anymore")
+                      "already closed group is not closed anymore")
         self.assertIs(g1_._v_isopen, True,
-                        "newly opened group is still closed")
+                      "newly opened group is still closed")
 
     def test19b_getNode(self):
         """Test getting a node that does not start with a slash ('/')."""

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -2061,8 +2061,8 @@ class Rows64bitsTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if stop > 127:
             stop -= 256
         start = stop - 10
-        self.assertTrue(common.allequal(array[-10:],
-                                 np.arange(start, stop, dtype='int8')))
+        self.assertTrue(common.allequal(
+            array[-10:], np.arange(start, stop, dtype='int8')))
 
 
 class Rows64bitsTestCase1(Rows64bitsTestCase):

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -2815,9 +2815,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -2005,9 +2005,9 @@ class Rows64bitsTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Fill the array
         na = np.arange(self.narows, dtype='int8')
-        #~ for i in xrange(self.nanumber):
-            #~ s = slice(i * self.narows, (i + 1)*self.narows)
-            #~ array[s] = na
+        # for i in xrange(self.nanumber):
+        #     s = slice(i * self.narows, (i + 1)*self.narows)
+        #     array[s] = na
         s = slice(0, self.narows)
         array[s] = na
         s = slice((self.nanumber-1)*self.narows, self.nanumber * self.narows)

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -2574,7 +2574,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                                           title=self.title,
                                           chunkshape=self.chunkshape,
                                           atom=self.atom, shape=self.shape)
-        #ptarr[...] = self.obj
+        # ptarr[...] = self.obj
         self.h5file.close()
 
         self.h5file = tb.open_file(self.h5fname)
@@ -2648,7 +2648,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_error(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,
                           self.where,
@@ -2658,7 +2658,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           atom=atom)
 
     def test_kwargs_obj_shape_error(self):
-        #atom = Atom.from_dtype(numpy.dtype('complex'))
+        # atom = Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,
@@ -2670,7 +2670,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_shape_error_01(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,
                           self.where,
@@ -2681,7 +2681,7 @@ class TestCreateCArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           shape=self.shape)
 
     def test_kwargs_obj_atom_shape_error_02(self):
-        #atom = Atom.from_dtype(numpy.dtype('complex'))
+        # atom = Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_carray,

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -457,7 +457,8 @@ class EmptyCArray2TestCase(BasicTestCase):
     reopen = 0  # This case does not reopen files
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class SlicesCArrayTestCase(BasicTestCase):
     compress = 1
     complib = "lzo"
@@ -475,7 +476,8 @@ class EllipsisCArrayTestCase(BasicTestCase):
     slices = (Ellipsis, slice(1, 2, 1))
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class Slices2CArrayTestCase(BasicTestCase):
     compress = 1
     complib = "lzo"
@@ -492,7 +494,8 @@ class Ellipsis2CArrayTestCase(BasicTestCase):
     slices = (slice(1, 2, 1), Ellipsis, slice(1, 4, 2))
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class Slices3CArrayTestCase(BasicTestCase):
     compress = 1      # To show the chunks id DEBUG is on
     complib = "lzo"
@@ -662,8 +665,9 @@ class BloscShuffleTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
-                        'BLOSC >= %s required' % common.min_blosc_bitshuffle_version)
+@common.unittest.skipIf(
+    common.blosc_version < common.min_blosc_bitshuffle_version,
+    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class BloscBitShuffleTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -705,7 +709,8 @@ class BloscBloscLZTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4TestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -719,7 +724,8 @@ class BloscLZ4TestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4HCTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -748,7 +754,8 @@ class BloscSnappyTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
+@common.unittest.skipIf(
+    'zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class BloscZlibTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -762,7 +769,8 @@ class BloscZlibTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
+@common.unittest.skipIf(
+    'zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class BloscZstdTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -774,7 +782,8 @@ class BloscZstdTestCase(BasicTestCase):
     step = 7
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class LZOComprTestCase(BasicTestCase):
     compress = 1  # sss
     complib = "lzo"
@@ -784,7 +793,8 @@ class LZOComprTestCase(BasicTestCase):
     step = 3
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class LZOShuffleTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1
@@ -1060,8 +1070,9 @@ class ReadOutArgumentTests(common.TempFileMixin, common.PyTablesTestCase):
 
     def create_array(self):
         array = np.arange(self.size, dtype='i8')
-        disk_array = self.h5file.create_carray('/', 'array', atom=tb.Int64Atom(),
-                                               shape=(self.size, ),
+        disk_array = self.h5file.create_carray('/', 'array',
+                                               atom=tb.Int64Atom(),
+                                               shape=(self.size,),
                                                filters=self.filters)
         disk_array[:] = array
         return array, disk_array
@@ -1096,7 +1107,8 @@ class ReadOutArgumentTests(common.TempFileMixin, common.PyTablesTestCase):
             self.assertIn('output array size invalid, got', str(exc))
 
 
-class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin,
+                                         common.PyTablesTestCase):
 
     def setUp(self):
         super().setUp()
@@ -1262,9 +1274,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Third row in carray ==>", data[2])
 
         self.assertEqual(carray.nrows, 3)
-        self.assertTrue(common.allequal(data[0], np.array([1, 1, 1], dtype='int32')))
-        self.assertTrue(common.allequal(data[1], np.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(common.allequal(data[2], np.array([-1, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[0], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[1], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[2], np.array([-1, 0, 0], dtype='int32')))
 
     def test02b_int(self):
         """Checking carray with strided NumPy ints appends."""
@@ -1295,9 +1310,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Third row in carray ==>", data[2])
 
         self.assertEqual(carray.nrows, 3)
-        self.assertTrue(common.allequal(data[0], np.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(common.allequal(data[1], np.array([3, 3, 3], dtype='int32')))
-        self.assertTrue(common.allequal(data[2], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[0], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[1], np.array([3, 3, 3], dtype='int32')))
+        self.assertTrue(common.allequal(
+            data[2], np.array([1, 1, 1], dtype='int32')))
 
 
 class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
@@ -2055,7 +2073,8 @@ class Rows64bitsTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(array.shape, (nrows,))
 
         # check the 10 first elements
-        self.assertTrue(common.allequal(array[:10], np.arange(10, dtype='int8')))
+        self.assertTrue(common.allequal(
+            array[:10], np.arange(10, dtype='int8')))
 
         # check the 10 last elements
         stop = self.narows % 256
@@ -2109,9 +2128,9 @@ class DfltAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         """Check that Atom.dflt is honored (string version)."""
 
         # Create a CArray with default values
-        self.h5file.create_carray('/', 'bar',
-                                  atom=tb.StringAtom(itemsize=5, dflt=b"abdef"),
-                                  shape=(10, 10))
+        self.h5file.create_carray(
+            '/', 'bar', atom=tb.StringAtom(itemsize=5, dflt=b"abdef"),
+            shape=(10, 10))
 
         if self.reopen:
             self._reopen()
@@ -2120,8 +2139,8 @@ class DfltAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         values = self.h5file.root.bar[:]
         if common.verbose:
             print("Read values:", values)
-        self.assertTrue(
-            common.allequal(values, np.array(["abdef"]*100, "S5").reshape(10, 10)))
+        self.assertTrue(common.allequal(
+            values, np.array(["abdef"] * 100, "S5").reshape(10, 10)))
 
     def test01_dflt(self):
         """Check that Atom.dflt is honored (int version)."""
@@ -2143,8 +2162,8 @@ class DfltAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         """Check that Atom.dflt is honored (float version)."""
 
         # Create a CArray with default values
-        self.h5file.create_carray('/', 'bar',
-                                  atom=tb.FloatAtom(dflt=1.134), shape=(10, 10))
+        self.h5file.create_carray(
+            '/', 'bar', atom=tb.FloatAtom(dflt=1.134), shape=(10, 10))
 
         if self.reopen:
             self._reopen()
@@ -2230,7 +2249,8 @@ class AtomDefaultReprTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row-->", ca[0])
             print("Defaults-->", ca.atom.dflt)
         self.assertTrue(common.allequal(ca[0], np.ones(N, 'f4')*generic))
-        self.assertTrue(common.allequal(ca.atom.dflt, np.ones(N, 'f4')*generic))
+        self.assertTrue(common.allequal(
+            ca.atom.dflt, np.ones(N, 'f4')*generic))
 
     def test02a_None(self):
         """Testing default values.  None (scalar)."""
@@ -2296,7 +2316,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ca.nrows, 1)
         if common.verbose:
             print("First row-->", ca[0])
-        self.assertTrue(common.allequal(ca[0], np.array([[1, 3], [4, 5]], 'i4')))
+        self.assertTrue(common.allequal(
+            ca[0], np.array([[1, 3], [4, 5]], 'i4')))
 
     def test01b_assign(self):
         """Assign several rows to a (unidimensional) CArray with a MD atom."""
@@ -2312,7 +2333,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ca.nrows, 3)
         if common.verbose:
             print("Third row-->", ca[2])
-        self.assertTrue(common.allequal(ca[2], np.array([[3, 3], [3, 3]], 'i4')))
+        self.assertTrue(common.allequal(
+            ca[2], np.array([[3, 3], [3, 3]], 'i4')))
 
     def test02a_assign(self):
         """Assign a row to a (multidimensional) CArray with a MD atom."""
@@ -2348,15 +2370,15 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ca.nrows, 3)
         if common.verbose:
             print("Third row-->", ca[2])
-        self.assertTrue(
-            common.allequal(ca[2], np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
+        self.assertTrue(common.allequal(
+            ca[2], np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
 
     def test03a_MDMDMD(self):
         """Complex assign of a MD array in a MD CArray with a MD atom."""
 
         # Create an CArray
-        ca = self.h5file.create_carray('/', 'test',
-                                       atom=tb.Int32Atom((2, 4)), shape=(3, 2, 3))
+        ca = self.h5file.create_carray(
+            '/', 'test', atom=tb.Int32Atom((2, 4)), shape=(3, 2, 3))
         if self.reopen:
             self._reopen('a')
             ca = self.h5file.root.test
@@ -2393,8 +2415,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         """Complex assign of a MD array in a MD CArray with a MD atom (III)."""
 
         # Create an CArray
-        ca = self.h5file.create_carray('/', 'test',
-                                       atom=tb.Int32Atom((2, 4)), shape=(3, 1, 2))
+        ca = self.h5file.create_carray(
+            '/', 'test', atom=tb.Int32Atom((2, 4)), shape=(3, 1, 2))
         if self.reopen:
             self._reopen('a')
             ca = self.h5file.root.test

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -63,8 +63,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if self.flavor == "numpy":
             if self.type == "string":
                 object = np.ndarray(buffer=b"a"*self.objsize,
-                                       shape=self.shape,
-                                       dtype="S%s" % carray.atom.itemsize)
+                                    shape=self.shape,
+                                    dtype="S%s" % carray.atom.itemsize)
             else:
                 object = np.arange(self.objsize, dtype=carray.atom.dtype)
                 object.shape = carray.shape

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -759,6 +759,7 @@ class BloscZlibTestCase(BasicTestCase):
     stop = 10
     step = 7
 
+
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
 @common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -594,7 +594,7 @@ class FiltersCase10(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class FiltersCaseBloscBloscLZ(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:blosclz")
     gfilters = tb.Filters(complevel=5, shuffle=True, complib="blosc:blosclz")
@@ -602,7 +602,7 @@ class FiltersCaseBloscBloscLZ(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class FiltersCaseBloscLZ4(FiltersTreeTestCase):
     def setUp(self):
@@ -613,7 +613,7 @@ class FiltersCaseBloscLZ4(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class FiltersCaseBloscLZ4HC(FiltersTreeTestCase):
     def setUp(self):
@@ -626,9 +626,9 @@ class FiltersCaseBloscLZ4HC(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('snappy' not in tb.blosc_compressor_list(),
-                 'snappy required')
+                        'snappy required')
 class FiltersCaseBloscSnappy(FiltersTreeTestCase):
     def setUp(self):
         self.filters = tb.Filters(
@@ -640,7 +640,7 @@ class FiltersCaseBloscSnappy(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class FiltersCaseBloscZlib(FiltersTreeTestCase):
     def setUp(self):
@@ -651,7 +651,7 @@ class FiltersCaseBloscZlib(FiltersTreeTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class FiltersCaseBloscZstd(FiltersTreeTestCase):
     def setUp(self):
@@ -829,10 +829,10 @@ class CopyGroupTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
-                                                        srcattrskeys))
-                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
-                                                        dstattrskeys))
+                print(f"srcattrskeys for node {srcnode._v_name}: "
+                      f"{srcattrskeys}")
+                print(f"dstattrskeys for node {dstnode._v_name}: "
+                      f"{dstattrskeys}")
             self.assertEqual(srcattrskeys, dstattrskeys)
             if common.verbose:
                 print("The attrs names has been copied correctly")
@@ -1235,10 +1235,10 @@ class CopyFileTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
-                                                        srcattrskeys))
-                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
-                                                        dstattrskeys))
+                print(f"srcattrskeys for node {srcnode._v_name}: "
+                      f"{srcattrskeys}")
+                print(f"dstattrskeys for node {dstnode._v_name}: "
+                      f"{dstattrskeys}")
             self.assertEqual(srcattrskeys, dstattrskeys)
             if common.verbose:
                 print("The attrs names has been copied correctly")
@@ -1284,10 +1284,10 @@ class CopyFileTestCase(common.TempFileMixin, common.PyTablesTestCase):
             dstattrskeys = dstattrs._f_list("all")
             # These lists should already be ordered
             if common.verbose:
-                print("srcattrskeys for node {}: {}".format(srcnode._v_name,
-                                                        srcattrskeys))
-                print("dstattrskeys for node {}: {}".format(dstnode._v_name,
-                                                        dstattrskeys))
+                print(f"srcattrskeys for node {srcnode._v_name}: "
+                      f"{srcattrskeys}")
+                print(f"dstattrskeys for node {dstnode._v_name}: "
+                      f"{dstattrskeys}")
 
             # Filters may differ, do not take into account
             if self.filters is not None:
@@ -2429,7 +2429,7 @@ class QuantizeTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def populateFile(self):
         root = self.h5file.root
         filters = tb.Filters(complevel=1, complib="blosc",
-                          least_significant_digit=1)
+                             least_significant_digit=1)
         ints = self.h5file.create_carray(root, "integers", tb.Int64Atom(),
                                          (1_000_000,), filters=filters)
         ints[:] = self.randomints
@@ -2440,17 +2440,17 @@ class QuantizeTestCase(common.TempFileMixin, common.PyTablesTestCase):
                                           (41,), filters=filters)
         data1[:] = self.data
         filters = tb.Filters(complevel=1, complib="blosc",
-                          least_significant_digit=0)
+                             least_significant_digit=0)
         data0 = self.h5file.create_carray(root, "data0", tb.Float64Atom(),
                                           (41,), filters=filters)
         data0[:] = self.data
         filters = tb.Filters(complevel=1, complib="blosc",
-                          least_significant_digit=2)
+                             least_significant_digit=2)
         data2 = self.h5file.create_carray(root, "data2", tb.Float64Atom(),
                                           (41,), filters=filters)
         data2[:] = self.data
         filters = tb.Filters(complevel=1, complib="blosc",
-                          least_significant_digit=-1)
+                             least_significant_digit=-1)
         datam1 = self.h5file.create_carray(root, "datam1", tb.Float64Atom(),
                                            (41,), filters=filters)
         datam1[:] = self.data

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -213,7 +213,7 @@ class CreateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         # Build a dictionary with the types as values and varnames as keys
         recordDict = {}
         recordDict["a" * 255] = tb.IntCol(dflt=1)
-        recordDict["b" * 256] = tb.IntCol(dflt=1)  # Should trigger a ValueError
+        recordDict["b" * 256] = tb.IntCol(dflt=1)  # Should raise a ValueError
 
         # Now, create a table with this record object
         # This way of creating node objects has been deprecated
@@ -293,10 +293,10 @@ class FiltersTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
             ea2.append(var3List)
 
             # Finally a couple of VLArrays too
-            vla1 = self.h5file.create_vlarray(group, 'vlarray1',
-                                              tb.StringAtom(itemsize=4), "col 1")
-            vla2 = self.h5file.create_vlarray(group, 'vlarray2',
-                                              tb.Int16Atom(), "col 3")
+            vla1 = self.h5file.create_vlarray(
+                group, 'vlarray1', tb.StringAtom(itemsize=4), "col 1")
+            vla2 = self.h5file.create_vlarray(
+                group, 'vlarray2', tb.Int16Atom(), "col 3")
             # And fill them with some values
             vla1.append(var1List)
             vla2.append(var3List)
@@ -543,7 +543,8 @@ class FiltersCase2(FiltersTreeTestCase):
     open_kwargs = dict(filters=filters)
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class FiltersCase3(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=True, complib="zlib")
     gfilters = tb.Filters(complevel=1, shuffle=False, complib="lzo")
@@ -580,14 +581,16 @@ class FiltersCase8(FiltersTreeTestCase):
     open_kwargs = dict(filters=filters)
 
 
-@common.unittest.skipIf(not common.bzip2_avail, 'BZIP2 compression library not available')
+@common.unittest.skipIf(not common.bzip2_avail,
+                        'BZIP2 compression library not available')
 class FiltersCase9(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=True, complib="zlib")
     gfilters = tb.Filters(complevel=5, shuffle=True, complib="bzip2")
     open_kwargs = dict(filters=filters)
 
 
-@common.unittest.skipIf(not common.blosc_avail, 'BLOSC compression library not available')
+@common.unittest.skipIf(not common.blosc_avail,
+                        'BLOSC compression library not available')
 class FiltersCase10(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=False, complevel=1, complib="blosc")
     gfilters = tb.Filters(complevel=5, shuffle=True, complib="blosc")
@@ -604,18 +607,22 @@ class FiltersCaseBloscBloscLZ(FiltersTreeTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class FiltersCaseBloscLZ4(FiltersTreeTestCase):
     def setUp(self):
-        self.filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:lz4")
-        self.gfilters = tb.Filters(complevel=5, shuffle=True, complib="blosc:lz4")
+        self.filters = tb.Filters(shuffle=False, complevel=1,
+                                  complib="blosc:lz4")
+        self.gfilters = tb.Filters(complevel=5, shuffle=True,
+                                   complib="blosc:lz4")
         self.open_kwargs = dict(filters=self.filters)
         super().setUp()
 
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class FiltersCaseBloscLZ4HC(FiltersTreeTestCase):
     def setUp(self):
         self.filters = tb.Filters(
@@ -642,33 +649,41 @@ class FiltersCaseBloscSnappy(FiltersTreeTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
+@common.unittest.skipIf(
+    'zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class FiltersCaseBloscZlib(FiltersTreeTestCase):
     def setUp(self):
-        self.filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:zlib")
-        self.gfilters = tb.Filters(complevel=5, shuffle=True, complib="blosc:zlib")
+        self.filters = tb.Filters(shuffle=False, complevel=1,
+                                  complib="blosc:zlib")
+        self.gfilters = tb.Filters(complevel=5, shuffle=True,
+                                   complib="blosc:zlib")
         self.open_kwargs = dict(filters=self.filters)
         super().setUp()
 
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
+@common.unittest.skipIf(
+    'zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class FiltersCaseBloscZstd(FiltersTreeTestCase):
     def setUp(self):
-        self.filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:zstd")
-        self.gfilters = tb.Filters(complevel=5, shuffle=True, complib="blosc:zstd")
+        self.filters = tb.Filters(shuffle=False, complevel=1,
+                                  complib="blosc:zstd")
+        self.gfilters = tb.Filters(complevel=5, shuffle=True,
+                                   complib="blosc:zstd")
         self.open_kwargs = dict(filters=self.filters)
         super().setUp()
 
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
-                        'BLOSC >= %s required' % common.min_blosc_bitshuffle_version)
+@common.unittest.skipIf(
+    common.blosc_version < common.min_blosc_bitshuffle_version,
+    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class FiltersCaseBloscBitShuffle(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:blosclz")
-    gfilters = tb.Filters(complevel=5, shuffle=False, bitshuffle=True, complib="blosc:blosclz")
+    gfilters = tb.Filters(complevel=5, shuffle=False, bitshuffle=True,
+                          complib="blosc:blosclz")
     open_kwargs = dict(filters=filters)
     # print("version:", tables.which_lib_version("blosc")[1])
 
@@ -728,8 +743,8 @@ class CopyGroupTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
                 # Create a couple of EArrays as well
                 ea1 = self.h5file.create_earray(group2, 'earray1',
-                                                tb.StringAtom(itemsize=4), (0,),
-                                                "col 1")
+                                                tb.StringAtom(itemsize=4),
+                                                (0,), "col 1")
                 ea2 = self.h5file.create_earray(group2, 'earray2',
                                                 tb.Int16Atom(), (0,), "col 3")
                 # Add some user attrs:
@@ -1009,7 +1024,8 @@ class CopyGroupCase7(CopyGroupTestCase):
     dstnode = '/'
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class CopyGroupCase8(CopyGroupTestCase):
     close = 1
     filters = tb.Filters(complevel=1, complib="lzo")
@@ -1071,8 +1087,8 @@ class CopyFileTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
                 # Create a couple of EArrays as well
                 ea1 = self.h5file.create_earray(group2, 'earray1',
-                                                tb.StringAtom(itemsize=4), (0,),
-                                                "col 1")
+                                                tb.StringAtom(itemsize=4),
+                                                (0,), "col 1")
                 ea2 = self.h5file.create_earray(group2, 'earray2',
                                                 tb.Int16Atom(), (0,),
                                                 "col 3")
@@ -1493,7 +1509,8 @@ class GroupFiltersTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail, 'BLOSC not available')
-class SetBloscMaxThreadsTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SetBloscMaxThreadsTestCase(common.TempFileMixin,
+                                 common.PyTablesTestCase):
     filters = tb.Filters(complevel=4, complib="blosc")
 
     def test00(self):
@@ -1741,7 +1758,8 @@ class DefaultDriverTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(root.table2.cols.var2.dtype, tb.FloatCol().dtype)
 
 
-@common.unittest.skipIf(common.hdf5_version < "1.8.9", "requires HDF5 >= 1.8,9")
+@common.unittest.skipIf(common.hdf5_version < "1.8.9",
+                        "requires HDF5 >= 1.8,9")
 class Sec2DriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_SEC2"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -1752,7 +1770,8 @@ class Sec2DriverTestCase(DefaultDriverTestCase):
         self.assertEqual([i for i in image[:4]], [137, 72, 68, 70])
 
 
-@common.unittest.skipIf(common.hdf5_version < "1.8.9", "requires HDF5 >= 1.8,9")
+@common.unittest.skipIf(common.hdf5_version < "1.8.9",
+                        "requires HDF5 >= 1.8,9")
 class StdioDriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_STDIO"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -1763,7 +1782,8 @@ class StdioDriverTestCase(DefaultDriverTestCase):
         self.assertEqual([i for i in image[:4]], [137, 72, 68, 70])
 
 
-@common.unittest.skipIf(common.hdf5_version < "1.8.9", "requires HDF5 >= 1.8,9")
+@common.unittest.skipIf(common.hdf5_version < "1.8.9",
+                        "requires HDF5 >= 1.8,9")
 class CoreDriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_CORE"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -1991,7 +2011,8 @@ class CoreDriverNoBackingStoreTestCase(common.PyTablesTestCase):
         # ensure that there is no change on the file on disk
         self.assertEqual(hexdigest, self._get_digest(self.h5fname))
 
-    @common.unittest.skipIf(common.hdf5_version < "1.8.9", 'HDF5 >= "1.8.9" required')
+    @common.unittest.skipIf(common.hdf5_version < "1.8.9",
+                            'HDF5 >= "1.8.9" required')
     def test_get_file_image(self):
         self.h5file = tb.open_file(self.h5fname, mode="w",
                                    driver=self.DRIVER,
@@ -2133,7 +2154,8 @@ class StreamDriverTestCase(NotSpportedDriverTestCase):
     DRIVER = "H5FD_STREAM"
 
 
-@common.unittest.skipIf(common.hdf5_version < "1.8.9", 'HDF5 >= "1.8.9" required')
+@common.unittest.skipIf(common.hdf5_version < "1.8.9",
+                        'HDF5 >= "1.8.9" required')
 class InMemoryCoreDriverTestCase(common.PyTablesTestCase):
     DRIVER = "H5FD_CORE"
 
@@ -2391,8 +2413,8 @@ class InMemoryCoreDriverTestCase(common.PyTablesTestCase):
 
         self.h5file.create_array(self.h5file.root, 'array', [1, 2],
                                  title="Array")
-        self.h5file.create_table(self.h5file.root, 'table', {'var1': tb.IntCol()},
-                                 "Table")
+        self.h5file.create_table(self.h5file.root, 'table',
+                                 {'var1': tb.IntCol()}, "Table")
         self.h5file.root._v_attrs.testattr = 41
 
         # ensure that the __str__ method works even if there is no phisical
@@ -2531,7 +2553,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(Sec2DriverTestCase))
         theSuite.addTest(common.unittest.makeSuite(StdioDriverTestCase))
         theSuite.addTest(common.unittest.makeSuite(CoreDriverTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CoreDriverNoBackingStoreTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            CoreDriverNoBackingStoreTestCase))
         theSuite.addTest(common.unittest.makeSuite(SplitDriverTestCase))
 
         theSuite.addTest(common.unittest.makeSuite(LogDriverTestCase))

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -1505,7 +1505,7 @@ class SetBloscMaxThreadsTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(nthreads_old, self.h5file.params['MAX_BLOSC_THREADS'])
         self.h5file.create_carray('/', 'some_array',
                                   atom=tb.Int32Atom(), shape=(3, 3),
-                                  filters = self.filters)
+                                  filters=self.filters)
         nthreads_old = tb.set_blosc_max_threads(1)
         if common.verbose:
             print("Previous max threads:", nthreads_old)
@@ -1518,7 +1518,7 @@ class SetBloscMaxThreadsTestCase(common.TempFileMixin, common.PyTablesTestCase):
         nthreads_old = tb.set_blosc_max_threads(4)
         self.h5file.create_carray('/', 'some_array',
                                   atom=tb.Int32Atom(), shape=(3, 3),
-                                  filters = self.filters)
+                                  filters=self.filters)
         self._reopen()
         nthreads_old = tb.set_blosc_max_threads(4)
         if common.verbose:

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -20,6 +20,7 @@ import numpy as np
 import tables as tb
 from tables.tests import common
 
+
 class Record(tb.IsDescription):
     var1 = tb.StringCol(itemsize=4)  # 4-character String
     var2 = tb.IntCol()               # integer

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -793,8 +793,8 @@ class CopyGroupTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         if common.verbose:
             print('\n', '-=' * 30)
-            print("Running %s.test01_nonRecursiveAttrs..." %
-                   self.__class__.__name__)
+            print(f"Running {self.__class__.__name__}"
+                  f".test01_nonRecursiveAttrs...")
 
         # Copy a group non-recursively with attrs
         srcgroup = self.h5file.root.group0.group1
@@ -909,8 +909,8 @@ class CopyGroupTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         if common.verbose:
             print('\n', '-=' * 30)
-            print("Running %s.test03_RecursiveFilters..." %
-                   self.__class__.__name__)
+            print(f"Running {self.__class__.__name__}"
+                  f".test03_RecursiveFilters...")
 
         # Create the destination node
         group = self.h5file2.root

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -765,8 +765,8 @@ class CopyGroupTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Copy a group non-recursively
         srcgroup = self.h5file.root.group0.group1
-        #srcgroup._f_copy_children(self.h5file2.root, recursive=False,
-        #                          filters=self.filters)
+        # srcgroup._f_copy_children(self.h5file2.root, recursive=False,
+        #                           filters=self.filters)
         self.h5file.copy_children(srcgroup, self.h5file2.root,
                                   recursive=False, filters=self.filters)
         if self.close:
@@ -2029,7 +2029,7 @@ class SplitDriverTestCase(DefaultDriverTestCase):
         for fname in self.h5fnames:
             if Path(fname).is_file():
                 Path(fname).unlink()
-        #super().tearDown()
+        # super().tearDown()
         common.PyTablesTestCase.tearDown(self)
 
     def assertIsFile(self):
@@ -2475,16 +2475,10 @@ class QuantizeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         quantized_2 = tb.utils.quantize(self.randomdata, 2)
         quantized_m1 = tb.utils.quantize(self.randomdata, -1)
 
-        # assertLess is new in Python 2.7
-        #self.assertLess(numpy.abs(quantized_0 - self.randomdata).max(), 0.5)
-        #self.assertLess(numpy.abs(quantized_1 - self.randomdata).max(), 0.05)
-        #self.assertLess(numpy.abs(quantized_2 - self.randomdata).max(), 0.005)
-        #self.assertLess(numpy.abs(quantized_m1 - self.randomdata).max(), 1.)
-
-        self.assertTrue(np.abs(quantized_0 - self.randomdata).max() < 0.5)
-        self.assertTrue(np.abs(quantized_1 - self.randomdata).max() < 0.05)
-        self.assertTrue(np.abs(quantized_2 - self.randomdata).max() < 0.005)
-        self.assertTrue(np.abs(quantized_m1 - self.randomdata).max() < 1.)
+        self.assertLess(np.abs(quantized_0 - self.randomdata).max(), 0.5)
+        self.assertLess(np.abs(quantized_1 - self.randomdata).max(), 0.05)
+        self.assertLess(np.abs(quantized_2 - self.randomdata).max(), 0.005)
+        self.assertLess(np.abs(quantized_m1 - self.randomdata).max(), 1.)
 
     def test02_array(self):
         """Checking quantized data as written to disk."""
@@ -2501,14 +2495,8 @@ class QuantizeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(self.h5file.root.integers[:].dtype,
                          self.randomints.dtype)
 
-        # assertLess is new in Python 2.7
-        #self.assertLess(
-        #    numpy.abs(self.h5file.root.floats[:] - self.randomdata).max(),
-        #    0.05
-        #)
-        self.assertTrue(
-            np.abs(self.h5file.root.floats[:] - self.randomdata).max() < 0.05
-        )
+        self.assertLess(
+            np.abs(self.h5file.root.floats[:] - self.randomdata).max(), 0.05)
 
 
 def suite():

--- a/tables/tests/test_do_undo.py
+++ b/tables/tests/test_do_undo.py
@@ -2728,7 +2728,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-## Local Variables:
-## mode: python
-## End:

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -354,7 +354,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 stop = rowshape[self.extdim]
             # do a copy() in order to ensure that len(object._data)
             # actually do a measure of its length
-            #object = object__[self.start:stop:self.step].copy()
+            # object = object__[self.start:stop:self.step].copy()
             object = object__[self.start:self.stop:self.step].copy()
             # Swap the axes again to have normal ordering
             if self.flavor == "numpy":
@@ -458,7 +458,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 stop = rowshape[self.extdim]
             # do a copy() in order to ensure that len(object._data)
             # actually do a measure of its length
-            #object = object__[self.start:stop:self.step].copy()
+            # object = object__[self.start:stop:self.step].copy()
             object = object__[self.start:self.stop:self.step].copy()
             # Swap the axes again to have normal ordering
             if self.flavor == "numpy":
@@ -470,7 +470,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         try:
             row = np.empty(earray.shape, dtype=earray.atom.dtype)
             slice_obj = [slice(None)] * len(earray.shape)
-            #slice_obj[earray.maindim] = slice(self.start, stop, self.step)
+            # slice_obj[earray.maindim] = slice(self.start, stop, self.step)
             slice_obj[earray.maindim] = slice(self.start, self.stop, self.step)
             row = row[tuple(slice_obj)].copy()
             earray.read(self.start, self.stop, self.step, out=row)
@@ -2645,7 +2645,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                                           title=self.title,
                                           chunkshape=self.chunkshape,
                                           atom=self.atom, shape=self.shape)
-        #ptarr.append(self.obj)
+        # ptarr.append(self.obj)
 
         self._reopen()
 
@@ -2721,7 +2721,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_error(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,
                           self.where,
@@ -2731,7 +2731,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           atom=atom)
 
     def test_kwargs_obj_shape_error(self):
-        #atom = tables.Atom.from_dtype(numpy.dtype('complex'))
+        # atom = tables.Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,
@@ -2743,7 +2743,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_shape_error_01(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,
                           self.where,
@@ -2754,7 +2754,7 @@ class TestCreateEArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
                           shape=self.shape)
 
     def test_kwargs_obj_atom_shape_error_02(self):
-        #atom = tables.Atom.from_dtype(numpy.dtype('complex'))
+        # atom = tables.Atom.from_dtype(numpy.dtype('complex'))
         shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_earray,

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -153,8 +153,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         # Read all the array
         for idx, row in enumerate(earray):
             if idx < initialrows:
-                self.assertTrue(
-                    common.allequal(row, np.asarray(self.obj[idx]), self.flavor))
+                self.assertTrue(common.allequal(
+                    row, np.asarray(self.obj[idx]), self.flavor))
                 continue
 
             chunk = int((earray.nrow - initialrows) % self.chunksize)
@@ -241,8 +241,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                                                   stop=self.stop,
                                                   step=self.step)):
             if idx < initialrows:
-                self.assertTrue(
-                    common.allequal(row, np.asarray(self.obj[idx]), self.flavor))
+                self.assertTrue(common.allequal(
+                    row, np.asarray(self.obj[idx]), self.flavor))
                 continue
 
             if self.chunksize == 1:
@@ -843,7 +843,8 @@ class Empty2EArrayTestCase(BasicTestCase):
     reopen = 0  # This case does not reopen files
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class SlicesEArrayTestCase(BasicTestCase):
     compress = 1
     complib = "lzo"
@@ -1080,7 +1081,8 @@ class BloscShuffleTestCase(BasicTestCase):
     step = 7
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class LZOComprTestCase(BasicTestCase):
     compress = 1  # sss
     complib = "lzo"
@@ -1091,7 +1093,8 @@ class LZOComprTestCase(BasicTestCase):
     step = 3
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class LZOShuffleTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
@@ -1216,7 +1219,8 @@ class StringComprTestCase(BasicTestCase):
     step = 20
 
 
-class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin,
+                                         common.PyTablesTestCase):
 
     def setUp(self):
         super().setUp()
@@ -1230,7 +1234,8 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
 
     def create_array(self, complevel):
         filters = tb.Filters(complevel=complevel, complib='blosc')
-        self.array = self.h5file.create_earray('/', 'earray', atom=tb.Int32Atom(),
+        self.array = self.h5file.create_earray('/', 'earray',
+                                               atom=tb.Int32Atom(),
                                                shape=self.array_size,
                                                filters=filters,
                                                chunkshape=self.chunkshape)
@@ -1364,9 +1369,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Third row in vlarray ==>", row[2])
 
         self.assertEqual(earray.nrows, 3)
-        self.assertTrue(common.allequal(row[0], np.array([1, 1, 1], dtype='int32')))
-        self.assertTrue(common.allequal(row[1], np.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(common.allequal(row[2], np.array([-1, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[2], np.array([-1, 0, 0], dtype='int32')))
 
     def test02b_int(self):
         """Checking earray with strided NumPy ints appends."""
@@ -1393,9 +1401,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Third row in vlarray ==>", row[2])
 
         self.assertEqual(earray.nrows, 3)
-        self.assertTrue(common.allequal(row[0], np.array([0, 0, 0], dtype='int32')))
-        self.assertTrue(common.allequal(row[1], np.array([3, 3, 3], dtype='int32')))
-        self.assertTrue(common.allequal(row[2], np.array([1, 1, 1], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([0, 0, 0], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([3, 3, 3], dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[2], np.array([1, 1, 1], dtype='int32')))
 
     def test03a_int(self):
         """Checking earray with byteswapped appends (ints)"""
@@ -1488,10 +1499,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
         native = earray[:4, :]
         swapped = earray[4:, :]
         if common.verbose:
-            print("Byteorder native rows:", tb.utils.byteorders[native.dtype.byteorder])
+            print("Byteorder native rows:",
+                  tb.utils.byteorders[native.dtype.byteorder])
             print("Byteorder earray on-disk:", earray.byteorder)
 
-        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder], sys.byteorder)
+        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder],
+                         sys.byteorder)
         self.assertEqual(earray.byteorder, byteorder)
         self.assertTrue(common.allequal(native, swapped))
 
@@ -1524,10 +1537,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
         native = earray[:4, :]
         swapped = earray[4:, :]
         if common.verbose:
-            print("Byteorder native rows:", tb.utils.byteorders[native.dtype.byteorder])
+            print("Byteorder native rows:",
+                  tb.utils.byteorders[native.dtype.byteorder])
             print("Byteorder earray on-disk:", earray.byteorder)
 
-        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder], sys.byteorder)
+        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder],
+                         sys.byteorder)
         self.assertEqual(earray.byteorder, byteorder)
         self.assertTrue(common.allequal(native, swapped))
 
@@ -1558,10 +1573,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
         native = earray[:4, :]
         swapped = earray[4:, :]
         if common.verbose:
-            print("Byteorder native rows:", tb.utils.byteorders[native.dtype.byteorder])
+            print("Byteorder native rows:",
+                  tb.utils.byteorders[native.dtype.byteorder])
             print("Byteorder earray on-disk:", earray.byteorder)
 
-        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder], sys.byteorder)
+        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder],
+                         sys.byteorder)
         self.assertEqual(earray.byteorder, byteorder)
         self.assertTrue(common.allequal(native, swapped))
 
@@ -1594,10 +1611,12 @@ class OffsetStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
         native = earray[:4, :]
         swapped = earray[4:, :]
         if common.verbose:
-            print("Byteorder native rows:", tb.utils.byteorders[native.dtype.byteorder])
+            print("Byteorder native rows:",
+                  tb.utils.byteorders[native.dtype.byteorder])
             print("Byteorder earray on-disk:", earray.byteorder)
 
-        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder], sys.byteorder)
+        self.assertEqual(tb.utils.byteorders[native.dtype.byteorder],
+                         sys.byteorder)
         self.assertEqual(earray.byteorder, byteorder)
         self.assertTrue(common.allequal(native, swapped))
 
@@ -2311,7 +2330,8 @@ class Rows64bitsTestCase(common.TempFileMixin, common.PyTablesTestCase):
         # Check shape
         self.assertEqual(array.shape, (nrows,))
         # check the 10 first elements
-        self.assertTrue(common.allequal(array[:10], np.arange(10, dtype='int8')))
+        self.assertTrue(common.allequal(
+            array[:10], np.arange(10, dtype='int8')))
         # check the 10 last elements
         stop = self.narows % 256
         if stop > 127:
@@ -2377,7 +2397,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 1)
         if common.verbose:
             print("First row-->", ea[0])
-        self.assertTrue(common.allequal(ea[0], np.array([[1, 3], [4, 5]], 'i4')))
+        self.assertTrue(common.allequal(
+            ea[0], np.array([[1, 3], [4, 5]], 'i4')))
 
     def test01b_append(self):
         """Append several rows to a (unidimensional) EArray with a MD
@@ -2394,7 +2415,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[2])
-        self.assertTrue(common.allequal(ea[2], np.array([[3, 3], [3, 3]], 'i4')))
+        self.assertTrue(common.allequal(
+            ea[2], np.array([[3, 3], [3, 3]], 'i4')))
 
     def test02a_append(self):
         """Append a row to a (multidimensional) EArray with a
@@ -2470,7 +2492,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[:, 2, ...])
-        self.assertTrue(common.allequal(ea[:, 2, ...], a.reshape((2, 3, 2, 4))*3))
+        self.assertTrue(common.allequal(ea[:, 2, ...],
+                                        a.reshape((2, 3, 2, 4))*3))
 
     def test03c_MDMDMD(self):
         """Complex append of a MD array in a MD EArray with a MD atom (III)."""
@@ -2489,7 +2512,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[:, :, 2, ...])
-        self.assertTrue(common.allequal(ea[:, :, 2, ...], a.reshape((2, 3, 2, 4))*3))
+        self.assertTrue(common.allequal(ea[:, :, 2, ...],
+                                        a.reshape((2, 3, 2, 4))*3))
 
 
 class MDAtomNoReopen(MDAtomTestCase):
@@ -2505,7 +2529,8 @@ class AccessClosedTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
         self.array = self.h5file.create_earray(self.h5file.root, 'array',
-                                               atom=tb.Int32Atom(), shape=(0, 10))
+                                               atom=tb.Int32Atom(),
+                                               shape=(0, 10))
         self.array.append(np.zeros((10, 10)))
 
     def test_read(self):

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -1104,7 +1104,7 @@ class LZOShuffleTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class Bzip2ComprTestCase(BasicTestCase):
     compress = 1
     complib = "bzip2"
@@ -1116,7 +1116,7 @@ class Bzip2ComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class Bzip2ShuffleTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
@@ -2411,8 +2411,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 1)
         if common.verbose:
             print("First row-->", ea[0])
-        self.assertTrue(common.allequal(ea[0],
-                                 np.array([[1, 3], [4, 5], [7, 9]], 'i4')))
+        self.assertTrue(common.allequal(
+            ea[0], np.array([[1, 3], [4, 5], [7, 9]], 'i4')))
 
     def test02b_append(self):
         """Append several rows to a (multidimensional) EArray with a MD
@@ -2431,8 +2431,8 @@ class MDAtomTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(ea.nrows, 3)
         if common.verbose:
             print("Third row-->", ea[2])
-        self.assertTrue(common.allequal(ea[2],
-                                 np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
+        self.assertTrue(common.allequal(
+            ea[2], np.array([[-2, 3], [-5, 5], [7, -9]], 'i4')))
 
     def test03a_MDMDMD(self):
         """Complex append of a MD array in a MD EArray with a

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -2863,9 +2863,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -2176,7 +2176,7 @@ class TruncateTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("array1-->", array1.read())
 
         self.assertTrue(common.allequal(
-            array1[:], np.array([],dtype='int16').reshape(0, 2)))
+            array1[:], np.array([], dtype='int16').reshape(0, 2)))
 
     def test01_truncate(self):
         """Checking EArray.truncate() method (truncating to 1 rows)"""

--- a/tables/tests/test_enum.py
+++ b/tables/tests/test_enum.py
@@ -663,11 +663,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_expression.py
+++ b/tables/tests/test_expression.py
@@ -1569,11 +1569,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_expression.py
+++ b/tables/tests/test_expression.py
@@ -1341,9 +1341,9 @@ class setOutputRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         r2 = eval("a-b-1")
         lsl = tuple([slice(None)] * self.maindim)
         # print "lsl-->", lsl + (slice(start,stop,step),)
-        l = len(range(start, stop, step))
+        lrange = len(range(start, stop, step))
         r.__setitem__(lsl + (slice(start, stop, step),),
-                      r2.__getitem__(lsl + (slice(0, l),)))
+                      r2.__getitem__(lsl + (slice(0, lrange),)))
         if common.verbose:
             print("Tested shape:", shape)
             print("Computed expression:", repr(r1[:]), r1.dtype)

--- a/tables/tests/test_garbage.py
+++ b/tables/tests/test_garbage.py
@@ -59,11 +59,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_hdf5compat.py
+++ b/tables/tests/test_hdf5compat.py
@@ -200,7 +200,8 @@ class ChunkedCompoundTestCase(common.TestFileMixin, common.PyTablesTestCase):
             self.assertEqual(row['g_name'], ord('m'))
 
 
-class ContiguousCompoundTestCase(common.TestFileMixin, common.PyTablesTestCase):
+class ContiguousCompoundTestCase(common.TestFileMixin,
+                                 common.PyTablesTestCase):
     """Test for support of native contiguous compound datasets.
 
     This example has been provided by Dav Clark.
@@ -241,7 +242,8 @@ class ContiguousCompoundTestCase(common.TestFileMixin, common.PyTablesTestCase):
         self.h5file.close()
 
 
-class ContiguousCompoundAppendTestCase(common.TestFileMixin, common.PyTablesTestCase):
+class ContiguousCompoundAppendTestCase(common.TestFileMixin,
+                                       common.PyTablesTestCase):
     """Test for appending data to native contiguous compound datasets."""
 
     h5fname = common.test_filename('non-chunked-table.h5')
@@ -352,7 +354,8 @@ class ObjectReferenceTestCase(common.TestFileMixin, common.PyTablesTestCase):
             array[0][0][0], np.array([0, 0], dtype=np.uint64)))
 
 
-class ObjectReferenceRecursiveTestCase(common.TestFileMixin, common.PyTablesTestCase):
+class ObjectReferenceRecursiveTestCase(common.TestFileMixin,
+                                       common.PyTablesTestCase):
     h5fname = common.test_filename('test_ref_array2.mat')
 
     def test_var(self):
@@ -391,12 +394,14 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(I32LETestCase))
         theSuite.addTest(common.unittest.makeSuite(ChunkedCompoundTestCase))
         theSuite.addTest(common.unittest.makeSuite(ContiguousCompoundTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ContiguousCompoundAppendTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(ContiguousCompoundAppendTestCase))
         theSuite.addTest(common.unittest.makeSuite(ExtendibleTestCase))
         theSuite.addTest(common.unittest.makeSuite(SzipTestCase))
         theSuite.addTest(common.unittest.makeSuite(MatlabFileTestCase))
         theSuite.addTest(common.unittest.makeSuite(ObjectReferenceTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ObjectReferenceRecursiveTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(ObjectReferenceRecursiveTestCase))
 
     return theSuite
 

--- a/tables/tests/test_hdf5compat.py
+++ b/tables/tests/test_hdf5compat.py
@@ -406,11 +406,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -40,9 +40,9 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         # Create a table
         title = "This is the IndexArray title"
         self.filters = tb.Filters(complevel=self.compress,
-                                      complib=self.complib,
-                                      shuffle=self.shuffle,
-                                      fletcher32=self.fletcher32)
+                                  complib=self.complib,
+                                  shuffle=self.shuffle,
+                                  fletcher32=self.fletcher32)
         table = self.h5file.create_table(group, 'table', TDescr, title,
                                          self.filters, self.nrows)
         for i in range(self.nrows):
@@ -493,8 +493,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Running %s.test10c_moveIndex..." % self.__class__.__name__)
 
         # Open the HDF5 file in read-write mode
-        self.h5file = tb.open_file(self.h5fname, mode="a",
-                                       node_cache_slots=10)
+        self.h5file = tb.open_file(self.h5fname, mode="a", node_cache_slots=10)
         table = self.h5file.root.table
         idxcol = table.cols.var1.index
         if common.verbose:
@@ -532,8 +531,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Running %s.test10d_moveIndex..." % self.__class__.__name__)
 
         # Open the HDF5 file in read-write mode
-        self.h5file = tb.open_file(self.h5fname, mode="a",
-                                       node_cache_slots=0)
+        self.h5file = tb.open_file(self.h5fname, mode="a", node_cache_slots=0)
         table = self.h5file.root.table
         idxcol = table.cols.var1.index
         if common.verbose:

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -710,6 +710,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self.assertEqual(
                 len(list(table.where('(var3 < e)', dict(e=limit)))), limit)
 
+
 small_ss = small_blocksizes[2]
 
 
@@ -944,6 +945,7 @@ class IndexProps:
                  filters=tb.index.default_index_filters):
         self.auto = auto
         self.filters = filters
+
 
 DefaultProps = IndexProps()
 NoAutoProps = IndexProps(auto=False)

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -2384,8 +2384,8 @@ class ReadSortedIndexTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("The values from read_sorted:", sortedtable2)
         # Compare with the sorted read table because we have no
         # guarantees that read_sorted returns a completely sorted table
-        self.assertTrue(common.allequal(sortedtable,
-                                 np.sort(sortedtable2, order="icol")))
+        self.assertTrue(common.allequal(
+            sortedtable, np.sort(sortedtable2, order="icol")))
 
     def test01_readSorted2(self):
         """Testing the Table.read_sorted() method with no arguments
@@ -2400,8 +2400,8 @@ class ReadSortedIndexTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("The values from read_sorted:", sortedtable2)
         # Compare with the sorted read table because we have no
         # guarantees that read_sorted returns a completely sorted table
-        self.assertTrue(common.allequal(sortedtable,
-                                 np.sort(sortedtable2, order="icol")))
+        self.assertTrue(common.allequal(
+            sortedtable, np.sort(sortedtable2, order="icol")))
 
     def test02_copy_sorted1(self):
         """Testing the Table.copy(sortby) method."""

--- a/tables/tests/test_indexes.py
+++ b/tables/tests/test_indexes.py
@@ -213,8 +213,9 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if common.verbose:
             print("Selected values:", results)
         self.assertEqual(len(results), min(10, table.nrows))
-        self.assertEqual(results, [float(i) for i in
-                                   reversed(list(range(min(10, table.nrows))))])
+        self.assertEqual(
+            results,
+            [float(i) for i in reversed(list(range(min(10, table.nrows))))])
 
     def test05_getWhereList(self):
         """Checking reading an Index with get_where_list (string flavor)"""
@@ -740,7 +741,8 @@ class BloscReadTestCase(BasicTestCase):
     nrows = small_ss
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class LZOReadTestCase(BasicTestCase):
     compress = 1
     complib = "lzo"
@@ -1761,14 +1763,16 @@ class OldIndexTestCase(common.TestFileMixin, common.PyTablesTestCase):
     def test1_x(self):
         """Check that files with 1.x indexes are recognized and warned."""
 
-        self.assertWarns(tb.exceptions.OldIndexWarning, self.h5file.get_node, "/table")
+        self.assertWarns(tb.exceptions.OldIndexWarning,
+                         self.h5file.get_node, "/table")
 
 
 # Sensible parameters for indexing with small blocksizes
 small_blocksizes = (512, 128, 32, 8)
 
 
-class CompletelySortedIndexTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class CompletelySortedIndexTestCase(common.TempFileMixin,
+                                    common.PyTablesTestCase):
     """Test case for testing a complete sort in a table."""
 
     nrows = 100
@@ -2669,7 +2673,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(Bzip2ReadTestCase))
         theSuite.addTest(common.unittest.makeSuite(ShuffleReadTestCase))
         theSuite.addTest(common.unittest.makeSuite(Fletcher32ReadTestCase))
-        theSuite.addTest(common.unittest.makeSuite(ShuffleFletcher32ReadTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(ShuffleFletcher32ReadTestCase))
         theSuite.addTest(common.unittest.makeSuite(OneHalfTestCase))
         theSuite.addTest(common.unittest.makeSuite(UpperBoundTestCase))
         theSuite.addTest(common.unittest.makeSuite(LowerBoundTestCase))
@@ -2680,7 +2685,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(IndexPropsChangeTestCase))
         theSuite.addTest(common.unittest.makeSuite(IndexFiltersTestCase))
         theSuite.addTest(common.unittest.makeSuite(OldIndexTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompletelySortedIndexTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompletelySortedIndexTestCase))
         theSuite.addTest(common.unittest.makeSuite(ManyNodesTestCase))
         theSuite.addTest(common.unittest.makeSuite(ReadSortedIndex0))
         theSuite.addTest(common.unittest.makeSuite(ReadSortedIndex3))

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3262,6 +3262,7 @@ class MediumITableMixin:
 class FullITableMixin:
     kind = "full"
 
+
 # Parameters for indexed queries.
 ckinds = ['UltraLight', 'Light', 'Medium', 'Full']
 testlevels = ['Normal', 'Heavy']

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3276,7 +3276,7 @@ testlevels = ['Normal', 'Heavy']
 def iclassdata():
     for ckind in ckinds:
         for ctest in normal_tests + heavy_tests:
-            classname = '{}I{}{}'.format(ckind[0], testlevels[common.heavy][0], ctest)
+            classname = f'{ckind[0]}I{testlevels[common.heavy][0]}{ctest}'
             # Uncomment the next one and comment the past one if one
             # don't want to include the methods (testing purposes only)
             # cbasenames = ( '%sITableMixin' % ckind, "object")
@@ -3293,7 +3293,8 @@ for (cname, cbasenames, cdict) in iclassdata():
 
 
 # Test case for issue #319
-class BuffersizeMultipleChunksize(common.TempFileMixin, common.PyTablesTestCase):
+class BuffersizeMultipleChunksize(common.TempFileMixin,
+                                  common.PyTablesTestCase):
     open_mode = 'w'
 
     def test01(self):
@@ -3392,7 +3393,8 @@ def suite():
                 suite_ = common.unittest.makeSuite(class_)
                 theSuite.addTest(suite_)
         theSuite.addTest(common.unittest.makeSuite(LastRowReuseBuffers))
-        theSuite.addTest(common.unittest.makeSuite(BuffersizeMultipleChunksize))
+        theSuite.addTest(
+            common.unittest.makeSuite(BuffersizeMultipleChunksize))
         theSuite.addTest(common.unittest.makeSuite(SideEffectNumPyQuicksort))
     return theSuite
 

--- a/tables/tests/test_indexvalues.py
+++ b/tables/tests/test_indexvalues.py
@@ -3185,8 +3185,7 @@ class LastRowReuseBuffers(common.PyTablesTestCase):
             nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertGreater(len(idx), 0,
-                            f"idx--> {idx} {i} {nrow} {value}")
+            self.assertGreater(len(idx), 0, f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
                 f"nrow not found: {idx} != {nrow}, {value}")
@@ -3204,8 +3203,7 @@ class LastRowReuseBuffers(common.PyTablesTestCase):
             nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertGreater(len(idx), 0,
-                            f"idx--> {idx} {i} {nrow} {value}")
+            self.assertGreater(len(idx), 0, f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
                 f"nrow not found: {idx} != {nrow}, {value}")
@@ -3223,8 +3221,7 @@ class LastRowReuseBuffers(common.PyTablesTestCase):
             nrow = random.randrange(self.nelem)
             value = id1[nrow]
             idx = ta.get_where_list('id1 == %s' % value)
-            self.assertGreater(len(idx), 0,
-                            f"idx--> {idx} {i} {nrow} {value}")
+            self.assertGreater(len(idx), 0, f"idx--> {idx} {i} {nrow} {value}")
             self.assertTrue(
                 nrow in idx,
                 f"nrow not found: {idx} != {nrow}, {value}")

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -328,7 +328,7 @@ class SoftLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def test13_direct_attribute_access_via_chained_softlinks(self):
         """Check get/set access via link2-->link1-->target.child.attribute"""
 
-        lgroup1 = self.h5file.get_node('/lgroup1')
+        self.h5file.get_node('/lgroup1')
         arr2 = self.h5file.get_node('/group1/arr2')
         # multiple chained links
         l_lgroup1 = self.h5file.create_soft_link('/', 'l_lgroup1', '/lgroup1')
@@ -341,9 +341,9 @@ class SoftLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def test14_child_of_softlink_to_group(self):
         """Create an array whose parent is a softlink to another group"""
 
-        group1 = self.h5file.get_node('/group1')
+        self.h5file.get_node('/group1')
         lgroup1 = self.h5file.get_node('/lgroup1')
-        new_arr = self.h5file.create_array(lgroup1, 'new_arr', obj=[1, 2, 3])
+        self.h5file.create_array(lgroup1, 'new_arr', obj=[1, 2, 3])
         new_arr2 = self.h5file.get_node('/group1/new_arr')
         self.assertEqual(new_arr2[:], [1, 2, 3])
 

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -378,11 +378,11 @@ class ExternalLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.exth5file.close()
         super().tearDown()
 
-        #open_files = tables.file._open_files
-        #if self.extfname in open_files:
-        #    #assert False
-        #    for handler in open_files.get_handlers_by_name(self.extfname):
-        #        handler.close()
+        # open_files = tables.file._open_files
+        # if self.extfname in open_files:
+        #     #assert False
+        #     for handler in open_files.get_handlers_by_name(self.extfname):
+        #         handler.close()
 
         Path(extfname).unlink()   # comment this for debugging purposes only
 

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -605,11 +605,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -497,10 +497,10 @@ class WriteTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self._testAData['x'].copy(),
             self._testAData['color'].copy()],
             dtype=[('x', '(2,)i4'), ('color', 'a2')])
-            # descr=tbl.description._v_nested_descr[0:2])
-            # or...
-            # names=tbl.description._v_nested_names[0:2],
-            # formats=tbl.description._v_nested_formats[0:2])
+        # descr=tbl.description._v_nested_descr[0:2])
+        # or...
+        # names=tbl.description._v_nested_names[0:2],
+        # formats=tbl.description._v_nested_formats[0:2])
         (raCols[0], raCols[-1]) = (raCols[-1].copy(), raCols[0].copy())
 
         # Write the resulting columns

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -63,6 +63,7 @@ class TestTDescr(tb.IsDescription):
             name = tb.StringCol(itemsize=2)
             value = tb.ComplexCol(itemsize=16, shape=2)
 
+
 # The corresponding nested array description:
 testADescr = [
     ('x', '(2,)int32'),
@@ -1196,6 +1197,7 @@ class B_Candidate(tb.IsDescription):
 class C_Candidate(tb.IsDescription):
     nested1 = Nested()
     nested2 = Nested
+
 
 Dnested = {
     'uid': tb.IntCol(pos=1),

--- a/tables/tests/test_nestedtypes.py
+++ b/tables/tests/test_nestedtypes.py
@@ -1502,11 +1502,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -953,8 +953,8 @@ class TableNativeFlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
                  ('name', '|S2'),
                  ('z2', '|u1')]
         npdata = np.zeros((3,), dtype=dtype)
-        #self.assertRaises(NotImplementedError,
-        #                  table.cols.Info.__setitem__, slice(3,6,1),  npdata)
+        # self.assertRaises(NotImplementedError,
+        #                   table.cols.Info.__setitem__, slice(3,6,1),  npdata)
         table.cols.Info[3:6] = npdata
         if self.close:
             self._reopen(mode='a')

--- a/tables/tests/test_numpy.py
+++ b/tables/tests/test_numpy.py
@@ -716,7 +716,8 @@ class TableNativeFlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(data), 100)
 
         # Finally, check that the contents are ok
-        self.assertTrue(common.allequal(data, np.arange(100, dtype="i8"), "numpy"))
+        self.assertTrue(common.allequal(
+            data, np.arange(100, dtype="i8"), "numpy"))
 
     def test03a_readWhere(self):
         """Checking the return of NumPy in read_where method (strings)."""
@@ -841,7 +842,8 @@ class TableNativeFlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(data), 100)
 
         # Finally, check that the contents are ok
-        self.assertTrue(common.allequal(data, np.zeros((100,), dtype="u1"), "numpy"))
+        self.assertTrue(common.allequal(
+            data, np.zeros((100,), dtype="u1"), "numpy"))
 
     def test05b_modifyingColumns(self):
         """Checking modifying several columns at once."""
@@ -1379,8 +1381,10 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(Basic2DTestCase))
         theSuite.addTest(common.unittest.makeSuite(GroupsArrayTestCase))
         theSuite.addTest(common.unittest.makeSuite(TableReadTestCase))
-        theSuite.addTest(common.unittest.makeSuite(TableNativeFlavorOpenTestCase))
-        theSuite.addTest(common.unittest.makeSuite(TableNativeFlavorCloseTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(TableNativeFlavorOpenTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(TableNativeFlavorCloseTestCase))
         theSuite.addTest(common.unittest.makeSuite(AttributesOpenTestCase))
         theSuite.addTest(common.unittest.makeSuite(AttributesCloseTestCase))
         theSuite.addTest(common.unittest.makeSuite(StrlenOpenTestCase))

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -427,8 +427,8 @@ def create_test_method(type_, op, extracond, func=None):
             pyrownos = np.array(pyrownos)  # row numbers already sorted
             pyfvalues = np.array(pyfvalues, dtype=sctype)
             pyfvalues.sort()
-            common.verbosePrint("* %d rows selected by Python from ``%s``."
-                   % (len(pyrownos), acolname))
+            common.verbosePrint(f"* {len(pyrownos)} rows selected by Python "
+                                f"from ``{acolname}``.")
             if rownos is None:
                 rownos = pyrownos  # initialise reference results
                 fvalues = pyfvalues
@@ -461,8 +461,8 @@ def create_test_method(type_, op, extracond, func=None):
                     "The PyTables type does not support the operation.")
             for ptfvals in ptfvalues:  # row numbers already sorted
                 ptfvals.sort()
-            common.verbosePrint("* %d rows selected by PyTables from ``%s``"
-                   % (len(ptrownos[0]), acolname), nonl=True)
+            common.verbosePrint(f"* {len(ptrownos[0])} rows selected by "
+                                f"PyTables from ``{acolname}``", nonl=True)
             common.verbosePrint("(indexing: %s)." % ["no", "yes"][bool(isidxq)])
             self.assertTrue(np.all(ptrownos[0] == rownos))
             self.assertTrue(np.all(ptfvalues[0] == fvalues))
@@ -799,27 +799,27 @@ class IndexedTableUsage(ScalarTableMixin, BaseTableUsageTestCase):
         for condition in self.conditions:
             c_usable_idxs = self.will_query_use_indexing(condition, {})
             self.assertEqual(c_usable_idxs, self.usable_idxs,
-                             "\nQuery with condition: ``%s``\n"
-                             "Computed usable indexes are: ``%s``\n"
-                             "and should be: ``%s``" %
-                            (condition, c_usable_idxs, self.usable_idxs))
+                             f"\nQuery with condition: ``{condition}``\n"
+                             f"Computed usable indexes are: "
+                             f"``{c_usable_idxs}``\nand should be: "
+                             f"``{self.usable_idxs}``")
             condvars = self.requiredExprVars(condition, None)
             compiled = self.compileCondition(condition, condvars)
             c_idx_expr = compiled.index_expressions
             self.assertEqual(c_idx_expr, self.idx_expr,
-                             "\nWrong index expression in condition:\n``%s``\n"
-                             "Compiled index expression is:\n``%s``\n"
-                             "and should be:\n``%s``" %
-                            (condition, c_idx_expr, self.idx_expr))
+                             f"\nWrong index expression in condition:\n"
+                             f"``{condition}``\nCompiled index expression is:"
+                             f"\n``{c_idx_expr}``\nand should be:\n"
+                             f"``{self.idx_expr}``")
             c_str_expr = compiled.string_expression
             self.assertEqual(c_str_expr, self.str_expr,
-                             "\nWrong index operations in condition:\n``%s``\n"
-                             "Computed index operations are:\n``%s``\n"
-                             "and should be:\n``%s``" %
-                            (condition, c_str_expr, self.str_expr))
-            common.verbosePrint("* Query with condition ``%s`` will use "
-                   "variables ``%s`` for indexing."
-                   % (condition, compiled.index_variables))
+                             f"\nWrong index operations in condition:\n"
+                             f"``{condition}``\nComputed index operations are:"
+                             f"\n``{c_str_expr}``\nand should be:\n"
+                             f"``{self.str_expr}``")
+            common.verbosePrint(
+                f"* Query with condition ``{condition}`` will use variables "
+                f"``{compiled.index_variables}`` for indexing.")
 
 
 class IndexedTableUsage1(IndexedTableUsage):

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -81,11 +81,9 @@ if hasattr(np, 'float16'):
 # if hasattr(numpy, 'complex256'):
 #    type_info['complex256'] = (numpy.complex256, complex)
 
-sctype_from_type = {type_: info[0]
-                        for (type_, info) in type_info.items()}
+sctype_from_type = {type_: info[0] for (type_, info) in type_info.items()}
 """Maps PyTables types to NumPy scalar types."""
-nxtype_from_type = {type_: info[1]
-                        for (type_, info) in type_info.items()}
+nxtype_from_type = {type_: info[1] for (type_, info) in type_info.items()}
 """Maps PyTables types to Numexpr types."""
 
 heavy_types = frozenset(['uint8', 'int16', 'uint16', 'float32', 'complex64'])

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -268,7 +268,8 @@ class BaseTableQueryTestCase(common.TempFileMixin, common.PyTablesTestCase):
             return
         try:
             kind = self.kind
-            common.verbosePrint(f"* Indexing ``{colname}`` columns. Type: {kind}.")
+            common.verbosePrint(
+                f"* Indexing ``{colname}`` columns. Type: {kind}.")
             for acolname in [colname, ncolname, extracolname]:
                 acolumn = self.table.colinstances[acolname]
                 acolumn.create_index(
@@ -464,7 +465,7 @@ def create_test_method(type_, op, extracond, func=None):
                 ptfvals.sort()
             common.verbosePrint(f"* {len(ptrownos[0])} rows selected by "
                                 f"PyTables from ``{acolname}``", nonl=True)
-            common.verbosePrint("(indexing: %s)." % ["no", "yes"][bool(isidxq)])
+            common.verbosePrint(f"(indexing: {'yes' if isidxq else 'no'}).")
             self.assertTrue(np.all(ptrownos[0] == rownos))
             self.assertTrue(np.all(ptfvalues[0] == fvalues))
             # The following test possible caching of query results.
@@ -1243,7 +1244,8 @@ def suite():
             for cdata in cdatafunc():
                 class_ = eval(cdata[0])
                 if heavy or not class_.heavy:
-                    suite_ = common.unittest.makeSuite(class_, prefix=autoprefix)
+                    suite_ = common.unittest.makeSuite(class_,
+                                                       prefix=autoprefix)
                     testSuite.addTest(suite_)
         # Tests on query usage.
         testSuite.addTest(common.unittest.makeSuite(ScalarTableUsageTestCase))

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -162,6 +162,7 @@ def table_description(classname, nclassname, shape=()):
 
     return type(classname, (tb.IsDescription,), classdict)
 
+
 TableDescription = table_description(
     'TableDescription', 'NestedDescription')
 """Unidimensional table description for testing queries."""
@@ -493,6 +494,7 @@ def add_test_method(type_, op, extracond='', func=None):
     setattr(TableDataTestCase, tmethod.__name__, tmethod)
     testn += 1
 
+
 # Create individual tests.  You may restrict which tests are generated
 # by replacing the sequences in the ``for`` statements.  For instance:
 testn = 0
@@ -522,6 +524,7 @@ class BigNITableMixin:
     assert nrows > NX_BLOCK_SIZE1 + NX_BLOCK_SIZE2
     assert nrows % NX_BLOCK_SIZE1 != 0
     assert nrows % NX_BLOCK_SIZE2 != 0  # to have some residual rows
+
 
 # Parameters for non-indexed queries.
 table_sizes = ['Small', 'Big']
@@ -577,6 +580,7 @@ class MediumSTableMixin:
 class BigSTableMixin:
     nrows = 500
 
+
 # Parameters for indexed queries.
 ckinds = ['UltraLight', 'Light', 'Medium', 'Full']
 itable_sizes = ['Small', 'Medium', 'Big']
@@ -622,6 +626,7 @@ for cdatafunc in [niclassdata, iclassdata]:
 # -------------------------
 class BaseTableUsageTestCase(BaseTableQueryTestCase):
     nrows = row_period
+
 
 _gvar = None
 """Use this when a global variable is needed."""

--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -482,15 +482,12 @@ def add_test_method(type_, op, extracond='', func=None):
     heavy = type_ in heavy_types or op in heavy_operators
     if heavy:
         testfmt = TableDataTestCase._testfmt_heavy
-        numfmt = ' [#H%d]'
     else:
         testfmt = TableDataTestCase._testfmt_light
-        numfmt = ' [#L%d]'
     tmethod = create_test_method(type_, op, extracond, func)
     # The test number is appended to the docstring to help
     # identify failing methods in non-verbose mode.
     tmethod.__name__ = testfmt % testn
-    # tmethod.__doc__ += numfmt % testn
     tmethod.__doc__ += testfmt % testn
     setattr(TableDataTestCase, tmethod.__name__, tmethod)
     testn += 1

--- a/tables/tests/test_suite.py
+++ b/tables/tests/test_suite.py
@@ -81,7 +81,7 @@ def test(verbose=False, heavy=False):
     common.print_heavy(heavy)
 
     # What a context this is!
-    #oldverbose, common.verbose = common.verbose, verbose
+    # oldverbose, common.verbose = common.verbose, verbose
     oldheavy, common.heavy = common.heavy, heavy
     try:
         result = common.unittest.TextTestRunner(verbosity=1+int(verbose)).run(suite())
@@ -90,5 +90,5 @@ def test(verbose=False, heavy=False):
         else:
             return 1
     finally:
-        #common.verbose = oldverbose
+        # common.verbose = oldverbose
         common.heavy = oldheavy  # there are pretty young heavies, too ;)

--- a/tables/tests/test_suite.py
+++ b/tables/tests/test_suite.py
@@ -84,7 +84,8 @@ def test(verbose=False, heavy=False):
     # oldverbose, common.verbose = common.verbose, verbose
     oldheavy, common.heavy = common.heavy, heavy
     try:
-        result = common.unittest.TextTestRunner(verbosity=1+int(verbose)).run(suite())
+        result = common.unittest.TextTestRunner(
+            verbosity=1 + int(verbose)).run(suite())
         if result.wasSuccessful():
             return 0
         else:

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -4043,8 +4043,8 @@ class RecArrayIO(common.TempFileMixin, common.PyTablesTestCase):
         table.append(r)
         table.append([(457, b'db1', 1.2), (5, b'de1', 1.3)])
         # Modify two existing rows
-        rows = np.rec.array(
-            [(457, b'db1', 1.2), (5, b'de1', 1.3)],formats="i4,a3,f8")
+        rows = np.rec.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
+                            formats="i4,a3,f8")
         table.modify_rows(start=1, rows=rows)
         # Create the modified recarray
         r1 = np.rec.array([(456, b'dbe', 1.2), (457, b'db1', 1.2),

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -48,6 +48,7 @@ class Record(tb.IsDescription):
         var15 = tb.ComplexCol(
             itemsize=32, dflt=(1.-0.j))  # Complex double (extended precision)
 
+
 #  Dictionary definition
 RecordDescriptionDict = {
     'var1': tb.StringCol(itemsize=4, dflt=b"abcd", pos=0),  # 4-character String

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -24,23 +24,23 @@ def is_os_64bit():
 # Test Record class
 class Record(tb.IsDescription):
     var1 = tb.StringCol(itemsize=4, dflt=b"abcd", pos=0)  # 4-character String
-    var2 = tb.IntCol(dflt=1, pos=1)                   # integer
-    var3 = tb.Int16Col(dflt=2, pos=2)                 # short integer
-    var4 = tb.Float64Col(dflt=3.1, pos=3)             # double (double-precision)
-    var5 = tb.Float32Col(dflt=4.2, pos=4)             # float  (single-precision)
-    var6 = tb.UInt16Col(dflt=5, pos=5)                # unsigned short integer
+    var2 = tb.IntCol(dflt=1, pos=1)  # integer
+    var3 = tb.Int16Col(dflt=2, pos=2)  # short integer
+    var4 = tb.Float64Col(dflt=3.1, pos=3)  # double (double-precision)
+    var5 = tb.Float32Col(dflt=4.2, pos=4)  # float  (single-precision)
+    var6 = tb.UInt16Col(dflt=5, pos=5)  # unsigned short integer
     var7 = tb.StringCol(itemsize=1, dflt=b"e", pos=6)  # 1-character String
-    var8 = tb.BoolCol(dflt=True, pos=7)               # boolean
+    var8 = tb.BoolCol(dflt=True, pos=7)  # boolean
     var9 = tb.ComplexCol(
-        itemsize=8, dflt=(0.+1.j), pos=8)       # Complex single precision
+        itemsize=8, dflt=(0.+1.j), pos=8)  # Complex single precision
     var10 = tb.ComplexCol(
-        itemsize=16, dflt=(1.-0.j), pos=9)      # Complex double precision
+        itemsize=16, dflt=(1.-0.j), pos=9)  # Complex double precision
     if hasattr(tb, 'Float16Col'):
-        var11 = tb.Float16Col(dflt=6.4)     # float  (half-precision)
+        var11 = tb.Float16Col(dflt=6.4)  # float  (half-precision)
     if hasattr(tb, 'Float96Col'):
-        var12 = tb.Float96Col(dflt=6.4)     # float  (extended precision)
+        var12 = tb.Float96Col(dflt=6.4)  # float  (extended precision)
     if hasattr(tb, 'Float128Col'):
-        var13 = tb.Float128Col(dflt=6.4)    # float  (extended precision)
+        var13 = tb.Float128Col(dflt=6.4)  # float  (extended precision)
     if hasattr(tb, 'Complex192Col'):
         var14 = tb.ComplexCol(
             itemsize=24, dflt=(1.-0.j))  # Complex double (extended precision)
@@ -51,19 +51,19 @@ class Record(tb.IsDescription):
 
 #  Dictionary definition
 RecordDescriptionDict = {
-    'var1': tb.StringCol(itemsize=4, dflt=b"abcd", pos=0),  # 4-character String
-    'var2': tb.IntCol(dflt=1, pos=1),              # integer
-    'var3': tb.Int16Col(dflt=2, pos=2),            # short integer
-    'var4': tb.Float64Col(dflt=3.1, pos=3),        # double (double-precision)
-    'var5': tb.Float32Col(dflt=4.2, pos=4),        # float  (single-precision)
-    'var6': tb.UInt16Col(dflt=5, pos=5),           # unsigned short integer
+    'var1': tb.StringCol(itemsize=4, dflt=b"abcd", pos=0),  # 4-char String
+    'var2': tb.IntCol(dflt=1, pos=1),  # integer
+    'var3': tb.Int16Col(dflt=2, pos=2),  # short integer
+    'var4': tb.Float64Col(dflt=3.1, pos=3),  # double (double-precision)
+    'var5': tb.Float32Col(dflt=4.2, pos=4),  # float  (single-precision)
+    'var6': tb.UInt16Col(dflt=5, pos=5),  # unsigned short integer
     'var7': tb.StringCol(
-        itemsize=1, dflt=b"e", pos=6),          # 1-character String
-    'var8': tb.BoolCol(dflt=True, pos=7),          # boolean
+        itemsize=1, dflt=b"e", pos=6),  # 1-character String
+    'var8': tb.BoolCol(dflt=True, pos=7),   # boolean
     'var9': tb.ComplexCol(
-        itemsize=8, dflt=(0.+1.j), pos=8),      # Complex single precision
+        itemsize=8, dflt=(0.+1.j), pos=8),  # Complex single precision
     'var10': tb.ComplexCol(
-        itemsize=16, dflt=(1.-0.j), pos=9),     # Complex double precision
+        itemsize=16, dflt=(1.-0.j), pos=9),  # Complex double precision
 }
 
 if hasattr(tb, 'Float16Col'):
@@ -356,8 +356,10 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("coldflts-->", tbl.coldflts[v], type(tbl.coldflts[v]))
                 print("desc.dflts-->", desc._v_dflts[v],
                       type(desc._v_dflts[v]))
-            self.assertTrue(common.areArraysEqual(tbl.coldflts[v], columns[v].dflt))
-            self.assertTrue(common.areArraysEqual(desc._v_dflts[v], columns[v].dflt))
+            self.assertTrue(
+                common.areArraysEqual(tbl.coldflts[v], columns[v].dflt))
+            self.assertTrue(
+                common.areArraysEqual(desc._v_dflts[v], columns[v].dflt))
 
         # Column path names.
         self.assertEqual(expectedNames, list(desc._v_pathnames))
@@ -394,15 +396,14 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual((rec['var1'], rec['var2'], rec['var7']),
                          (b"0001", nrows, b"1"))
         if isinstance(rec['var5'], np.ndarray):
-            self.assertTrue(common.allequal(rec['var5'],
-                                            np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                rec['var5'], np.array((float(nrows),)*4, np.float32)))
         else:
             self.assertEqual(rec['var5'], float(nrows))
         if isinstance(rec['var9'], np.ndarray):
-            self.assertTrue(
-                common.allequal(rec['var9'],
-                                np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
-                                         np.complex64)))
+            self.assertTrue(common.allequal(
+                rec['var9'], np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
+                                      np.complex64)))
         else:
             self.assertEqual((rec['var9']), float(nrows)+0.j)
         self.assertEqual(len(result), 20)
@@ -435,15 +436,15 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual((rec['var1'], rec['var2'], rec['var7']),
                          (strnrows, nrows, b"1"))
         if isinstance(rec['var5'], np.ndarray):
-            self.assertTrue(common.allequal(rec['var5'],
-                                            np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                rec['var5'], np.array((float(nrows),)*4, np.float32)))
         else:
             self.assertEqual(rec['var5'], float(nrows))
         if isinstance(rec['var9'], np.ndarray):
-            self.assertTrue(
-                common.allequal(rec['var9'],
-                                np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
-                                         np.complex64)))
+            self.assertTrue(common.allequal(
+                rec['var9'],
+                np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
+                         np.complex64)))
         else:
             self.assertEqual(rec['var9'], float(nrows)+0.j)
         self.assertEqual(len(result), 20)
@@ -1539,8 +1540,10 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(obj.nrows, self.expectedrows)
 
     def test07_out_of_order_members(self):
-        # If members are stored 'out of order' make sure they are loaded correctly
-        self.h5file = tb.open_file(common.test_filename("out_of_order_types.h5"))
+        # If members are stored 'out of order' make sure they are loaded
+        # correctly
+        self.h5file = tb.open_file(
+            common.test_filename("out_of_order_types.h5"))
         row = self.h5file.get_node('/group/table')[0]
 
         self.assertEqual(row[0], b'*'*14)
@@ -1741,7 +1744,8 @@ class CompressBloscBloscLZTablesTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class CompressBloscLZ4TablesTestCase(BasicTestCase):
     title = "CompressLZ4Tables"
     compress = 1
@@ -1751,7 +1755,8 @@ class CompressBloscLZ4TablesTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class CompressBloscLZ4HCTablesTestCase(BasicTestCase):
     title = "CompressLZ4HCTables"
     compress = 1
@@ -1772,7 +1777,8 @@ class CompressBloscSnappyTablesTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
+@common.unittest.skipIf(
+    'zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class CompressBloscZlibTablesTestCase(BasicTestCase):
     title = "CompressZlibTables"
     compress = 1
@@ -1782,7 +1788,8 @@ class CompressBloscZlibTablesTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
+@common.unittest.skipIf(
+    'zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class CompressBloscZstdTablesTestCase(BasicTestCase):
     title = "CompressZstdTables"
     compress = 1
@@ -1869,7 +1876,8 @@ class BigTablesTestCase(BasicTestCase):
     appendrows = 100
 
 
-class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin,
+                                         common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
 
@@ -1920,7 +1928,8 @@ class SizeOnDiskInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTe
         self.assertLess(self.table.size_on_disk, self.table.size_in_memory)
 
 
-class NonNestedTableReadTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class NonNestedTableReadTestCase(common.TempFileMixin,
+                                 common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
 
@@ -2049,7 +2058,8 @@ class NonNestedTableReadTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self.assertIn('output array size invalid, got', str(exc))
 
 
-class TableReadByteorderTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class TableReadByteorderTestCase(common.TempFileMixin,
+                                 common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
         self.system_byteorder = sys.byteorder
@@ -2770,7 +2780,8 @@ class GetItemTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(result["var2"].tolist(), list(range(
             2, self.expectedrows-6)))
         result = table[2:]
-        self.assertEqual(result["var2"].tolist(), list(range(2, self.expectedrows)))
+        self.assertEqual(result["var2"].tolist(),
+                         list(range(2, self.expectedrows)))
         result = table[-2:]
         self.assertEqual(result["var2"].tolist(),
                          list(range(self.expectedrows-2, self.expectedrows)))
@@ -2849,10 +2860,12 @@ class GetItemTestCase(common.TempFileMixin, common.PyTablesTestCase):
         table = self.h5file.root.table0
         colvar2 = table.cols.var2
         self.assertEqual(colvar2[2:6].tolist(), list(range(2, 6)))
-        self.assertEqual(colvar2[2:-6].tolist(), list(range(2, self.expectedrows-6)))
-        self.assertEqual(colvar2[2:].tolist(), list(range(2, self.expectedrows)))
+        self.assertEqual(colvar2[2:-6].tolist(),
+                         list(range(2, self.expectedrows - 6)))
+        self.assertEqual(colvar2[2:].tolist(),
+                         list(range(2, self.expectedrows)))
         self.assertEqual(colvar2[-2:].tolist(),
-                         list(range(self.expectedrows-2, self.expectedrows)))
+                         list(range(self.expectedrows - 2, self.expectedrows)))
 
     def test08_threeItemsCol(self):
         """Checking __getitem__ method in Col with start, stop, step
@@ -2870,7 +2883,8 @@ class GetItemTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(colvar2[2::3].tolist(), list(range(
             2, self.expectedrows, 3)))
         self.assertEqual(colvar2[:6:2].tolist(), list(range(0, 6, 2)))
-        self.assertEqual(colvar2[::].tolist(), list(range(0, self.expectedrows, 1)))
+        self.assertEqual(colvar2[::].tolist(),
+                         list(range(0, self.expectedrows, 1)))
 
     def test09_negativeStep(self):
         """Checking __getitem__ method in Col with negative step parameter."""
@@ -4581,8 +4595,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 4, 7])
             self.assertEqual(table1.description._v_itemsize, 15)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # This could be not the same when re-opening the file
         # self.assertEqual(table1.description._v_ColObjects,
@@ -4655,8 +4671,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 3, 7])
             self.assertEqual(table1.description._v_itemsize, 15)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # Leaf attributes
         self.assertEqual(table1.title, table2.title)
@@ -4731,8 +4749,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 4, 8, 20, 24])
             self.assertEqual(table1.description._v_itemsize, 32)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # Leaf attributes
         self.assertEqual("title table2", table2.title)
@@ -4803,8 +4823,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 8, 11])
             self.assertEqual(table1.description._v_itemsize, 15)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # Leaf attributes
         self.assertEqual(table1.title, table2.title)
@@ -4872,9 +4894,9 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
         if self.aligned and self.open_kwargs['allow_padding'] == True:
-            # The conditions for guessing the correct alignment are very tricky,
-            # so better disable the checks.  Feel free to re-enable them during
-            # debugging by removing the False condition below.
+            # The conditions for guessing the correct alignment are very
+            # tricky, so better disable the checks.  Feel free to re-enable
+            # them during debugging by removing the False condition below.
             if False:
                 if is_os_64bit() and is_python_64bit():
                     self.assertEqual(table1.description._v_offsets, [0, 8, 16])
@@ -4885,8 +4907,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 8, 11])
             self.assertEqual(table1.description._v_itemsize, 19)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # Leaf attributes
         self.assertEqual(table1.title, table2.title)
@@ -4963,8 +4987,10 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         else:
             self.assertEqual(table1.description._v_offsets, [0, 8, 11])
             self.assertEqual(table1.description._v_itemsize, 15)
-        self.assertEqual(table1.description._v_offsets, table2.description._v_offsets)
-        self.assertEqual(table1.description._v_itemsize, table2.description._v_itemsize)
+        self.assertEqual(table1.description._v_offsets,
+                         table2.description._v_offsets)
+        self.assertEqual(table1.description._v_itemsize,
+                         table2.description._v_itemsize)
 
         # Leaf attributes
         self.assertEqual(table1.title, table2.title)
@@ -5220,8 +5246,8 @@ class LargeRowSize(common.TempFileMixin, common.PyTablesTestCase):
     def test01(self):
         """Checking saving a Table with an extremely large rowsize"""
 
-        # Create a recarray
-        r = np.zeros(10, dtype=np.dtype('(300,100)i4,(400,400)f8'))   # 1.4 MB rowsize
+        # Create a recarray (1.4 MB rowsize)
+        r = np.zeros(10, dtype=np.dtype('(300,100)i4,(400,400)f8'))
         # From PyTables 1.3 on, we allow row sizes equal or larger than 640 KB
         self.h5file.create_table(self.h5file.root, 'largerow', r)
 
@@ -5684,8 +5710,8 @@ class ZeroSizedTestCase(common.TempFileMixin, common.PyTablesTestCase):
         super().setUp()
 
         # Create a Table
-        t = self.h5file.create_table('/', 'table',
-                                     {'c1': tb.Int32Col(), 'c2': tb.Float64Col()})
+        t = self.h5file.create_table('/', 'table', {'c1': tb.Int32Col(),
+                                                    'c2': tb.Float64Col()})
         # Append a single row
         t.append([(1, 2.2)])
 
@@ -5728,8 +5754,10 @@ class IrregularStrideTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if common.verbose:
             print("\nSelected coords1-->", coords1)
             print("Selected coords2-->", coords2)
-        self.assertTrue(common.allequal(coords1, np.arange(5, dtype=tb.utils.SizeType)))
-        self.assertTrue(common.allequal(coords2, np.arange(5, dtype=tb.utils.SizeType)))
+        self.assertTrue(
+            common.allequal(coords1, np.arange(5, dtype=tb.utils.SizeType)))
+        self.assertTrue(
+            common.allequal(coords2, np.arange(5, dtype=tb.utils.SizeType)))
 
 
 class Issue262TestCase(common.TempFileMixin, common.PyTablesTestCase):
@@ -6512,29 +6540,39 @@ def suite():
 
     for n in range(niter):
         theSuite.addTest(common.unittest.makeSuite(BasicWriteTestCase))
-        theSuite.addTest(common.unittest.makeSuite(OldRecordBasicWriteTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(OldRecordBasicWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(DictWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(NumPyDTWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(RecArrayOneWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(RecArrayTwoWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(RecArrayThreeWriteTestCase))
-        theSuite.addTest(common.unittest.makeSuite(RecArrayAlignedWriteTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(RecArrayAlignedWriteTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
             CompressBloscShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
             CompressBloscBitShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
             CompressBloscBloscLZTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscLZ4TablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscLZ4HCTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscSnappyTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscZlibTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscZstdTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscLZ4TablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscLZ4HCTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscSnappyTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscZlibTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscZstdTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressLZOTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressLZOShuffleTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressLZOShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressZLIBTablesTestCase))
-        theSuite.addTest(common.unittest.makeSuite(CompressZLIBShuffleTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressZLIBShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(Fletcher32TablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(AllFiltersTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressTwoTablesTestCase))
@@ -6560,7 +6598,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(CloseCopyTestCase))
         theSuite.addTest(common.unittest.makeSuite(AlignedOpenCopyTestCase))
         theSuite.addTest(common.unittest.makeSuite(AlignedCloseCopyTestCase))
-        theSuite.addTest(common.unittest.makeSuite(AlignedNoPaddingOpenCopyTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(AlignedNoPaddingOpenCopyTestCase))
         theSuite.addTest(common.unittest.makeSuite(CopyIndex1TestCase))
         theSuite.addTest(common.unittest.makeSuite(CopyIndex2TestCase))
         theSuite.addTest(common.unittest.makeSuite(CopyIndex3TestCase))
@@ -6595,7 +6634,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(TestCreateTableArgs))
 
     if common.heavy:
-        theSuite.addTest(common.unittest.makeSuite(CompressBzip2TablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBzip2TablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
             CompressBzip2ShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CopyIndex10TestCase))

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -4589,7 +4589,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             self.assertEqual(table1.description._v_offsets, [0, 4, 8])
             self.assertEqual(table1.description._v_itemsize, 16)
         else:
@@ -4665,7 +4665,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             self.assertEqual(table1.description._v_offsets, [0, 4, 8])
             self.assertEqual(table1.description._v_itemsize, 16)
         else:
@@ -4743,7 +4743,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             self.assertEqual(table1.description._v_offsets, [0, 4, 8, 20, 24])
             self.assertEqual(table1.description._v_itemsize, 32)
         else:
@@ -4817,7 +4817,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             self.assertEqual(table1.description._v_offsets, [0, 8, 12])
             self.assertEqual(table1.description._v_itemsize, 16)
         else:
@@ -4893,7 +4893,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             # The conditions for guessing the correct alignment are very
             # tricky, so better disable the checks.  Feel free to re-enable
             # them during debugging by removing the False condition below.
@@ -4981,7 +4981,7 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqualColinstances(table1, table2)
         self.assertEqual(repr(table1.description), repr(table2.description))
         # Check alignment
-        if self.aligned and self.open_kwargs['allow_padding'] == True:
+        if self.aligned and self.open_kwargs['allow_padding'] is True:
             self.assertEqual(table1.description._v_offsets, [0, 8, 12])
             self.assertEqual(table1.description._v_itemsize, 16)
         else:

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -94,7 +94,7 @@ class OldRecord(tb.IsDescription):
     var7 = tb.StringCol(itemsize=1, dflt=b"e", pos=6)
     var8 = tb.Col.from_type("bool", shape=(), dflt=1, pos=7)
     var9 = tb.ComplexCol(itemsize=8, shape=(), dflt=(0.+1.j), pos=8)
-    var10 = tb.ComplexCol(itemsize=16, shape=(), dflt=(1.-0.j), pos = 9)
+    var10 = tb.ComplexCol(itemsize=16, shape=(), dflt=(1.-0.j), pos=9)
     if hasattr(tb, 'Float16Col'):
         var11 = tb.Col.from_type("float16", (), 6.4)
     if hasattr(tb, 'Float96Col'):

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -15,6 +15,7 @@ from tables.tests import common
 def is_python_64bit():
     return struct.calcsize("P") == 8
 
+
 # To know whether the os platform is 32 or 64 bit
 def is_os_64bit():
     return platform.machine().endswith('64')
@@ -1776,6 +1777,7 @@ class CompressBloscZlibTablesTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
     complib = "blosc:zlib"
+
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
@@ -4995,6 +4997,7 @@ class AlignedOpenCopyTestCase(CopyTestCase):
     close = False
     aligned = True
     open_kwargs = {'allow_padding': True}
+
 
 class AlignedNoPaddingOpenCopyTestCase(CopyTestCase):
     close = False

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1411,7 +1411,6 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Last selected value ==>", result[-1])
             print("Total selected records in table ==>", len(result))
 
-        nrows = table.nrows
         table.nrowsinbuf = 4  # small value of the buffer
         # Delete all rows
         table.remove_rows(0, self.expectedrows)
@@ -1446,7 +1445,6 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Last selected value ==>", result[-1])
             print("Total selected records in table ==>", len(result))
 
-        nrows = table.nrows
         table.nrowsinbuf = 4  # small value of the buffer
         # Delete 100 rows
         table.remove_rows()

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -2042,8 +2042,8 @@ class NonNestedTableReadTestCase(common.TempFileMixin,
 
     def test_specified_field_buffer_too_small(self):
         output = np.empty((99, ), 'i4')
-        func = lambda: self.table.read(field='f5', out=output)
-        self.assertRaises(ValueError, func)
+        self.assertRaises(ValueError,
+                          lambda: self.table.read(field='f5', out=output))
         try:
             self.table.read(field='f5', out=output)
         except ValueError as exc:

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -2198,8 +2198,8 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         table.nrowsinbuf = self.nrowsinbuf
         resrange = slice(self.start, self.stop, self.step).indices(table.nrows)
         reslength = len(list(range(*resrange)))
-        #print "self.checkrecarray = ", self.checkrecarray
-        #print "self.checkgetCol = ", self.checkgetCol
+        # print "self.checkrecarray = ", self.checkrecarray
+        # print "self.checkgetCol = ", self.checkgetCol
         if self.checkrecarray:
             recarray = table.read(self.start, self.stop, self.step)
             result = []
@@ -2547,9 +2547,9 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("\nGreat!, the next ValueError was catched!")
                 print(value)
             self.h5file.close()
-        #else:
-        #    print rec
-        #    self.fail("expected a ValueError")
+        # else:
+        #     print rec
+        #     self.fail("expected a ValueError")
 
         # Case where step == 0
         self.step = 0
@@ -2561,9 +2561,9 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("\nGreat!, the next ValueError was catched!")
                 print(value)
             self.h5file.close()
-        #else:
-        #    print rec
-        #    self.fail("expected a ValueError")
+        # else:
+        #     print rec
+        #     self.fail("expected a ValueError")
 
 
 class IterRangeTestCase(BasicRangeTestCase):
@@ -6446,7 +6446,7 @@ class TestCreateTableArgs(common.TempFileMixin, common.PyTablesTestCase):
         ptarr = self.h5file.create_table(self.where, self.name,
                                          title=self.title,
                                          description=self.description)
-        #ptarr.append(self.obj)
+        # ptarr.append(self.obj)
         self._reopen()
 
         ptarr = self.h5file.get_node(self.where, self.name)

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -2150,7 +2150,7 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for j in range(3):
             # Create a table
             filterprops = tb.Filters(complevel=self.compress,
-                                         shuffle=self.shuffle)
+                                     shuffle=self.shuffle)
             table = self.h5file.create_table(group, 'table'+str(j),
                                              self.record,
                                              title=self.title,
@@ -2622,7 +2622,7 @@ class GetItemTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for j in range(3):
             # Create a table
             filterprops = tb.Filters(complevel=self.compress,
-                                         shuffle=self.shuffle)
+                                     shuffle=self.shuffle)
             table = self.h5file.create_table(group, 'table'+str(j),
                                              self.record,
                                              title=self.title,
@@ -3029,7 +3029,7 @@ class SetItemTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         # Modify two existing rows
         rows = np.rec.array([(457, b'db1', 1.2), (5, b'de1', 1.3)],
-                             formats="i4,a3,f8")
+                            formats="i4,a3,f8")
         # table.modify_rows(start=1, rows=rows)
         table[1:3] = rows
         # Create the modified recarray
@@ -3978,9 +3978,9 @@ class RecArrayIO(common.TempFileMixin, common.PyTablesTestCase):
             rows=np.rec.array([(456, 'db2', 1.2)], formats="i4,a3,f8"))
         # Create the modified recarray
         r1 = np.rec.array([(456, b'dbe', 1.2), (2, b'ded', 1.3),
-                            (456, b'db2', 1.2), (5, b'de1', 1.3)],
-                           formats="i4,a3,f8",
-                           names="col1,col2,col3")
+                           (456, b'db2', 1.2), (5, b'de1', 1.3)],
+                          formats="i4,a3,f8",
+                          names="col1,col2,col3")
         # Read the modified table
         if self.reopen:
             self._reopen()
@@ -4312,7 +4312,7 @@ class RecArrayIO(common.TempFileMixin, common.PyTablesTestCase):
 
         # Modify a couple of columns
         columns = np.rec.array([("aaa", 1.2), ("bbb", .1), ("ccc", .3)],
-                                formats="a3,f8")
+                               formats="a3,f8")
         table.modify_columns(start=1, columns=columns, names=["col2", "col3"])
         # Create the modified recarray
         r1 = np.rec.array([(456, 'dbe', 1.2), (2, 'aaa', 1.2),

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -496,15 +496,14 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(rec[:2], (strnrows, 19))
         self.assertEqual(rec[3], b'1')
         if isinstance(rec[2], np.ndarray):
-            self.assertTrue(common.allequal(rec[2],
-                                     np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                rec[2], np.array((float(nrows),)*4, np.float32)))
         else:
             self.assertEqual(rec[2], nrows)
         if isinstance(rec[4], np.ndarray):
-            self.assertTrue(
-                common.allequal(rec[4],
-                         np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
-                                  np.complex64)))
+            self.assertTrue(common.allequal(
+                rec[4], np.array([0.+float(nrows)*1.j, float(nrows)+0.j],
+                                 np.complex64)))
         else:
             self.assertEqual(rec[4], float(nrows)+0.j)
         self.assertEqual(len(result), 20)
@@ -802,8 +801,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual((row['var1'], row['var2'], row['var7']),
                          (b"0001", nrows, b"1"))
         if isinstance(row['var5'], np.ndarray):
-            self.assertTrue(common.allequal(row['var5'],
-                                     np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                row['var5'], np.array((float(nrows),)*4, np.float32)))
         else:
             self.assertEqual(row['var5'], float(nrows))
         if self.appendrows <= 20:
@@ -904,8 +903,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual((row['var1'], row['var2'], row['var7']),
                          ("0001", nrows, "1"))
         if isinstance(row['var5'], np.ndarray):
-            self.assertTrue(common.allequal(row['var5'],
-                                     np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                row['var5'], np.array((float(nrows),)*4, np.float32)))
         else:
             self.assertEqual(row['var5'], float(nrows))
         if self.appendrows <= 20:
@@ -1700,7 +1699,7 @@ class RecArrayAlignedWriteTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class CompressBloscTablesTestCase(BasicTestCase):
     title = "CompressBloscTables"
     compress = 6
@@ -1708,7 +1707,7 @@ class CompressBloscTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class CompressBloscShuffleTablesTestCase(BasicTestCase):
     title = "CompressBloscTables"
     compress = 1
@@ -1717,9 +1716,10 @@ class CompressBloscShuffleTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
-@common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
-                 'BLOSC >= %s required' % common.min_blosc_bitshuffle_version)
+                        'BLOSC compression library not available')
+@common.unittest.skipIf(
+    common.blosc_version < common.min_blosc_bitshuffle_version,
+    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class CompressBloscBitShuffleTablesTestCase(BasicTestCase):
     title = "CompressBloscBitShuffleTables"
     compress = 1
@@ -1729,7 +1729,7 @@ class CompressBloscBitShuffleTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class CompressBloscBloscLZTablesTestCase(BasicTestCase):
     title = "CompressBloscLZTables"
     compress = 1
@@ -1738,7 +1738,7 @@ class CompressBloscBloscLZTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class CompressBloscLZ4TablesTestCase(BasicTestCase):
     title = "CompressLZ4Tables"
@@ -1748,7 +1748,7 @@ class CompressBloscLZ4TablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class CompressBloscLZ4HCTablesTestCase(BasicTestCase):
     title = "CompressLZ4HCTables"
@@ -1758,9 +1758,9 @@ class CompressBloscLZ4HCTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('snappy' not in tb.blosc_compressor_list(),
-                 'snappy required')
+                        'snappy required')
 class CompressBloscSnappyTablesTestCase(BasicTestCase):
     title = "CompressSnappyTables"
     compress = 1
@@ -1769,7 +1769,7 @@ class CompressBloscSnappyTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class CompressBloscZlibTablesTestCase(BasicTestCase):
     title = "CompressZlibTables"
@@ -1778,7 +1778,7 @@ class CompressBloscZlibTablesTestCase(BasicTestCase):
     complib = "blosc:zlib"
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class CompressBloscZstdTablesTestCase(BasicTestCase):
     title = "CompressZstdTables"
@@ -1787,14 +1787,16 @@ class CompressBloscZstdTablesTestCase(BasicTestCase):
     complib = "blosc:zstd"
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class CompressLZOTablesTestCase(BasicTestCase):
     title = "CompressLZOTables"
     compress = 1
     complib = "lzo"
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class CompressLZOShuffleTablesTestCase(BasicTestCase):
     title = "CompressLZOTables"
     compress = 1
@@ -1803,7 +1805,7 @@ class CompressLZOShuffleTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class CompressBzip2TablesTestCase(BasicTestCase):
     title = "CompressBzip2Tables"
     compress = 1
@@ -1811,7 +1813,7 @@ class CompressBzip2TablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class CompressBzip2ShuffleTablesTestCase(BasicTestCase):
     title = "CompressBzip2Tables"
     compress = 1
@@ -4709,8 +4711,8 @@ class CopyTestCase(common.TempFileMixin, common.PyTablesTestCase):
             for colname in table1.colnames:
                 # self.assertTrue(allequal(row1[colname],
                 # table2[nrow][colname]))
-                self.assertTrue(common.allequal(row1[colname],
-                                         table2.read(nrow, field=colname)[0]))
+                self.assertTrue(common.allequal(
+                    row1[colname], table2.read(nrow, field=colname)[0]))
 
         # Assert other properties in table
         self.assertEqual(table1.nrows, table2.nrows)
@@ -5040,8 +5042,8 @@ class CopyIndexTestCase(common.TempFileMixin, common.PyTablesTestCase):
         r2 = r[self.start:self.stop:self.step]
         for nrow in range(r2.shape[0]):
             for colname in table1.colnames:
-                self.assertTrue(common.allequal(r2[nrow][colname],
-                                         table2[nrow][colname]))
+                self.assertTrue(common.allequal(
+                    r2[nrow][colname], table2[nrow][colname]))
 
         # Assert the number of rows in table
         if common.verbose:
@@ -5090,8 +5092,8 @@ class CopyIndexTestCase(common.TempFileMixin, common.PyTablesTestCase):
         r2 = r[self.start:self.stop:self.step]
         for nrow in range(r2.shape[0]):
             for colname in table1.colnames:
-                self.assertTrue(common.allequal(r2[nrow][colname],
-                                         table2[nrow][colname]))
+                self.assertTrue(common.allequal(
+                    r2[nrow][colname], table2[nrow][colname]))
 
         # Assert the number of rows in table
         if common.verbose:

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -116,8 +116,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self.initRecArray()
         for j in range(3):
             # Create a table
-            filters = tb.Filters(complevel=self.compress,
-                                     complib=self.complib)
+            filters = tb.Filters(complevel=self.compress, complib=self.complib)
             if j < 2:
                 byteorder = sys.byteorder
             else:

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -259,8 +259,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             r['var7']
         ), (b"0001", b"0001", nrows, nrows, b"1"))
         if isinstance(r['var5'], np.ndarray):
-            self.assertTrue(common.allequal(r['var5'],
-                                     np.array((nrows,)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                r['var5'], np.array((nrows,)*4, np.float32)))
         else:
             self.assertEqual(r['var5'], float(nrows))
         self.assertEqual(len(result), 20)
@@ -287,21 +287,21 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         nrows = table.nrows
         result2 = [r for r in table.iterrows() if r['var2'][0][0] < 20][-1]
         if isinstance(result2['var5'], np.ndarray):
-            self.assertTrue(common.allequal(result1[0],
-                                     np.array((float(0),)*4, np.float32)))
-            self.assertTrue(common.allequal(result1[1],
-                                     np.array((float(1),)*4, np.float32)))
-            self.assertTrue(common.allequal(result1[2],
-                                     np.array((float(2),)*4, np.float32)))
-            self.assertTrue(common.allequal(result1[3],
-                                     np.array((float(3),)*4, np.float32)))
-            self.assertTrue(common.allequal(result1[10],
-                                     np.array((float(10),)*4, np.float32)))
-            self.assertTrue(common.allequal(result2['var5'],
-                                     np.array((float(nrows-1),)*4,
-                                              np.float32)))
+            self.assertTrue(common.allequal(
+                result1[0], np.array((float(0),) * 4, np.float32)))
+            self.assertTrue(common.allequal(
+                result1[1], np.array((float(1),) * 4, np.float32)))
+            self.assertTrue(common.allequal(
+                result1[2], np.array((float(2),) * 4, np.float32)))
+            self.assertTrue(common.allequal(
+                result1[3], np.array((float(3),) * 4, np.float32)))
+            self.assertTrue(common.allequal(
+                result1[10], np.array((float(10),) * 4, np.float32)))
+            self.assertTrue(common.allequal(
+                result2['var5'], np.array((float(nrows - 1),) * 4, np.float32)
+            ))
         else:
-            self.assertEqual(result2['var5'], float(nrows-1))
+            self.assertEqual(result2['var5'], float(nrows - 1))
         self.assertEqual(len(result1), 20)
 
         # Read the records and select those with "var2" file less than 20
@@ -393,8 +393,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
             row['var7']),
             (b"0001", b"0001", nrows, nrows, b"1"))
         if isinstance(row['var5'], np.ndarray):
-            self.assertTrue(common.allequal(row['var5'],
-                                     np.array((float(nrows),)*4, np.float32)))
+            self.assertTrue(common.allequal(
+                row['var5'], np.array((float(nrows),) * 4, np.float32)))
         else:
             self.assertEqual(row['var5'], float(nrows))
         if self.appendrows <= 20:
@@ -499,14 +499,15 @@ class RecArrayAlignedWriteTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class CompressBloscTablesTestCase(BasicTestCase):
     title = "CompressBloscTables"
     compress = 1
     complib = "blosc"
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(not common.lzo_avail,
+                        'LZO compression library not available')
 class CompressLZOTablesTestCase(BasicTestCase):
     title = "CompressLZOTables"
     compress = 1
@@ -514,7 +515,7 @@ class CompressLZOTablesTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class CompressBzip2TablesTestCase(BasicTestCase):
     title = "CompressBzip2Tables"
     compress = 1

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -11,30 +11,30 @@ from tables.tests import common
 
 # Test Record class
 class Record(tb.IsDescription):
-    var0 = tb.StringCol(itemsize=4, dflt=b"", shape=2)  # 4-character string array
+    var0 = tb.StringCol(itemsize=4, dflt=b"", shape=2)  # 4-char str array
     var1 = tb.StringCol(itemsize=4, dflt=[b"abcd", b"efgh"], shape=(2, 2))
     var1_ = tb.IntCol(dflt=((1, 1),), shape=2)           # integer array
     var2 = tb.IntCol(dflt=((1, 1), (1, 1)), shape=(2, 2))  # integer array
-    var3 = tb.Int16Col(dflt=2)                         # short integer
-    var4 = tb.FloatCol(dflt=3.1)                       # double (double-precision)
-    var5 = tb.Float32Col(dflt=4.2)                     # float  (single-precision)
-    var6 = tb.UInt16Col(dflt=5)                        # unsigned short integer
-    var7 = tb.StringCol(itemsize=1, dflt=b"e")          # 1-character String
+    var3 = tb.Int16Col(dflt=2)  # short integer
+    var4 = tb.FloatCol(dflt=3.1)  # double (double-precision)
+    var5 = tb.Float32Col(dflt=4.2)  # float  (single-precision)
+    var6 = tb.UInt16Col(dflt=5)  # unsigned short integer
+    var7 = tb.StringCol(itemsize=1, dflt=b"e")  # 1-character String
 
 
 #  Dictionary definition
 RecordDescriptionDict = {
     'var0': tb.StringCol(itemsize=4, dflt=b"", shape=2),  # 4-char str array
     'var1': tb.StringCol(itemsize=4, dflt=[b"abcd", b"efgh"], shape=(2, 2)),
-    # 'var0': StringCol(itemsize=4, shape=2),       # 4-character String
-    # 'var1': StringCol(itemsize=4, shape=(2,2)),   # 4-character String
-    'var1_': tb.IntCol(shape=2),                      # integer array
-    'var2': tb.IntCol(shape=(2, 2)),                  # integer array
-    'var3': tb.Int16Col(),                           # short integer
-    'var4': tb.FloatCol(),                           # double (double-precision)
-    'var5': tb.Float32Col(),                         # float  (single-precision)
-    'var6': tb.Int16Col(),                           # unsigned short integer
-    'var7': tb.StringCol(itemsize=1),                # 1-character String
+    # 'var0': StringCol(itemsize=4, shape=2),  # 4-character String
+    # 'var1': StringCol(itemsize=4, shape=(2,2)),  # 4-character String
+    'var1_': tb.IntCol(shape=2),  # integer array
+    'var2': tb.IntCol(shape=(2, 2)),  # integer array
+    'var3': tb.Int16Col(),  # short integer
+    'var4': tb.FloatCol(),  # double (double-precision)
+    'var5': tb.Float32Col(),  # float  (single-precision)
+    'var6': tb.Int16Col(),  # unsigned short integer
+    'var7': tb.StringCol(itemsize=1),  # 1-character String
 }
 
 # Record class with numpy dtypes (mixed shapes is checked here)
@@ -44,7 +44,8 @@ class RecordDT(tb.IsDescription):
     var0 = tb.Col.from_dtype(np.dtype("2S4"), dflt=b"")  # shape in dtype
     var1 = tb.Col.from_dtype(np.dtype(("S4", (
         2, 2))), dflt=[b"abcd", b"efgh"])  # shape is a mix
-    var1_ = tb.Col.from_dtype(np.dtype("2i4"), dflt=((1, 1),))  # shape in dtype
+    var1_ = tb.Col.from_dtype(
+        np.dtype("2i4"), dflt=((1, 1),))  # shape in dtype
     var2 = tb.Col.from_sctype("i4", shape=(
         2, 2), dflt=((1, 1), (1, 1)))  # shape is a mix
     var3 = tb.Col.from_dtype(np.dtype("i2"), dflt=2)
@@ -2213,7 +2214,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(RecArrayOneWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(RecArrayTwoWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(RecArrayThreeWriteTestCase))
-        theSuite.addTest(common.unittest.makeSuite(RecArrayAlignedWriteTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(RecArrayAlignedWriteTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressZLIBTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressTwoTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(IterRangeTestCase))
@@ -2231,10 +2233,12 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(UpdateRowTestCase2))
         theSuite.addTest(common.unittest.makeSuite(UpdateRowTestCase3))
         theSuite.addTest(common.unittest.makeSuite(UpdateRowTestCase4))
-        theSuite.addTest(common.unittest.makeSuite(CompressBloscTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBloscTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressLZOTablesTestCase))
     if common.heavy:
-        theSuite.addTest(common.unittest.makeSuite(CompressBzip2TablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBzip2TablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(BigTablesTestCase))
 
     return theSuite

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -25,8 +25,8 @@ class Record(tb.IsDescription):
 RecordDescriptionDict = {
     'var0': tb.StringCol(itemsize=4, dflt=b"", shape=2),  # 4-char str array
     'var1': tb.StringCol(itemsize=4, dflt=[b"abcd", b"efgh"], shape=(2, 2)),
-    #'var0': StringCol(itemsize=4, shape=2),       # 4-character String
-    #'var1': StringCol(itemsize=4, shape=(2,2)),   # 4-character String
+    # 'var0': StringCol(itemsize=4, shape=2),       # 4-character String
+    # 'var1': StringCol(itemsize=4, shape=(2,2)),   # 4-character String
     'var1_': tb.IntCol(shape=2),                      # integer array
     'var2': tb.IntCol(shape=(2, 2)),                  # integer array
     'var3': tb.Int16Col(),                           # short integer
@@ -540,8 +540,8 @@ class BigTablesTestCase(BasicTestCase):
     # reducing to 1000 would be more than enough
     # F. Alted 2004-01-19
 
-    #expectedrows = 10000
-    #appendrows = 1000
+    # expectedrows = 10000
+    # appendrows = 1000
     expectedrows = 1000
     appendrows = 100
 
@@ -942,8 +942,8 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 (type, value, traceback) = sys.exc_info()
                 print("\nGreat!, the next ValueError was catched!")
             self.h5file.close()
-        #else:
-        #    self.fail("expected a ValueError")
+        # else:
+        #     self.fail("expected a ValueError")
 
         # Case where step == 0
         self.step = 0
@@ -954,8 +954,8 @@ class BasicRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 (type, value, traceback) = sys.exc_info()
                 print("\nGreat!, the next ValueError was catched!")
             self.h5file.close()
-        #else:
-        #    self.fail("expected a ValueError")
+        # else:
+        #     self.fail("expected a ValueError")
 
 
 class IterRangeTestCase(BasicRangeTestCase):

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -21,6 +21,7 @@ class Record(tb.IsDescription):
     var6 = tb.UInt16Col(dflt=5)                        # unsigned short integer
     var7 = tb.StringCol(itemsize=1, dflt=b"e")          # 1-character String
 
+
 #  Dictionary definition
 RecordDescriptionDict = {
     'var0': tb.StringCol(itemsize=4, dflt=b"", shape=2),  # 4-char str array

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -1120,8 +1120,8 @@ class RecArrayIO(common.TempFileMixin, common.PyTablesTestCase):
         table.cols.col1[1:] = [[[2, 3], [3, 4], [4, 5]]]
 
         # Create the modified recarray
-        r1 = np.rec.array([ ([456, 457], s0, f0), ([2, 3], s1, f1),
-                            ([3, 4], s2, f2), ([4, 5], s3, f3)],
+        r1 = np.rec.array([([456, 457], s0, f0), ([2, 3], s1, f1),
+                           ([3, 4], s2, f2), ([4, 5], s3, f3)],
                           formats="(2,)i4,(3,)a3,(3,2)f8",
                           names="col1,col2,col3")
 

--- a/tables/tests/test_tablesMD.py
+++ b/tables/tests/test_tablesMD.py
@@ -23,8 +23,7 @@ class Record(tb.IsDescription):
 
 #  Dictionary definition
 RecordDescriptionDict = {
-    'var0': tb.StringCol(itemsize=4, dflt=b"", shape=2),  # 4-character string
-                                                       # array
+    'var0': tb.StringCol(itemsize=4, dflt=b"", shape=2),  # 4-char str array
     'var1': tb.StringCol(itemsize=4, dflt=[b"abcd", b"efgh"], shape=(2, 2)),
     #'var0': StringCol(itemsize=4, shape=2),       # 4-character String
     #'var1': StringCol(itemsize=4, shape=(2,2)),   # 4-character String

--- a/tables/tests/test_timestamps.py
+++ b/tables/tests/test_timestamps.py
@@ -69,7 +69,8 @@ class TrackTimesMixin:
         vla.append(var3List)
 
 
-class TimestampTestCase(TrackTimesMixin, common.TempFileMixin, common.PyTablesTestCase):
+class TimestampTestCase(TrackTimesMixin, common.TempFileMixin,
+                        common.PyTablesTestCase):
     title = "A title"
     nrows = 10
 
@@ -114,7 +115,8 @@ class TimestampTestCase(TrackTimesMixin, common.TempFileMixin, common.PyTablesTe
             self.assertGreaterEqual(tracked_ctimes[1], tracked_ctimes[0])
 
 
-class BitForBitTestCase(TrackTimesMixin, common.TempFileMixin, common.PyTablesTestCase):
+class BitForBitTestCase(TrackTimesMixin, common.TempFileMixin,
+                        common.PyTablesTestCase):
     title = "A title"
     nrows = 10
 

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -149,7 +149,7 @@ class CompareTestCase(common.TempFileMixin, common.PyTablesTestCase):
     # The description used in the test Table.
     class MyTimeRow(tb.IsDescription):
         t32col = tb.Time32Col(pos=0)
-        t64col = tb.Time64Col(shape=(2,), pos = 1)
+        t64col = tb.Time64Col(shape=(2,), pos=1)
 
     # The atoms used in the test VLArrays.
     myTime32Atom = tb.Time32Atom(shape=(2,))
@@ -341,7 +341,7 @@ class UnalignedTestCase(common.TempFileMixin, common.PyTablesTestCase):
     class MyTimeRow(tb.IsDescription):
         i8col = tb.Int8Col(pos=0)
         t32col = tb.Time32Col(pos=1)
-        t64col = tb.Time64Col(shape=(2,), pos = 2)
+        t64col = tb.Time64Col(shape=(2,), pos=2)
 
     def test00_CompareTable(self):
         """Comparing written unaligned time data with read data in a Table."""

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -281,8 +281,9 @@ class CompareTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t64col'][:])
-        self.assertTrue(common.allequal(recarr['t64col'][:], orig_val, np.float64),
-                        "Stored and retrieved values do not match.")
+        self.assertTrue(
+            common.allequal(recarr['t64col'][:], orig_val, np.float64),
+            "Stored and retrieved values do not match.")
 
     def test03_Compare64EArray(self):
         """Comparing written 64-bit time data with read data in an EArray."""
@@ -391,8 +392,9 @@ class UnalignedTestCase(common.TempFileMixin, common.PyTablesTestCase):
         if common.verbose:
             print("Original values:", orig_val)
             print("Retrieved values:", recarr['t64col'][:])
-        self.assertTrue(common.allequal(recarr['t64col'][:], orig_val, np.float64),
-                        "Stored and retrieved values do not match.")
+        self.assertTrue(common.allequal(
+            recarr['t64col'][:], orig_val, np.float64),
+            "Stored and retrieved values do not match.")
 
 
 class BigEndianTestCase(common.PyTablesTestCase):

--- a/tables/tests/test_timetype.py
+++ b/tables/tests/test_timetype.py
@@ -520,10 +520,3 @@ if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()
     common.unittest.main(defaultTest='suite')
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -671,7 +671,7 @@ class DeepTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         h5fname2 = tempfile.mktemp(".h5")
         try:
             with tb.open_file(h5fname2, mode="w",
-                                  node_cache_slots=10) as h5file2:
+                              node_cache_slots=10) as h5file2:
                 if common.verbose:
                     print("\nCopying deep tree...")
 
@@ -987,7 +987,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
             if pathname == node_to_find:
                 found_node = True
             self.assertIn(pathname, hidden,
-                            "Listed hidden node ``%s``." % pathname)
+                          f"Listed hidden node ``{pathname}``.")
 
         self.assertTrue(found_node,
                         "Hidden node ``%s`` was not listed." % node_to_find)
@@ -1004,7 +1004,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
             if pathname == node_to_find:
                 found_node = True
             self.assertIn(pathname, hidden,
-                            "Listed hidden node ``%s``." % pathname)
+                          f"Listed hidden node ``{pathname}``.")
 
         self.assertTrue(found_node,
                         "Hidden node ``%s`` was not listed." % node_to_find)

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -506,8 +506,8 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         """
         root_dir = dir(self.h5file.root)
 
-        ## Check some regular attributes.
-        #
+        # Check some regular attributes.
+
         self.assertIn('_v_children', root_dir)
         self.assertIn('_v_attrs', root_dir)
         self.assertIn('_v_groups', root_dir)
@@ -515,8 +515,8 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertIn('_g_get_child_group_class', root_dir)
         self.assertIn('_f_close', root_dir)
 
-        ## Check children nodes.
-        #
+        # Check children nodes.
+
         self.assertIn('group0', root_dir)
         self.assertIn('table0', root_dir)
         self.assertIn('var1', root_dir)

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -943,7 +943,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for group in self.h5file.walk_groups('/'):
             pathname = group._v_pathname
             self.assertNotIn(pathname, hidden,
-                            "Walked across hidden group ``%s``." % pathname)
+                             f"Walked across hidden group ``{pathname}``.")
 
     def test03_walkNodes(self):
         """Hidden node absence in `File.walk_nodes()`."""
@@ -953,7 +953,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in self.h5file.walk_nodes('/'):
             pathname = node._v_pathname
             self.assertNotIn(pathname, hidden,
-                            "Walked across hidden node ``%s``." % pathname)
+                             f"Walked across hidden node ``{pathname}``.")
 
     def test04_listNodesVisible(self):
         """Listing visible nodes under a visible group (list_nodes)."""
@@ -963,7 +963,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in self.h5file.list_nodes('/g'):
             pathname = node._v_pathname
             self.assertNotIn(pathname, hidden,
-                            "Listed hidden node ``%s``." % pathname)
+                             f"Listed hidden node ``{pathname}``.")
 
     def test04b_listNodesVisible(self):
         """Listing visible nodes under a visible group (iter_nodes)."""
@@ -973,7 +973,7 @@ class HiddenTreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in self.h5file.iter_nodes('/g'):
             pathname = node._v_pathname
             self.assertNotIn(pathname, hidden,
-                            "Listed hidden node ``%s``." % pathname)
+                             f"Listed hidden node ``{pathname}``.")
 
     def test05_listNodesHidden(self):
         """Listing visible nodes under a hidden group (list_nodes)."""

--- a/tables/tests/test_tree.py
+++ b/tables/tests/test_tree.py
@@ -134,7 +134,7 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
             for name in nodenames:
                 try:
                     object = self.h5file.get_node(group, name, 'Array')
-                except:
+                except Exception:
                     pass
                 else:
                     nodearrays.append(object._v_pathname)
@@ -194,7 +194,7 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in nodelist:
             try:
                 objectlist = self.h5file.list_nodes(node)
-            except:
+            except Exception:
                 pass
             else:
                 objects.extend(objectlist)
@@ -212,7 +212,7 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in objects:
             try:
                 objectlist = self.h5file.list_nodes(node)
-            except:
+            except Exception:
                 pass
             else:
                 for object in objectlist:
@@ -290,7 +290,7 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in nodelist:
             try:
                 objectlist = [o for o in self.h5file.iter_nodes(node)]
-            except:
+            except Exception:
                 pass
             else:
                 objects.extend(objectlist)
@@ -308,7 +308,7 @@ class TreeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         for node in objects:
             try:
                 objectlist = [o for o in self.h5file.iter_nodes(node)]
-            except:
+            except Exception:
                 pass
             else:
                 for object in objectlist:

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -296,7 +296,8 @@ class AtomTestCase(common.PyTablesTestCase):
 
     def test_from_kind_05(self):
         # ValueError: no default item size for kind ``string``
-        self.assertRaises(ValueError, tb.Atom.from_kind, 'string', dflt=b'hello')
+        self.assertRaises(ValueError, tb.Atom.from_kind, 'string',
+                          dflt=b'hello')
 
     def test_from_kind_06(self):
         # ValueError: unknown kind: 'Float'

--- a/tables/tests/test_utils.py
+++ b/tables/tests/test_utils.py
@@ -87,6 +87,7 @@ def suite():
 
     return theSuite
 
+
 if __name__ == '__main__':
     common.parse_argv(sys.argv)
     common.print_versions()

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -2389,8 +2389,7 @@ class ReadRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
     def populateFile(self):
         group = self.rootgroup
-        filters = tb.Filters(complevel=self.compress,
-                                 complib=self.complib)
+        filters = tb.Filters(complevel=self.compress, complib=self.complib)
         vlarray = self.h5file.create_vlarray(group, 'vlarray', tb.Int32Atom(),
                                              "ragged array if ints",
                                              filters=filters,
@@ -2786,8 +2785,7 @@ class GetItemRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
     def populateFile(self):
         group = self.rootgroup
-        filters = tb.Filters(complevel=self.compress,
-                                 complib=self.complib)
+        filters = tb.Filters(complevel=self.compress, complib=self.complib)
         vlarray = self.h5file.create_vlarray(group, 'vlarray', tb.Int32Atom(),
                                              "ragged array if ints",
                                              filters=filters,
@@ -3098,8 +3096,7 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
     def populateFile(self):
         group = self.rootgroup
-        filters = tb.Filters(complevel=self.compress,
-                                 complib=self.complib)
+        filters = tb.Filters(complevel=self.compress, complib=self.complib)
         vlarray = self.h5file.create_vlarray(group, 'vlarray', tb.Int32Atom(),
                                              "ragged array if ints",
                                              filters=filters,

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -254,7 +254,7 @@ class ZlibComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class BloscComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 0
@@ -262,23 +262,23 @@ class BloscComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class BloscShuffleComprTestCase(BasicTestCase):
     compress = 6
     shuffle = 1
     complib = "blosc"
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
-                 'BLOSC >= %s required' % common.min_blosc_bitshuffle_version)
+                        f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class BloscBitShuffleComprTestCase(BasicTestCase):
     compress = 9
     bitshuffle = 1
     complib = "blosc"
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 class BloscBloscLZComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
@@ -286,7 +286,7 @@ class BloscBloscLZComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4ComprTestCase(BasicTestCase):
     compress = 9
@@ -295,7 +295,7 @@ class BloscLZ4ComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4HCComprTestCase(BasicTestCase):
     compress = 9
@@ -304,9 +304,9 @@ class BloscLZ4HCComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('snappy' not in tb.blosc_compressor_list(),
-                 'snappy required')
+                        'snappy required')
 class BloscSnappyComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
@@ -314,7 +314,7 @@ class BloscSnappyComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class BloscZlibComprTestCase(BasicTestCase):
     compress = 9
@@ -322,7 +322,7 @@ class BloscZlibComprTestCase(BasicTestCase):
     complib = "blosc:zlib"
 
 @common.unittest.skipIf(not common.blosc_avail,
-                 'BLOSC compression library not available')
+                        'BLOSC compression library not available')
 @common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class BloscZstdComprTestCase(BasicTestCase):
     compress = 9
@@ -337,7 +337,7 @@ class LZOComprTestCase(BasicTestCase):
 
 
 @common.unittest.skipIf(not common.bzip2_avail,
-                 'BZIP2 compression library not available')
+                        'BZIP2 compression library not available')
 class Bzip2ComprTestCase(BasicTestCase):
     compress = 1
     complib = "bzip2"

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -646,7 +646,7 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32",
             "uint32",
             "int64",
-            #"UInt64",  # Unavailable in some platforms
+            # "UInt64",  # Unavailable in some platforms
         ]
         if common.verbose:
             print('\n', '-=' * 30)
@@ -688,7 +688,7 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32": np.int32,
             "uint32": np.uint32,
             "int64": np.int64,
-            #"UInt64": numpy.int64,  # Unavailable in some platforms
+            # "UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
             print('\n', '-=' * 30)
@@ -738,7 +738,7 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32",
             "uint32",
             "int64",
-            #"UInt64",  # Unavailable in some platforms
+            # "UInt64",  # Unavailable in some platforms
         ]
         if common.verbose:
             print('\n', '-=' * 30)
@@ -784,7 +784,7 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32": np.int32,
             "uint32": np.uint32,
             "int64": np.int64,
-            #"UInt64": numpy.int64,  # Unavailable in some platforms
+            # "UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
             print('\n', '-=' * 30)
@@ -840,7 +840,7 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32": np.int32,
             "uint32": np.uint32,
             "int64": np.int64,
-            #"UInt64": numpy.int64,  # Unavailable in some platforms
+            # "UInt64": numpy.int64,  # Unavailable in some platforms
         }
         if common.verbose:
             print('\n', '-=' * 30)
@@ -1809,7 +1809,7 @@ class MDTypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "int32",
             "uint32",
             "int64",
-            #"UInt64",  # Unavailable in some platforms
+            # "UInt64",  # Unavailable in some platforms
         ]
         root = self.rootgroup
         if common.verbose:
@@ -2190,7 +2190,7 @@ class FlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "uint32",
             "int64",
             # Not checked because some platforms does not support it
-            #"UInt64",
+            # "UInt64",
         ]
 
         root = self.rootgroup
@@ -2250,7 +2250,7 @@ class FlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
             "uint32",
             "int64",
             # Not checked because some platforms does not support it
-            #"UInt64",
+            # "UInt64",
         ]
 
         root = self.rootgroup
@@ -4231,7 +4231,7 @@ class TestCreateVLArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
         ptarr = self.h5file.create_vlarray(self.where, self.name,
                                            title=self.title,
                                            atom=self.atom)
-        #ptarr.append(self.obj)
+        # ptarr.append(self.obj)
         self.h5file.close()
 
         self.h5file = tb.open_file(self.h5fname)
@@ -4264,7 +4264,7 @@ class TestCreateVLArrayArgs(common.TempFileMixin, common.PyTablesTestCase):
 
     def test_kwargs_obj_atom_error(self):
         atom = tb.Atom.from_dtype(np.dtype('complex'))
-        #shape = self.shape + self.shape
+        # shape = self.shape + self.shape
         self.assertRaises(TypeError,
                           self.h5file.create_vlarray,
                           self.where,

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -152,7 +152,7 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 for i in range(len(rows1f)):
                     self.assertTrue(common.allequal(rows2[i], rows1f[i], self.flavor))
             elif self.flavor == "python":
-                    self.assertEqual(rows2, rows1)
+                self.assertEqual(rows2, rows1)
 
     def test02b_getitem(self):
         """Checking vlarray __getitem__ (scalars)"""

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -86,10 +86,10 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(nrows, vlarray.nrows)
         if self.flavor == "numpy":
             self.assertEqual(type(row), np.ndarray)
-            self.assertTrue(
-                common.allequal(row, np.array([1, 2], dtype='int32'), self.flavor))
-            self.assertTrue(
-                common.allequal(row2, np.array([], dtype='int32'), self.flavor))
+            self.assertTrue(common.allequal(
+                row, np.array([1, 2], dtype='int32'), self.flavor))
+            self.assertTrue(common.allequal(
+                row2, np.array([], dtype='int32'), self.flavor))
         elif self.flavor == "python":
             self.assertEqual(row, [1, 2])
             self.assertEqual(row2, [])
@@ -108,7 +108,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(self.shuffle, vlarray.filters.shuffle)
         if self.bitshuffle != vlarray.filters.bitshuffle and common.verbose:
             print("Error in shuffle. Class:", self.__class__.__name__)
-            print("self, vlarray:", self.bitshuffle, vlarray.filters.bitshuffle)
+            print("self, vlarray:", self.bitshuffle,
+                  vlarray.filters.bitshuffle)
         self.assertEqual(self.shuffle, vlarray.filters.shuffle)
         if self.fletcher32 != vlarray.filters.fletcher32 and common.verbose:
             print("Error in fletcher32. Class:", self.__class__.__name__)
@@ -150,7 +151,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 for val in rows1:
                     rows1f.append(np.array(val, dtype='int32'))
                 for i in range(len(rows1f)):
-                    self.assertTrue(common.allequal(rows2[i], rows1f[i], self.flavor))
+                    self.assertTrue(common.allequal(
+                        rows2[i], rows1f[i], self.flavor))
             elif self.flavor == "python":
                 self.assertEqual(rows2, rows1)
 
@@ -183,7 +185,8 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("Rows read in vlarray ==>", rows2)
 
             for i in range(len(rows1)):
-                self.assertTrue(common.allequal(rows2[i], rows1[i], self.flavor))
+                self.assertTrue(common.allequal(
+                    rows2[i], rows1[i], self.flavor))
 
     def test03_append(self):
         """Checking vlarray append."""
@@ -271,8 +274,9 @@ class BloscShuffleComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
-                        f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
+@common.unittest.skipIf(
+    common.blosc_version < common.min_blosc_bitshuffle_version,
+    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class BloscBitShuffleComprTestCase(BasicTestCase):
     compress = 9
     bitshuffle = 1
@@ -289,7 +293,8 @@ class BloscBloscLZComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4ComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
@@ -298,7 +303,8 @@ class BloscLZ4ComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('lz4' not in tb.blosc_compressor_list(), 'lz4 required')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc_compressor_list(), 'lz4 required')
 class BloscLZ4HCComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
@@ -317,7 +323,8 @@ class BloscSnappyComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zlib' not in tb.blosc_compressor_list(), 'zlib required')
+@common.unittest.skipIf(
+    'zlib' not in tb.blosc_compressor_list(), 'zlib required')
 class BloscZlibComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
@@ -326,14 +333,16 @@ class BloscZlibComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf('zstd' not in tb.blosc_compressor_list(), 'zstd required')
+@common.unittest.skipIf(
+    'zstd' not in tb.blosc_compressor_list(), 'zstd required')
 class BloscZstdComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
     complib = "blosc:zstd"
 
 
-@common.unittest.skipIf(not common.lzo_avail, 'LZO compression library not available')
+@common.unittest.skipIf(
+    not common.lzo_avail, 'LZO compression library not available')
 class LZOComprTestCase(BasicTestCase):
     compress = 1
     complib = "lzo"
@@ -427,7 +436,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        np.testing.assert_array_equal(row[0], np.array(["1", "123", "123"], 'S'))
+        np.testing.assert_array_equal(row[0],
+                                      np.array(["1", "123", "123"], 'S'))
         np.testing.assert_array_equal(row[1], np.array(["1", "321"], 'S'))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
@@ -531,9 +541,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(
-            common.allequal(row[0], np.array([b"1", b"123", b"12", b"", b"123"])))
-        self.assertTrue(common.allequal(row[1], np.array(["44", "4"], dtype="S3")))
+        self.assertTrue(common.allequal(
+            row[0], np.array([b"1", b"123", b"12", b"", b"123"])))
+        self.assertTrue(common.allequal(
+            row[1], np.array(["44", "4"], dtype="S3")))
         self.assertEqual(len(row[0]), 5)
         self.assertEqual(len(row[1]), 2)
 
@@ -581,7 +592,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print('\n', '-=' * 30)
             print("Running %s.test02_BoolAtom..." % self.__class__.__name__)
 
-        vlarray = self.h5file.create_vlarray('/', 'BoolAtom', atom=tb.BoolAtom(),
+        vlarray = self.h5file.create_vlarray('/', 'BoolAtom',
+                                             atom=tb.BoolAtom(),
                                              title="Ragged array of Booleans")
         vlarray.append([1, 0, 3])
         vlarray.append([-1, 0])
@@ -599,8 +611,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(common.allequal(row[0], np.array([1, 0, 1], dtype='bool')))
-        self.assertTrue(common.allequal(row[1], np.array([1, 0], dtype='bool')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([1, 0, 1], dtype='bool')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([1, 0], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
 
@@ -611,7 +625,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print('\n', '-=' * 30)
             print("Running %s.test02b_BoolAtom..." % self.__class__.__name__)
 
-        vlarray = self.h5file.create_vlarray('/', 'BoolAtom', atom=tb.BoolAtom(),
+        vlarray = self.h5file.create_vlarray('/', 'BoolAtom',
+                                             atom=tb.BoolAtom(),
                                              title="Ragged array of Booleans")
         vlarray.append([1, 0, 3])
         vlarray.append([-1, 0])
@@ -633,8 +648,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertTrue(common.allequal(row[0], np.array([0, 1, 1], dtype='bool')))
-        self.assertTrue(common.allequal(row[1], np.array([0, 1], dtype='bool')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([0, 1, 1], dtype='bool')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([0, 1], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 2)
 
@@ -656,8 +673,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("Running %s.test03_IntAtom..." % self.__class__.__name__)
 
         for atype in ttypes:
-            vlarray = self.h5file.create_vlarray('/', atype,
-                                                 atom=tb.Atom.from_sctype(atype))
+            vlarray = self.h5file.create_vlarray(
+                '/', atype, atom=tb.Atom.from_sctype(atype))
             vlarray.append([1, 2, 3])
             vlarray.append([-1, 0])
 
@@ -675,8 +692,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(common.allequal(row[0], np.array([1, 2, 3], dtype=atype)))
-            self.assertTrue(common.allequal(row[1], np.array([-1, 0], dtype=atype)))
+            self.assertTrue(
+                common.allequal(row[0], np.array([1, 2, 3], dtype=atype)))
+            self.assertTrue(
+                common.allequal(row[1], np.array([-1, 0], dtype=atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -723,10 +742,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                common.allequal(row[0], np.array([1, 2, 3], dtype=ttypes[atype])))
-            self.assertTrue(
-                common.allequal(row[1], np.array([-1, 0], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[0], np.array([1, 2, 3], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[1], np.array([-1, 0], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -771,8 +790,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(common.allequal(row[0], np.array([3, 2, 1], dtype=atype)))
-            self.assertTrue(common.allequal(row[1], np.array([0, -1], dtype=atype)))
+            self.assertTrue(
+                common.allequal(row[0], np.array([3, 2, 1], dtype=atype)))
+            self.assertTrue(
+                common.allequal(row[1], np.array([0, -1], dtype=atype)))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -825,10 +846,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                common.allequal(row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
-            self.assertTrue(
-                common.allequal(row[1], np.array([0, -1], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[1], np.array([0, -1], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -888,10 +909,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                                  sys.byteorder)
                 self.assertEqual(vlarray.byteorder, byteorder)
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(
-                common.allequal(row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
-            self.assertTrue(
-                common.allequal(row[1], np.array([0, -1], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[0], np.array([3, 2, 1], dtype=ttypes[atype])))
+            self.assertTrue(common.allequal(
+                row[1], np.array([0, -1], dtype=ttypes[atype])))
             self.assertEqual(len(row[0]), 3)
             self.assertEqual(len(row[1]), 2)
 
@@ -931,7 +952,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(common.allequal(row[0], np.array([1.3, 2.2, 3.3], atype)))
+            self.assertTrue(common.allequal(
+                row[0], np.array([1.3, 2.2, 3.3], atype)))
             self.assertTrue(common.allequal(
                 row[1], np.array([-1.3e34, 1.e-32], atype)))
             self.assertEqual(len(row[0]), 3)
@@ -1028,7 +1050,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.nrows, 2)
-            self.assertTrue(common.allequal(row[0], np.array([4.3, 2.2, 4.3], atype)))
+            self.assertTrue(common.allequal(
+                row[0], np.array([4.3, 2.2, 4.3], atype)))
             self.assertTrue(
                 common.allequal(row[1], np.array([-1.1e34, 1.3e-32], atype)))
             self.assertEqual(len(row[0]), 3)
@@ -1143,7 +1166,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
                 print("First row in vlarray ==>", row[0])
 
             self.assertEqual(vlarray.byteorder, byteorder)
-            self.assertEqual(tb.utils.byteorders[row[0].dtype.byteorder], sys.byteorder)
+            self.assertEqual(tb.utils.byteorders[row[0].dtype.byteorder],
+                             sys.byteorder)
             self.assertEqual(vlarray.nrows, 2)
             self.assertTrue(common.allequal(
                 row[0], np.array([4.3, 2.2, 4.3], dtype=ttypes[atype])))
@@ -1337,7 +1361,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
 
         vlarray = self.h5file.create_vlarray(
             '/', "Object", atom=tb.ObjectAtom())
-        vlarray.append([[1, 2, 3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"])
+        vlarray.append(
+            [[1, 2, 3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"])
         vlarray.append([3, 4, C()])
         vlarray.append(42)
 
@@ -1354,7 +1379,9 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertEqual(row[0], [[1, 2, 3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"])
+        self.assertEqual(
+            row[0],
+            [[1, 2, 3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"])
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [3, 4])
@@ -1371,10 +1398,12 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print('\n', '-=' * 30)
             print("Running %s.test06b_Object..." % self.__class__.__name__)
 
-        vlarray = self.h5file.create_vlarray('/', "Object", atom=tb.ObjectAtom())
+        vlarray = self.h5file.create_vlarray('/', "Object",
+                                             atom=tb.ObjectAtom())
         # When updating an object, this seems to change the number
         # of bytes that pickle.dumps generates
-        # vlarray.append(([1,2,3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"))
+        # vlarray.append(
+        #     ([1,2,3], "aaa", "aaa\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"))
         vlarray.append(([1, 2, 3], "aaa", "\xef\xbf\xbd\xef\xbf\xbd4"))
         # vlarray.append([3,4, C()])
         vlarray.append([3, 4, [24]])
@@ -1398,7 +1427,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 2)
-        self.assertEqual(row[0], ([1, 2, 4], "aa4", "\xef\xbf\xbd\xef\xbf\xbd5"))
+        self.assertEqual(row[0],
+                         ([1, 2, 4], "aa4", "\xef\xbf\xbd\xef\xbf\xbd5"))
         list1 = list(row[1])
         obj = list1.pop()
         self.assertEqual(list1, [4, 4])
@@ -1415,7 +1445,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print('\n', '-=' * 30)
             print("Running %s.test06c_Object..." % self.__class__.__name__)
 
-        vlarray = self.h5file.create_vlarray('/', "Object", atom=tb.ObjectAtom())
+        vlarray = self.h5file.create_vlarray('/', "Object",
+                                             atom=tb.ObjectAtom())
         vlarray.append(np.array([[1, 2], [0, 4]], 'i4'))
         vlarray.append(np.array([0, 1, 2, 3], 'i8'))
         vlarray.append(np.array(42, 'i1'))
@@ -1433,7 +1464,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertTrue(common.allequal(row[0], np.array([[1, 2], [0, 4]], 'i4')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([[1, 2], [0, 4]], 'i4')))
         self.assertTrue(common.allequal(row[1], np.array([0, 1, 2, 3], 'i8')))
         self.assertTrue(common.allequal(row[2], np.array(42, 'i1')))
 
@@ -1444,7 +1476,8 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print('\n', '-=' * 30)
             print("Running %s.test06d_Object..." % self.__class__.__name__)
 
-        vlarray = self.h5file.create_vlarray('/', "Object", atom=tb.ObjectAtom())
+        vlarray = self.h5file.create_vlarray('/', "Object",
+                                             atom=tb.ObjectAtom())
         vlarray.append(np.array([[1, 2], [0, 4]], 'i4'))
         vlarray.append(np.array([0, 1, 2, 3], 'i8'))
         vlarray.append(np.array(42, 'i1'))
@@ -1469,8 +1502,10 @@ class TypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", row[0])
 
         self.assertEqual(vlarray.nrows, 3)
-        self.assertTrue(common.allequal(row[0], np.array([[1, 0], [0, 4]], 'i4')))
-        self.assertTrue(common.allequal(row[1], np.array([0, 1, 0, 3], 'i8')))
+        self.assertTrue(common.allequal(
+            row[0], np.array([[1, 0], [0, 4]], 'i4')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([0, 1, 0, 3], 'i8')))
         self.assertTrue(common.allequal(row[2], np.array(22, 'i1')))
 
     def test07_VLUnicodeAtom(self):
@@ -1764,7 +1799,8 @@ class MDTypesTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(vlarray.nrows, 2)
         self.assertTrue(common.allequal(
             row[0], np.array([[1, 0, 1], [1, 1, 1], [0, 0, 0]], dtype='bool')))
-        self.assertTrue(common.allequal(row[1], np.array([[1, 0, 0]], dtype='bool')))
+        self.assertTrue(common.allequal(
+            row[1], np.array([[1, 0, 0]], dtype='bool')))
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 1)
 
@@ -1997,7 +2033,8 @@ class AppendShapeTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("First row in vlarray ==>", repr(row))
 
         self.assertEqual(vlarray.nrows, 1)
-        self.assertTrue(common.allequal(row, np.zeros(dtype='int32', shape=(0,))))
+        self.assertTrue(common.allequal(
+            row, np.zeros(dtype='int32', shape=(0,))))
         self.assertEqual(len(row), 0)
 
     def test03a_cast(self):
@@ -2092,8 +2129,8 @@ class FlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
                   self.__class__.__name__)
 
         # Create an string atom
-        vlarray = self.h5file.create_vlarray(root, "vlarray",
-                                             tb.Atom.from_kind('int', itemsize=4))
+        vlarray = self.h5file.create_vlarray(
+            root, "vlarray", tb.Atom.from_kind('int', itemsize=4))
         vlarray.flavor = self.flavor
         self.h5file.close()
         self.h5file = tb.open_file(self.h5fname, "r")
@@ -2120,8 +2157,8 @@ class FlavorTestCase(common.TempFileMixin, common.PyTablesTestCase):
                   self.__class__.__name__)
 
         # Create an string atom
-        vlarray = self.h5file.create_vlarray(root, "vlarray",
-                                             tb.Atom.from_kind('int', itemsize=4))
+        vlarray = self.h5file.create_vlarray(
+            root, "vlarray", tb.Atom.from_kind('int', itemsize=4))
         vlarray.flavor = self.flavor
 
         # Read all the rows (it should be empty):
@@ -2505,13 +2542,14 @@ class ReadRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 1)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(common.allequal(row[0][0], np.arange(0, dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[0][0], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(common.allequal(row[1][
-                            x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(common.allequal(row[2][
-                            x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test02b_stop(self):
         """Checking reads with only a stop value in a slice"""
@@ -2539,11 +2577,14 @@ class ReadRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
         for x in range(1):
-            self.assertTrue(common.allequal(row[0][x], np.arange(0, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(common.allequal(row[1][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test03_startstop(self):
         """Checking reads with a start and stop values"""
@@ -2571,11 +2612,14 @@ class ReadRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(common.allequal(row[0][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(common.allequal(row[1][x-5], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test03b_startstop(self):
         """Checking reads with a start and stop values in slices"""
@@ -2603,11 +2647,14 @@ class ReadRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(common.allequal(row[0][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(common.allequal(row[1][x-5], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test04_startstopstep(self):
         """Checking reads with a start, stop & step values"""
@@ -2878,11 +2925,14 @@ class GetItemRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 1)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(common.allequal(row[0][0], np.arange(0, dtype='int32')))
+        self.assertTrue(common.allequal(
+            row[0][0], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(common.allequal(row[1][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test02b_stop(self):
         """Checking reads with only a stop value in a slice"""
@@ -2910,11 +2960,14 @@ class GetItemRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
         for x in range(1):
-            self.assertTrue(common.allequal(row[0][x], np.arange(0, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(0, dtype='int32')))
         for x in range(10):
-            self.assertTrue(common.allequal(row[1][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x], np.arange(x, dtype='int32')))
         for x in range(99):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test03_startstop(self):
         """Checking reads with a start and stop values"""
@@ -2942,11 +2995,14 @@ class GetItemRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(common.allequal(row[0][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(common.allequal(row[1][x-5], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test03b_startstop(self):
         """Checking reads with a start and stop values in slices"""
@@ -2974,11 +3030,14 @@ class GetItemRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 100)
         for x in range(0, 10):
-            self.assertTrue(common.allequal(row[0][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[0][x], np.arange(x, dtype='int32')))
         for x in range(5, 15):
-            self.assertTrue(common.allequal(row[1][x-5], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[1][x-5], np.arange(x, dtype='int32')))
         for x in range(0, 100):
-            self.assertTrue(common.allequal(row[2][x], np.arange(x, dtype='int32')))
+            self.assertTrue(common.allequal(
+                row[2][x], np.arange(x, dtype='int32')))
 
     def test04_slices(self):
         """Checking reads with a start, stop & step values"""
@@ -3136,9 +3195,12 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(common.allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[2], np.arange(99, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[2], np.arange(99, dtype='int32') * 2 + 3))
 
     def test01np_start(self):
         """Checking updates that modifies a complete row"""
@@ -3167,9 +3229,12 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 99)
-        self.assertTrue(common.allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[2], np.arange(99, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[2], np.arange(99, dtype='int32') * 2 + 3))
 
     def test02_partial(self):
         """Checking updates with only a part of a row"""
@@ -3198,8 +3263,10 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(common.allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(10, dtype='int32') * 2 + 3))
         a = np.arange(3, 99, dtype='int32')
         a = a * 2 + 3
         self.assertTrue(common.allequal(row[2], a))
@@ -3232,9 +3299,12 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 3)
         self.assertEqual(len(row[1]), 4)
         self.assertEqual(len(row[2]), 5)
-        self.assertTrue(common.allequal(row[0], np.arange(3, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(4, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[2], np.arange(5, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(3, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(4, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[2], np.arange(5, dtype='int32') * 2 + 3))
 
     def test03b_several_rows(self):
         """Checking updating several rows at once (list style)"""
@@ -3264,9 +3334,12 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(common.allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[2], np.arange(96, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[2], np.arange(96, dtype='int32') * 2 + 3))
 
     def test03c_several_rows(self):
         """Checking updating several rows at once (NumPy's where style)"""
@@ -3296,9 +3369,12 @@ class SetRangeTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(row[0]), 0)
         self.assertEqual(len(row[1]), 10)
         self.assertEqual(len(row[2]), 96)
-        self.assertTrue(common.allequal(row[0], np.arange(0, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[1], np.arange(10, dtype='int32') * 2 + 3))
-        self.assertTrue(common.allequal(row[2], np.arange(96, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[0], np.arange(0, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[1], np.arange(10, dtype='int32') * 2 + 3))
+        self.assertTrue(common.allequal(
+            row[2], np.arange(96, dtype='int32') * 2 + 3))
 
     def test04_out_of_range(self):
         """Checking out of range updates (first index)"""
@@ -3900,7 +3976,8 @@ class TruncateTestCase(common.TempFileMixin, common.PyTablesTestCase):
             print("array1-->", array1.read())
 
         self.assertEqual(array1.nrows, 1)
-        self.assertTrue(common.allequal(array1[0], np.array([456, 2], dtype='int16')))
+        self.assertTrue(common.allequal(
+            array1[0], np.array([456, 2], dtype='int16')))
 
     def test02_truncate(self):
         """Checking VLArray.truncate() method (truncating to == self.nrows)"""
@@ -3921,7 +3998,8 @@ class TruncateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(array1.nrows, 2)
         self.assertTrue(
             common.allequal(array1[0], np.array([456, 2], dtype='int16')))
-        self.assertTrue(common.allequal(array1[1], np.array([3], dtype='int16')))
+        self.assertTrue(common.allequal(
+            array1[1], np.array([3], dtype='int16')))
 
     def test03_truncate(self):
         """Checking VLArray.truncate() method (truncating to > self.nrows)"""
@@ -3944,11 +4022,14 @@ class TruncateTestCase(common.TempFileMixin, common.PyTablesTestCase):
         # Check the original values
         self.assertTrue(
             common.allequal(array1[0], np.array([456, 2], dtype='int16')))
-        self.assertTrue(common.allequal(array1[1], np.array([3], dtype='int16')))
+        self.assertTrue(common.allequal(
+            array1[1], np.array([3], dtype='int16')))
 
         # Check that the added rows are empty
-        self.assertTrue(common.allequal(array1[2], np.array([], dtype='int16')))
-        self.assertTrue(common.allequal(array1[3], np.array([], dtype='int16')))
+        self.assertTrue(common.allequal(
+            array1[2], np.array([], dtype='int16')))
+        self.assertTrue(common.allequal(
+            array1[3], np.array([], dtype='int16')))
 
 
 class TruncateOpenTestCase(TruncateTestCase):
@@ -4022,7 +4103,8 @@ class PointSelectionTestCase(common.TempFileMixin, common.PyTablesTestCase):
             self.assertRaises(IndexError, vlarr.__getitem__, key)
 
 
-class SizeInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeInMemoryPropertyTestCase(common.TempFileMixin,
+                                   common.PyTablesTestCase):
     def create_array(self, atom, complevel):
         filters = tb.Filters(complevel=complevel, complib='blosc')
         self.array = self.h5file.create_vlarray('/', 'vlarray', atom=atom,
@@ -4079,7 +4161,8 @@ class SizeInMemoryPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase
         self.assertEqual(self.array.size_in_memory, expected_size)
 
 
-class SizeOnDiskPropertyTestCase(common.TempFileMixin, common.PyTablesTestCase):
+class SizeOnDiskPropertyTestCase(common.TempFileMixin,
+                                 common.PyTablesTestCase):
     def create_array(self, atom, complevel):
         filters = tb.Filters(complevel=complevel, complib='blosc')
         self.h5file.create_vlarray('/', 'vlarray', atom, filters=filters)
@@ -4287,7 +4370,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(ZlibComprTestCase))
         theSuite.addTest(common.unittest.makeSuite(BloscComprTestCase))
         theSuite.addTest(common.unittest.makeSuite(BloscShuffleComprTestCase))
-        theSuite.addTest(common.unittest.makeSuite(BloscBitShuffleComprTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(BloscBitShuffleComprTestCase))
         theSuite.addTest(common.unittest.makeSuite(BloscBloscLZComprTestCase))
         theSuite.addTest(common.unittest.makeSuite(BloscLZ4ComprTestCase))
         theSuite.addTest(common.unittest.makeSuite(BloscLZ4HCComprTestCase))
@@ -4328,7 +4412,8 @@ def suite():
         theSuite.addTest(common.unittest.makeSuite(TruncateOpenTestCase))
         theSuite.addTest(common.unittest.makeSuite(TruncateCloseTestCase))
         theSuite.addTest(common.unittest.makeSuite(PointSelectionTestCase))
-        theSuite.addTest(common.unittest.makeSuite(SizeInMemoryPropertyTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(SizeInMemoryPropertyTestCase))
         theSuite.addTest(common.unittest.makeSuite(SizeOnDiskPropertyTestCase))
         theSuite.addTest(common.unittest.makeSuite(AccessClosedTestCase))
         theSuite.addTest(common.unittest.makeSuite(TestCreateVLArrayArgs))

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -268,6 +268,7 @@ class BloscShuffleComprTestCase(BasicTestCase):
     shuffle = 1
     complib = "blosc"
 
+
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
 @common.unittest.skipIf(common.blosc_version < common.min_blosc_bitshuffle_version,
@@ -276,6 +277,7 @@ class BloscBitShuffleComprTestCase(BasicTestCase):
     compress = 9
     bitshuffle = 1
     complib = "blosc"
+
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
@@ -320,6 +322,7 @@ class BloscZlibComprTestCase(BasicTestCase):
     compress = 9
     shuffle = 1
     complib = "blosc:zlib"
+
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')

--- a/tables/undoredo.py
+++ b/tables/undoredo.py
@@ -171,11 +171,3 @@ def undo_del_attr(file_, path, name):
 
 def redo_del_attr(file_, path, name):
     attr_to_shadow(file_, path, name)
-
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## End:

--- a/tables/undoredo.py
+++ b/tables/undoredo.py
@@ -126,7 +126,7 @@ def attr_to_shadow(file_, path, name):
 
     # Set the attribute only if it has not been kept in the shadow.
     # This avoids re-pickling complex attributes on REDO.
-    if not shname in shattrs:
+    if shname not in shattrs:
         shattrs._g__setattr(shname, value)
 
     attrs._g__delattr(name)

--- a/tables/undoredo.py
+++ b/tables/undoredo.py
@@ -75,7 +75,6 @@ def move_to_shadow(file_, path):
     node._g_move(shparent, shname)
 
 
-
 def move_from_shadow(file_, path):
     (shparent, shname) = file_._shadow_name()
     node = shparent._f_get_child(shname)
@@ -85,25 +84,20 @@ def move_from_shadow(file_, path):
     node._g_move(parent, name)
 
 
-
 def undo_create(file_, path):
     move_to_shadow(file_, path)
-
 
 
 def redo_create(file_, path):
     move_from_shadow(file_, path)
 
 
-
 def undo_remove(file_, path):
     move_from_shadow(file_, path)
 
 
-
 def redo_remove(file_, path):
     move_to_shadow(file_, path)
-
 
 
 def undo_move(file_, origpath, destpath):
@@ -114,14 +108,12 @@ def undo_move(file_, origpath, destpath):
     node._g_move(origparent, origname)
 
 
-
 def redo_move(file_, origpath, destpath):
     (destpname, destname) = split_path(destpath)
 
     node = file_._get_node(origpath)
     destparent = file_._get_node(destpname)
     node._g_move(destparent, destname)
-
 
 
 def attr_to_shadow(file_, path, name):
@@ -140,7 +132,6 @@ def attr_to_shadow(file_, path, name):
     attrs._g__delattr(name)
 
 
-
 def attr_from_shadow(file_, path, name):
     (shparent, shname) = file_._shadow_name()
     shattrs = shparent._v_attrs
@@ -153,20 +144,16 @@ def attr_from_shadow(file_, path, name):
     # shattrs._g__delattr(shname)
 
 
-
 def undo_add_attr(file_, path, name):
     attr_to_shadow(file_, path, name)
-
 
 
 def redo_add_attr(file_, path, name):
     attr_from_shadow(file_, path, name)
 
 
-
 def undo_del_attr(file_, path, name):
     attr_from_shadow(file_, path, name)
-
 
 
 def redo_del_attr(file_, path, name):

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -46,7 +46,6 @@ class UnImplemented(hdf5extension.UnImplemented, Leaf):
     # Class identifier.
     _c_classid = 'UNIMPLEMENTED'
 
-
     def __init__(self, parentnode, name):
         """Create the `UnImplemented` instance."""
 
@@ -122,7 +121,6 @@ class Unknown(Node):
 
     # Class identifier
     _c_classid = 'UNKNOWN'
-
 
     def __init__(self, parentnode, name):
         """Create the `Unknown` instance."""

--- a/tables/unimplemented.py
+++ b/tables/unimplemented.py
@@ -157,4 +157,3 @@ class Unknown(Node):
 # These are listed here for backward compatibility with PyTables 0.9.x indexes
 class OldIndexArray(UnImplemented):
     _c_classid = 'IndexArray'
-

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -452,11 +452,3 @@ def _test():
 
 if __name__ == '__main__':
     _test()
-
-
-## Local Variables:
-## mode: python
-## py-indent-offset: 4
-## tab-width: 4
-## fill-column: 72
-## End:

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -130,7 +130,6 @@ def convert_to_np_atom2(object, atom):
     return nparr
 
 
-
 def check_file_access(filename, mode='r'):
     """Check for file access in the specified `mode`.
 
@@ -183,7 +182,6 @@ def check_file_access(filename, mode='r'):
             raise OSError(f"file ``{path}`` exists but it can not be written")
     else:
         raise ValueError(f"invalid mode: {mode!r}")
-
 
 
 def lazyattr(fget):
@@ -299,7 +297,6 @@ def log_instance_creation(instance, name=None):
         tracked_classes[name].append(weakref.ref(instance))
 
 
-
 def string_to_classes(s):
     if s == '*':
         c = sorted(tracked_classes)
@@ -313,11 +310,9 @@ def fetch_logged_instances(classes="*"):
     return [(cn, len(tracked_classes[cn])) for cn in classnames]
 
 
-
 def count_logged_instances(classes, file=sys.stdout):
     for classname in string_to_classes(classes):
         file.write("%s: %d\n" % (classname, len(tracked_classes[classname])))
-
 
 
 def list_logged_instances(classes, file=sys.stdout):
@@ -327,7 +322,6 @@ def list_logged_instances(classes, file=sys.stdout):
             obj = ref()
             if obj is not None:
                 file.write('    %s\n' % repr(obj))
-
 
 
 def dump_logged_instances(classes, file=sys.stdout):

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -14,6 +14,7 @@ import math
 import os
 import sys
 import warnings
+import weakref
 from pathlib import Path
 from time import perf_counter as clock
 
@@ -286,7 +287,6 @@ def quantize(data, least_significant_digit):
 # Utilities to detect leaked instances.  See recipe 14.10 of the Python
 # Cookbook by Martelli & Ascher.
 tracked_classes = {}
-import weakref
 
 
 def log_instance_creation(instance, name=None):

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -111,7 +111,6 @@ def convert_to_np_atom(arr, atom, copy=False):
     return nparr
 
 
-
 # The next is used in Array, EArray and VLArray, and it is a bit more
 # high level than convert_to_np_atom
 def convert_to_np_atom2(object, atom):
@@ -340,7 +339,6 @@ def dump_logged_instances(classes, file=sys.stdout):
                 file.write('    %s:\n' % obj)
                 for key, value in obj.__dict__.items():
                     file.write(f'        {key:>20} : {value}\n')
-
 
 
 #

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -77,7 +77,7 @@ def idx2long(index):
 
     try:
         return int(index)
-    except:
+    except Exception:
         raise TypeError("not an integer type.")
 
 

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -349,7 +349,7 @@ class VLArray(hdf5extension.VLArray, Leaf):
             self._v_chunkshape = tuple(SizeType(s) for s in chunkshape)
 
         super().__init__(parentnode, name, new, filters,
-                                      byteorder, _log, track_times)
+                         byteorder, _log, track_times)
 
     def _g_post_init_hook(self):
         super()._g_post_init_hook()

--- a/tables/vlarray.py
+++ b/tables/vlarray.py
@@ -874,9 +874,8 @@ class VLArray(hdf5extension.VLArray, Leaf):
     def __repr__(self):
         """This provides more metainfo in addition to standard __str__"""
 
-        return """{}
-  atom = {!r}
-  byteorder = {!r}
-  nrows = {}
-  flavor = {!r}""".format(self, self.atom, self.byteorder, self.nrows,
-                    self.flavor)
+        return f"""{self}
+  atom = {self.atom!r}
+  byteorder = {self.byteorder!r}
+  nrows = {self.nrows}
+  flavor = {self.flavor!r}"""


### PR DESCRIPTION
This makes `flake8` much happier about the `tables/` directory.

As discussed in #867, we should set and check some coding standards, such as PEP8. For this, first the whole codebase should pass the `flake8` test and then we can have some automatic check for new PR in order not to contaminate the code.

This PR solves most of the issues reported by

```
python3 -m flake8 --extend-ignore=D,N --statistics --count tables
```

Before this PR, there were 1268 problems. After this PR we are down to some `E501` (line too long) in doctest and template that probably can be reformatted and the rest are mostly caused by wildcard imports to be investigated and normalized to `from x import y`.

All the individual commits can be squashed to a single one afterwards.