### PR TITLE
Proposed fix for infinite loop at lrucacheextension.pyx

### DIFF
--- a/tables/lrucacheextension.pyx
+++ b/tables/lrucacheextension.pyx
@@ -371,7 +371,8 @@ cdef class ObjectCache(BaseCache):
     # Protection against too large data cache size
     while size + self.cachesize > self.maxcachesize:
       # Remove the LRU node among the 10 largest ones
-      largidx = self.sizes.argsort()[-10:]
+      not_nones = [x is not None for x in self.__list]
+      largidx = self.sizes[not_nones].argsort()[-10:]
       nslot1 = self.atimes[largidx].argmin()
       nslot2 = largidx[nslot1]
       self.removeslot_(nslot2)


### PR DESCRIPTION
Hi,

Under non specific conditions I'm sometimes running into an infinite loop at [lrucacheextension.pyx:372](https://github.com/PyTables/PyTables/blob/10985dada67284ffecac3c0aa196d4afee254116/tables/lrucacheextension.pyx#L372). When the code enters the `while` loop, it tries to remove a `node` from the cache through a call to [removeslot_](https://github.com/PyTables/PyTables/blob/10985dada67284ffecac3c0aa196d4afee254116/tables/lrucacheextension.pyx#L377) but if the node is `None` it does not free cache space (see [this](https://github.com/PyTables/PyTables/blob/10985dada67284ffecac3c0aa196d4afee254116/tables/lrucacheextension.pyx#L352)).

I have added the following line before [this one](https://github.com/PyTables/PyTables/blob/10985dada67284ffecac3c0aa196d4afee254116/tables/lrucacheextension.pyx#L374) to prevent selecting `None` nodes. Although this has worked for the concrete example I was testing I'm not sure if this is an adequate modification.

```python
while size + self.cachesize > self.maxcachesize:
    not_nones = [x is not None for x in self.__list]
    largidx = self.sizes[not_nones].argsort()[-10:]
    ...
```

Would someone be able to review this modification?