### PR TITLE
Fix doctests

### DIFF
--- a/tables/expression.py
+++ b/tables/expression.py
@@ -60,13 +60,15 @@ class Expr:
     --------
     The following shows an example of using Expr.
 
-        >>> a = f.create_array('/', 'a', np.array([1,2,3]))
-        >>> b = f.create_array('/', 'b', np.array([3,4,5]))
+        >>> import tables as tb, numpy as np
+        >>> h5f = tb.open_file('/tmp/expr.h5', 'w')
+        >>> a = h5f.create_array('/', 'a', np.array([1,2,3]))
+        >>> b = h5f.create_array('/', 'b', np.array([3,4,5]))
         >>> c = np.array([4,5,6])
         >>> expr = tb.Expr("2 * a + b * c")   # initialize the expression
-        >>> expr.eval()                 # evaluate it
-        array([14, 24, 36])
-        >>> sum(expr)                   # use as an iterator
+        >>> expr.eval()                       # evaluate it
+        array([14, 24, 36], dtype=int64)
+        >>> sum(expr)                         # use as an iterator
         74
 
     where you can see that you can mix different containers in
@@ -74,15 +76,15 @@ class Expr:
 
     You can also work with multidimensional arrays::
 
-        >>> a2 = f.create_array('/', 'a2', np.array([[1,2],[3,4]]))
-        >>> b2 = f.create_array('/', 'b2', np.array([[3,4],[5,6]]))
+        >>> a2 = h5f.create_array('/', 'a2', np.array([[1,2],[3,4]]))
+        >>> b2 = h5f.create_array('/', 'b2', np.array([[3,4],[5,6]]))
         >>> c2 = np.array([4,5])           # This will be broadcasted
         >>> expr = tb.Expr("2 * a2 + b2-c2")
         >>> expr.eval()
         array([[1, 3],
-               [7, 9]])
+               [7, 9]], dtype=int64)
         >>> sum(expr)
-        array([ 8, 12])
+        array([ 8, 12], dtype=int64)
 
     .. rubric:: Expr attributes
 

--- a/tables/link.py
+++ b/tables/link.py
@@ -154,6 +154,8 @@ class SoftLink(linkextension.SoftLink, Link):
 
     ::
 
+        >>> import numpy as np
+        >>> import tables as tb
         >>> f = tb.open_file('/tmp/test_softlink.h5', 'w')
         >>> a = f.create_array('/', 'A', np.arange(10))
         >>> link_a = f.create_soft_link('/', 'link_A', target='/A')
@@ -161,7 +163,7 @@ class SoftLink(linkextension.SoftLink, Link):
         # transparent read/write access to a softlinked node
         >>> link_a[0] = -1
         >>> print(link_a[:], link_a.dtype)
-        (array([-1,  1,  2,  3,  4,  5,  6,  7,  8,  9]), dtype('int64'))
+        [-1  1  2  3  4  5  6  7  8  9] int64
 
         # dereferencing a softlink using the __call__() method
         >>> print(link_a() is a)
@@ -170,9 +172,9 @@ class SoftLink(linkextension.SoftLink, Link):
         # SoftLink.remove() overrides Array.remove()
         >>> link_a.remove()
         >>> print(link_a)
-        <closed tables.link.SoftLink at 0x7febe97186e0>
+        <closed tables.link.SoftLink at 0x...>
         >>> print(a[:], a.dtype)
-        (array([-1,  1,  2,  3,  4,  5,  6,  7,  8,  9]), dtype('int64'))
+        [-1  1  2  3  4  5  6  7  8  9] int64
 
 
     """

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -183,7 +183,7 @@ def lazyattr(fget):
     instance method.  The docstring of `fget` is used for the property
     itself.  For instance:
 
-    >>> class MyClass(object):
+    >>> class MyClass:
     ...     @lazyattr
     ...     def attribute(self):
     ...         'Attribute description.'
@@ -191,7 +191,7 @@ def lazyattr(fget):
     ...         return 10
     ...
     >>> type(MyClass.attribute)
-    <type 'property'>
+    <class 'property'>
     >>> MyClass.attribute.__doc__
     'Attribute description.'
     >>> obj = MyClass()


### PR DESCRIPTION
This should fix all failed doctests in #874, but does only a few of them. Most are still failing:

1. `tables.attributeset.AttributeSet`
2. `tables.file.File.__str__`
3. `tables.group.Group.__repr__`
4. `tables.group.Group.__str__`
5. `tables.link.ExternalLink.__call__`
6. `tables.link.ExternalLink.__str__`
7. `tables.link.SoftLink.__call__`
8. `tables.link.SoftLink.__str__`
9. `tables.table.Table.where`

`1` raises `PicklingError`. `2–8` require an existing file that does not exist. `9` is a short piece of code that expects an existing structure beforehand. 