### PR TITLE
Fix numpy 1.20.0 future/deprecation warnings

### DIFF
--- a/tables/tests/test_array.py
+++ b/tables/tests/test_array.py
@@ -504,7 +504,7 @@ class Basic2DOneTestCase(BasicTestCase):
 class Basic2DTwoTestCase(BasicTestCase):
     # 2D case, with a multidimensional dtype
     title = "Rank-2 case 2"
-    tupleInt = np.array(np.arange(4), dtype=(np.int_, (4,)))
+    tupleInt = np.array(range(4), dtype=(int, (4,)))
     tupleChar = np.array(["abc"]*3, dtype=("S3", (3,)))
     endiancheck = True
 
@@ -2439,7 +2439,7 @@ class BroadcastTest(common.TempFileMixin, common.PyTablesTestCase):
         array_shape = (2, 3)
         element_shape = (3,)
 
-        dtype = np.dtype((np.int, element_shape))
+        dtype = np.dtype((int, element_shape))
         atom = tb.Atom.from_dtype(dtype)
         h5arr = self.h5file.create_array(self.h5file.root, 'array',
                                           atom=atom, shape=array_shape)


### PR DESCRIPTION
Fix following two future/deprecation warnings when using `numpy` 1.20.0:

```
tables/tests/test_array.py:507: FutureWarning: creating an array with a subarray dtype will behave differently when the `np.array()` (or `asarray`, etc.) call includes an array or array object.
If you are converting a single array or a list of arrays,you can opt-in to the future behaviour using:
    np.array(arr, dtype=np.dtype(['f', dtype]))['f']
    np.array([arr1, arr2], dtype=np.dtype(['f', dtype]))['f']

By including a new field and indexing it after the conversion.
This may lead to a different result or to current failures succeeding.  (FutureWarning since NumPy 1.20)
  tupleInt = np.array(np.arange(4), dtype=(np.int_, (4,)))
```

and

```
tables/tests/test_array.py:2442: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  dtype = np.dtype((np.int, element_shape))
```