### PR TITLE
Build linux Wheels for 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - 'releases/**'
+      - 'wheels_3.10'
     tags:
       - v*
   release:
@@ -43,7 +44,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y epel-release && yum install -y hdf5-devel zlib-devel bzip2-devel lzo-devel blosc-devel"
           CIBW_BEFORE_BUILD: "pip install numpy numexpr cython>=0.29.21"
           CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE'"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - 'releases/**'
-      - 'wheels_3.10'
     tags:
       - v*
   release:


### PR DESCRIPTION
Followup to #917, where i've forgotten to update this CI file to python 3.10 as well.

This will also close the following issues in my opinion (once released, obviously), (as i don't think they are about 3.6.1 specifically, but about the latest version of pytables): #911, #884


The output of the Ran pipeline will be as follows:
```
RELEASE_NOTES-3.6.2.dev0.txt
pytables-3.6.2.dev0.md5
pytablesmanual-3.6.2.dev0-html.tar.gz
pytablesmanual-3.6.2.dev0.pdf
tables-3.6.2.dev0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
tables-3.6.2.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
tables-3.6.2.dev0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
tables-3.6.2.dev0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
tables-3.6.2.dev0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
tables-3.6.2.dev0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
tables-3.6.2.dev0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
tables-3.6.2.dev0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
tables-3.6.2.dev0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
tables-3.6.2.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
tables-3.6.2.dev0.tar.gz
```

The artifact itself can be retrieved from the [action run](https://github.com/xmatthias/PyTables/actions/runs/1567354362) i made in my repository for the almost last commit (i intentionally left the last commit in to show that there were no other changes made).

I've then tested the 2 new builds (cp310 for both x86 and aarch64) as follows after downloading and unzipping the artifact.zip file

**x86:**
```
docker run -it --rm -v $(pwd):/app --entrypoint bash python:3.10-slim-bullseye
# The following happens within the docker image
cd app
pip install tables-3.6.2.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pip show tables (to get the below path)
python /usr/local/lib/python3.10/site-packages/tables/tests/test_all.py

root@b5918523da3d:/app# python /usr/local/lib/python3.10/site-packages/tables/tests/test_all.py                                  
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=                                                     
PyTables version:    3.6.2.dev0                                                                                                  
HDF5 version:        1.8.12                                                                                                      
NumPy version:       1.21.4                                                                                                      
Numexpr version:     2.8.1 (not using Intel's VML/MKL)                                                                           
Zlib version:        1.2.11 (in Python interpreter)                                                                              
LZO version:         2.06 (Aug 12 2011)                                                                                          
BZIP2 version:       1.0.6 (6-Sept-2010)                                                                                         
Blosc version:       1.11.3 (2017-03-09)                                                                                         
Blosc compressors:   blosclz (1.0.5), lz4 (1.7.3), lz4hc (1.7.3), snappy (unknown), zlib (1.2.7), zstd (1.3.6)                   
Blosc filters:       shuffle, bitshuffle                                                                                         
Python version:      3.10.1 (main, Dec  8 2021, 03:45:17) [GCC 10.2.1 20210110]                                                  
Platform:            Linux-5.15.6-arch2-1-x86_64-with-glibc2.31                                                                  
Byte-ordering:       little                                                                                                      
Detected cores:      8                                                                                                           
Default encoding:    utf-8                                                                                                       
Default FS encoding: utf-8                                                                                                       
Default locale:      (en_US, UTF-8)                                                                                              
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=                                                     
Performing only a light (yet comprehensive) subset of the test suite.                                                            
If you want a more complete test, try passing the --heavy flag to this script                                                    
(or set the 'heavy' parameter in case you are using tables.test() call).                                                         
The whole suite will take more than 4 hours to complete on a relatively
modern CPU and around 512 MB of main memory.                                                                                     
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
..................................................
[....]
..................................................
----------------------------------------------------------------------
Ran 6371 tests in 85.024s

OK (skipped=14)

```

**ARM64 (Oracle free tier virtual machine)**
```
uname -a
Linux ***** 5.11.0-1016-oracle #17~20.04.1-Ubuntu SMP Thu Aug 12 06:20:07 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux

docker run -it --rm -v $(pwd):/app --entrypoint bash python:3.10-slim-bullseye
# The following happens within the docker image
cd app
# Install gcc compiler (numexpr does not provide wheels for aarch64)
apt update && apt install build-essential 

pip install tables-3.6.2.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pip show tables
## get tothe below 

root@a4dd50dc945d:/app# python /usr/local/lib/python3.10/site-packages/tables/tests/test_all.py
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
PyTables version:    3.6.2.dev0
HDF5 version:        1.8.12
NumPy version:       1.21.4
Numexpr version:     2.8.1 (not using Intel's VML/MKL)
Zlib version:        1.2.11 (in Python interpreter)
LZO version:         2.06 (Aug 12 2011)
BZIP2 version:       1.0.6 (6-Sept-2010)
Blosc version:       1.11.3 (2017-03-09)
Blosc compressors:   blosclz (1.0.5), lz4 (1.7.3), lz4hc (1.7.3), snappy (unknown), zlib (1.2.7), zstd (1.3.6)
Blosc filters:       shuffle, bitshuffle
Python version:      3.10.1 (main, Dec  8 2021, 03:02:19) [GCC 10.2.1 20210110]
Platform:            Linux-5.11.0-1016-oracle-aarch64-with-glibc2.31
Byte-ordering:       little
Detected cores:      4
Default encoding:    utf-8
Default FS encoding: utf-8
Default locale:      (en_US, UTF-8)
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Performing only a light (yet comprehensive) subset of the test suite.
If you want a more complete test, try passing the --heavy flag to this script
(or set the 'heavy' parameter in case you are using tables.test() call).
The whole suite will take more than 4 hours to complete on a relatively
modern CPU and around 512 MB of main memory.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[....] # several boring lines with lots of points
..................................................
----------------------------------------------------------------------
Ran 6371 tests in 159.761s

OK (skipped=14)


```

if you need additional tests done please let me know and i'll see if i can help in that.

---

Obviously, the wheels will be available in the github action (once the action completes in either the main branch, or in a release branch) - and will require manual upload to pypi when doing a release - so even if you might not be able to provide a full set of wheels, i hope you'll be able to upload the available wheels when it's time to do a release.
