### PR TITLE
Added basic API for Column-level attributes (issue #821)

### DIFF
--- a/tables/attributeset.py
+++ b/tables/attributeset.py
@@ -680,6 +680,139 @@ be ready to see PyTables asking for *lots* of memory and possibly slow I/O"""
             return str(self)
 
 
+class ColumnAttributeSet:
+
+    def __init__(self, column):
+
+        self._v_tableattrs = column.table.attrs
+        self.__dict__['_v_fieldindex'] = column._v_pos
+        self.__dict__['_v_column'] = column # Does this need to be a weak reference?
+
+    def issystemcolumnname(self, key):
+        """Checks whether a key is a reserved attribute name, or should be passed through."""
+        return key in ['_v_tableattrs', '_v_fieldindex', '_v_column']
+
+    def _prefix(self, string):
+        """Prefixes a key with a special pattern for storing with table attributes"""
+        field_index = self.__dict__['_v_fieldindex']
+        return 'FIELD_%i_ATTR_%s' % (field_index, string)
+
+    def __getattr__(self, key):
+        """Retrieves a PyTables attribute for this column"""        
+        if not self.issystemcolumnname(key):
+            return getattr(self._v_tableattrs, self._prefix(key))
+        else:
+            return super().__getattr__(key)
+
+    def __setattr__(self, key, val):
+        """Sets a PyTables attribute for this column"""        
+        if not self.issystemcolumnname(key):
+            setattr(self._v_tableattrs, self._prefix(key), val)
+        else:
+            return super().__setattr__(key, val)
+
+    def __getitem__(self, key):
+        """A dictionary-like interface for __getattr__"""
+        if not self.issystemcolumnname(key):
+            return self._v_tableattrs[self._prefix(key)]
+        else:
+            return self[key]
+
+    def __setitem__(self, key, value):
+        """A dictionary-like interface for __setattr__"""
+        if not self.issystemcolumnname(key):
+            self._v_tableattrs[self._prefix(key)] = value
+        else:
+            self[key] = value
+
+    def __delattr__(self, key):
+        """Deletes the attribute for this column"""
+        if self.issystemcolumnname(key):
+            # This is a bad idea, but if the user really wants it, do it
+            super().__delattr__(key)
+        else:
+            delattr(self._v_tableattrs, self._prefix(key))
+
+    def __delitem__(self, key):
+        """A dictionary-like interface for __delattr__"""
+        if self.issystemcolumnname(key):
+            # This is a bad idea, but if the user really wants it, do it
+            super().__delitem__(key)
+        else:
+            del self._v_tableattrs[self._prefix(key)]
+
+    def _f_rename(self, oldattrname, newattrname):
+        """Rename an attribute from oldattrname to newattrname."""
+
+        if oldattrname == newattrname:
+            # Do nothing
+            return
+
+        # First, fetch the value of the oldattrname
+        attrvalue = getattr(self, oldattrname)
+
+        # Now, create the new attribute
+        setattr(self, newattrname, attrvalue)
+
+        # Finally, remove the old attribute
+        delattr(self, oldattrname)        
+
+    def _f_copy(self, where):
+        """Copy attributes to another column"""
+
+        # Is there a better way to do this?
+        from .table import Column
+        if not isinstance(where, Column):
+            raise TypeError(f"destination object is not a column: {where!r}")
+
+        for key in self.keys():
+            where.attrs[key] = self[key]
+
+    def keys(self):
+        """Returns the list of attributes for this column"""
+        col_prefix = self._prefix('')
+        length = len(col_prefix)
+        return [key[length:] for key in self._v_tableattrs._v_attrnames if key.startswith(col_prefix)]
+
+    def contains(self, key):
+        """Returns whether a key is in the attribute set"""
+        return key in self.keys()
+
+    def __str__(self):
+        """A string representation of this object"""
+
+    def __repr__(self):
+        """A detailed string representation for this object"""
+        print('TODO')
+
+
+    def __str__(self):
+        """The string representation for this object."""
+
+
+        # The pathname
+        pathname = self._v_tableattrs._v__nodepath
+        # Get this class name
+        classname = self._v_column.__class__.__name__ #self._v_tableattrs._v_node.__class__.__name__
+        # The attribute names
+        attrnumber = sum(1 for _ in self.keys())
+        # The column name
+        columnname = self._v_column.name
+
+        return f"{pathname}.cols.{columnname}._v_attrs ({classname}), {attrnumber} attributes"
+
+    def __repr__(self):
+        """A detailed string representation for this object."""
+
+        # print additional info only if there are attributes to show
+        attrnames = self.keys()
+        if attrnames:
+            rep = [f'{attr} := {getattr(self, attr)!r}' for attr in attrnames]
+            return f"{self!s}:\n   [" + ',\n    '.join(rep) + "]"
+        else:
+            return str(self)
+
+
 class NotLoggedAttributeSet(AttributeSet):
     def _g_log_add(self, name):
         pass

--- a/tables/table.py
+++ b/tables/table.py
@@ -29,6 +29,7 @@ from .path import join_path, split_path
 from .index import (
     OldIndex, default_index_filters, default_auto_index, Index, IndexesDescG,
     IndexesTableG)
+from .attributeset import ColumnAttributeSet
 
 
 profile = False
@@ -3674,3 +3675,15 @@ class Column:
         """A detailed string representation for this object."""
 
         return str(self)
+
+    @lazyattr
+    def _v_pos(self):
+        return self.descr._v_colobjects[self.name]._v_pos
+
+    @lazyattr
+    def _v_attrs(self):
+        return ColumnAttributeSet(self)
+
+    @lazyattr
+    def attrs(self):
+        return self._v_attrs


### PR DESCRIPTION
The column-level attributes are only accessible once the table and the columns are instantiated. There's currently no support for adding attributes on creation (e.g., something like `pt.Float32Col(dflt=0.0, shape=(3,2), attrs=dict(foo='bar', description='some string')`)