### PR TITLE
Enable CI on windows 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        exclude:
-          - os: windows-latest
-            python: "3.9"
-          - os: windows-latest
-            python: "3.10"
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image:
+  - Visual Studio 2015
 environment:
   PACKAGE_NAME: tables
   BUILD_DEPENDS: "numpy>=1.8.0 numexpr>=2.5.2 cython bzip2 hdf5"
@@ -19,6 +21,18 @@ environment:
 
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.9"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.10"
       PYTHON_ARCH: "64"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,9 +31,10 @@ environment:
       PYTHON_VERSION: "3.9"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: "3.10"
-      PYTHON_ARCH: "64"
+    # python 3.10 currently fails while compiling blosc
+    # - PYTHON: "C:\\Miniconda37-x64"
+    #   PYTHON_VERSION: "3.10"
+    #   PYTHON_ARCH: "64"
 
 install:
   - powershell .\\ci\\appveyor\\missing-headers.ps1

--- a/setup.py
+++ b/setup.py
@@ -689,11 +689,7 @@ if __name__ == "__main__":
             inc_dirs.append(Path(hdrdir))  # save header directory if needed
         if libdir not in default_library_dirs and libdir not in ("", True):
             # save library directory if needed
-            if os.name == "nt":
-                # Important to quote the libdir for Windows (Vista) systems
-                lib_dirs.append(Path(f'"{libdir}"'))
-            else:
-                lib_dirs.append(Path(libdir))
+            lib_dirs.append(Path(libdir))
 
         if package.tag not in ["HDF5"]:
             # Keep record of the optional libraries found.


### PR DESCRIPTION
Enable CI on windows for python 3.9 and python 3.10.

Replaces #919 (i think this is the shortest/easiest way?) 

---

The offending line is `lib_dirs.append(Path(f'"{libdir}"'))` - which results in a quoted lib-dir 

This does not seem to cause issues up to python 3.8 - but results in LNK failures in 3.9 and up.
The line itself was added sometime in 2008 - but is no longer needed (and apparently, in new versions no longer supported).

The resulting linker command (`C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\link.exe /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:"C:\Miniconda37-x64\envs\build_env\Library\lib" [...]`) is wrongly/oddly quoted. 

Comparing outputs between this line for 3.9 and 3.8 shows that the quotes are set quite differently - however i was unable to trade it to the "real" source - other than either setuptools or distutils (which i've had at the same version).


--- 

The appveyor build fails for windows 3.10 - however strangely, it is successful in github (which however does not build the wheel explicitly in the build step - but does build it as part of the installation step).

```
C:\projects\pytables\c-blosc\blosc\bitshuffle-avx2.c(172) : error C2065: 'ymm_1' : undeclared identifier
C:\projects\pytables\c-blosc\blosc\bitshuffle-avx2.c(172) : error C2109: subscript requires array or pointer type
C:\projects\pytables\c-blosc\blosc\bitshuffle-avx2.c(172) : fatal error C1003: error count exceeds 100; stopping compilation
```

This makes me believe that it's caused by an appveyor environmental issue (the used image is rather old).

I've left this "failing" for the moment intentionally so we can look at the error and discuss - but i think the simple way to progress is to remove 3.10 from appveyor for the moment (3.10 is still tested in github ci - and i'm working on building windows wheels there, too, but will still need to test if they are actually working).