### PR TITLE
Run CI against python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/setup.py
+++ b/setup.py
@@ -1049,6 +1049,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 """


### PR DESCRIPTION
Considering that python 3.10 is now released since quite some time, i think pytables should be running CI against this.

This seems to be possible without major issues - however it will ensure that compatibility with 3.10 is there (and remains there) by running the test-suite against python3.10 as well.

