### PR TITLE
Add CI wheel build for MacOS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest', 'macos-10.15' ]
+        os: [ 'ubuntu-latest', 'macos-10.15' ]
         # arch: [x86_64, aarch64]
         arch: [ x86_64 ]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,9 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'macos-10.15' ]
-        # arch: [x86_64, aarch64]
-        arch: [ x86_64 ]
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        arch: [x86_64, aarch64]
 
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +52,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS_LINUX: ${{matrix.arch}}
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_ARCHS_MACOS: ${{ matrix.arch == 'aarch64' && 'arm64' || 'x86_64'}}
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
           CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y epel-release && yum install -y hdf5-devel zlib-devel bzip2-devel lzo-devel blosc-devel"
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
@@ -120,6 +120,8 @@ jobs:
         arch: ['x64', 'x86']
         exclude:
         - os: 'ubuntu-latest'
+          arch: 'x86'
+        - os: 'macos-latest'
           arch: 'x86'
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ ubuntu-latest ]
-        arch: [x86_64, aarch64]
+        os: [ 'ubuntu-latest', 'macos-latest', 'macos-10.15' ]
+        # arch: [x86_64, aarch64]
+        arch: [ x86_64 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,11 +35,21 @@ jobs:
         if:  startsWith(matrix.os, 'ubuntu')
         name: Set up QEMU
 
+      - name: Install prerequisites for macOS
+        if: contains(matrix.os, 'macos')
+        env:
+          # Best compatibility, even with older releases of macOS.
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+        run: |
+          brew install --build-from-source --no-binaries --force szip
+          brew reinstall --build-from-source --no-binaries --force c-blosc bzip2 hdf5 lz4 lzo snappy zstd zlib
+          brew link --overwrite --force bzip2 zlib
+
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade cibuildwheel
 
-      - name: Build wheels
+      - name: Build wheels for Linux or macOS (64-bit | aarch64)
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -48,6 +58,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y epel-release && yum install -y hdf5-devel zlib-devel bzip2-devel lzo-devel blosc-devel"
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
           CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE'"
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+          CIBW_ENVIRONMENT_MACOS: BZIP2_DIR=/usr/local/opt/bzip2 LDFLAGS+="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib" CPPFLAGS+="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include" PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
           CIBW_SKIP: '*-musllinux_*'
 
       - uses: actions/upload-artifact@v2
@@ -103,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
         python-version: ['3.7', '3.8', '3.9','3.10']
         arch: ['x64', 'x86']
         exclude:


### PR DESCRIPTION
Adding support for MacOS builds, for both x64 and arm64 builds.
Only the x64 are being tested - and I'd be grateful if someone can step up and try to install the arm64 binary on a M1 system.

A recent CI run for this can be found [here](https://github.com/xmatthias/PyTables/runs/4535307675?check_suite_focus=true).

This is based mostly on the great work from @amotl in #872

---

This is currently using the hdf5 (and blosc) library from brew (as well as some other libraries necessary for building).
While this might for sure be seen as controversial, i don't see this as worse than using libraries from conda (which pytables does and did for Windows CI already).

I'm also working on a "build hdf5 from source" PR - which will build hdf5 from source on linux/macos Systems - but the brew dependency will probably remain there for some "basic" libraries we don't really want to build.

I'm not sure if it would be better to use the builtin / vendored blosc (I'm not sure on reasons for vendoring that library - but discovered that it'll be built as part of the wheel building process if the library is not there).
