### PR TITLE
Remove MacOS arm64 wheel 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
         arch: [x86_64, aarch64]
+        exclude:
+        - os: 'macos-latest'
+          arch: 'aarch64'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Unfortunately, the wheels we're building for Macos Silicon (arm64 builds) are not working correctly.

As mentioned in #927, help will be needed to test the arm64 binary - which i've now gotten (but it went the wrong way).

I've had a friend with a mac M1 install the wheel from the latest master build, and unfortunately, the arm64 wheel has the error also highlighted in #887 - 

```
ImportError: dlopen(/opt/homebrew/lib/python3.8/site-packages/tables/utilsextension.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '_H5E_CALLBACK_g'
```

I'm not sure we will be able to provide these wheels unless someone with an M1 (and some skills / patience) can help us get CI for this working (which may require additional changes to how the build process works - as i don't think this is a "ci only" thing, basd in #887).

With the removal of this, all remaining wheels have been tested, either manually (aarch64) - or in ci (all 64bit and win32).

Without a Mac M1 however, this is almost impossible to accomplish - as i can't test these myself, i'll have to defer this to either not provide these wheels - or to someone who is better equipped (from a hardware perspective) for this task.
