### PR TITLE
Readme should no longer show badge from travis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,6 @@
 .. image:: https://github.com/PyTables/PyTables/workflows/CI/badge.svg
    :target: https://github.com/PyTables/PyTables/actions?query=workflow%3ACI
 
-.. image:: https://travis-ci.org/PyTables/PyTables.svg?branch=master
-   :target: https://travis-ci.org/PyTables/PyTables
-
 .. image:: https://ci.appveyor.com/api/projects/status/github/PyTables/PyTables?branch=master&svg=true
    :target: https://ci.appveyor.com/project/PyTablesCI/pytables
 


### PR DESCRIPTION
Readme should no longer show badge from travis, since travis is no longer used.