### PR TITLE
convert np.typeDict to np.sctypeDict

### DIFF
--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -163,8 +163,8 @@ NPExtPrefixesToPTKinds = npext_prefixes_to_ptkinds
 HDF5ClassToString = hdf5_class_to_string
 
 
-from numpy import typeDict
-cdef int have_float16 = ("float16" in typeDict)
+from numpy import sctypeDict
+cdef int have_float16 = ("float16" in sctypeDict)
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
Tests in a downstream project started raising the following warning:
```
  /home/sroet/miniconda3/envs/pyretis/lib/python3.9/site-packages/tables/__init__.py:24: DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.
    from .utilsextension import (
```

This PR removes the alias
