### PR TITLE
Add windows wheels and independent test to GHA

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - 'releases/**'
+      - 'ci/**'
     tags:
       - v*
   release:
@@ -19,8 +20,8 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest ]
         arch: [x86_64, aarch64]
-        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,10 +29,10 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - uses: docker/setup-qemu-action@v1
-        if:  ${{matrix.arch}} == 'aarch64'
+        if:  startsWith(matrix.os, 'ubuntu')
         name: Set up QEMU
 
       - name: Install cibuildwheel
@@ -45,13 +46,82 @@ jobs:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y epel-release && yum install -y hdf5-devel zlib-devel bzip2-devel lzo-devel blosc-devel"
-          CIBW_BEFORE_BUILD: "pip install numpy numexpr cython>=0.29.21"
+          CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
           CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE'"
           CIBW_SKIP: '*-musllinux_*'
 
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
+
+  build_wheels_windows:
+    name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        arch: [win32, win_amd64]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Install Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          channels: defaults,conda-forge
+          use-only-tar-bz2: true
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade cibuildwheel
+
+      - name: Build wheels for Windows (${{ matrix.arch }})
+        run: cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp36-${{ matrix.arch }} cp37-${{ matrix.arch }} cp38-${{ matrix.arch }} cp39-${{ matrix.arch }} cp310-${{ matrix.arch }}"
+
+          CIBW_BEFORE_ALL_WINDOWS: "conda create --yes --name=build && conda activate build && conda config --env --set subdir ${{ matrix.arch == 'win32' && 'win-32' || 'win-64' }} && conda install --yes blosc bzip2 hdf5 lz4 lzo snappy zstd zlib"
+          CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
+          CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
+          CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  test_wheels:
+    needs: [ build_wheels, build_wheels_windows ]
+    name: Test ${{ matrix.python-version }} wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+        python-version: ['3.7', '3.8', '3.9','3.10']
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: ./wheelhouse/
+
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tables on ${{ matrix.python-version }}
+        run: |
+          pip install numpy>=1.19.0 numexpr>=2.6.2
+          pip install --no-index --find-links wheelhouse/artifact/ tables
+
+      - name: Run tests on ${{ matrix.python-version }}
+        run: |
+          python -m tables.tests.test_all
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ ubuntu-latest ]
-        # arch: [x86_64, aarch64]
-        arch: [x86_64]
+        arch: [x86_64, aarch64]
 
     steps:
       - uses: actions/checkout@v2
@@ -99,12 +98,17 @@ jobs:
 
   test_wheels:
     needs: [ build_wheels, build_wheels_windows ]
-    name: Test ${{ matrix.python-version }} wheels for ${{ matrix.os }}
+    name: Test ${{ matrix.python-version }} ${{ matrix.arch }} wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
         python-version: ['3.7', '3.8', '3.9','3.10']
+        arch: ['x64', 'x86']
+        exclude:
+        - os: 'ubuntu-latest'
+          arch: 'x86'
 
     steps:
       - uses: actions/download-artifact@v2
@@ -115,6 +119,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.arch }}
 
       - name: Install tables on ${{ matrix.python-version }}
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,8 @@ jobs:
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ ubuntu-latest ]
-        arch: [x86_64, aarch64]
+        # arch: [x86_64, aarch64]
+        arch: [x86_64]
 
     steps:
       - uses: actions/checkout@v2
@@ -89,7 +90,8 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: "conda create --yes --name=build && conda activate build && conda config --env --set subdir ${{ matrix.arch == 'win32' && 'win-32' || 'win-64' }} && conda install --yes blosc bzip2 hdf5 lz4 lzo snappy zstd zlib"
           CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
           CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
-          CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
+          CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21 delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Add windows wheels and independent test to GHA

For the most part (especially the windows part), this is based on top of the great work from @amotl in #872.

Built wheels for ubuntu x64, windows (win32 and amd64) are tested in a second CI step.
This ensures that no hdf5 Build dependencies are installed, as these are fresh, new machines.
The build step also does not do the checkout step, so the original source is also not available (intentionally).

python for linux on x86 devices seems to be unavailable based on [this run](https://github.com/xmatthias/PyTables/runs/4526501674?check_suite_focus=true) - which shows that linux binaries are not available through the python setup action (i also don't think 32bit for linux is all too relevant).

**EDIT** You can find the last run which ran the affected CI [here](https://github.com/xmatthias/PyTables/actions/runs/1580025842) - which ran against the latest commit in this branch.

----

Please note the following:
* macOS ci is still missing and will be added in a separate PR
* linux/unix wheels are using a different, older version of hdf5 for now (does not change in this PR). I think the best approach will be to compile that from source to get the latest version (or at least an updated one). 

I have both of the above working (for the most part) - but would like to add things step by step, to keep PR's minimal, and simplify reviews.