### PR TITLE
Build hdf5 from source when building wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,6 @@ jobs:
           # Best compatibility, even with older releases of macOS.
           MACOSX_DEPLOYMENT_TARGET: "10.9"
         run: |
-          brew install --build-from-source --no-binaries --force szip
           brew reinstall --build-from-source --no-binaries --force  bzip2 lz4 lzo snappy zstd zlib
           brew link --overwrite --force bzip2 zlib
 
@@ -63,12 +62,12 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch == 'aarch64' && 'arm64' || 'x86_64'}}
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
-          CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y zlib-devel bzip2-devel lzo-devel ${{ matrix.arch == 'aarch64' && 'blosc-devel' || ''}} && ./ci/github/get_hdf5_if_needed.sh"
+          CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y zlib-devel bzip2-devel lzo-devel && ./ci/github/get_hdf5_if_needed.sh"
           CIBW_BEFORE_ALL_MACOS: "./ci/github/get_hdf5_if_needed.sh"
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
-          CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE' HDF5_DIR=/tmp/hdf5 HDF5_VERSION=${{ env.HDF5_VERSION }} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/"
+          CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE' HDF5_DIR=/tmp/hdf5 CFLAGS=-g0 HDF5_VERSION=${{ env.HDF5_VERSION }} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/"
           MACOSX_DEPLOYMENT_TARGET: "10.9"
-          CIBW_ENVIRONMENT_MACOS: HDF5_DIR=/tmp/hdf5 HDF5_VERSION=${{ env.HDF5_VERSION }} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/ BZIP2_DIR=/usr/local/opt/bzip2 LDFLAGS+="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib" CPPFLAGS+="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include" PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
+          CIBW_ENVIRONMENT_MACOS: HDF5_DIR=/tmp/hdf5 HDF5_VERSION=${{ env.HDF5_VERSION }} CFLAGS=-g0 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/ BZIP2_DIR=/usr/local/opt/bzip2 LDFLAGS+="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib" CPPFLAGS+="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include" PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
           CIBW_SKIP: '*-musllinux_*'
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,6 +17,8 @@ jobs:
   build_wheels:
     name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      HDF5_VERSION: 1.12.1
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
@@ -37,35 +39,36 @@ jobs:
           python-version: '3.9'
 
       - uses: docker/setup-qemu-action@v1
-        if:  startsWith(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
         name: Set up QEMU
 
       - name: Install prerequisites for macOS
-        if: contains(matrix.os, 'macos')
+        if: runner.os == 'macOS'
         env:
           # Best compatibility, even with older releases of macOS.
           MACOSX_DEPLOYMENT_TARGET: "10.9"
         run: |
           brew install --build-from-source --no-binaries --force szip
-          brew reinstall --build-from-source --no-binaries --force c-blosc bzip2 hdf5 lz4 lzo snappy zstd zlib
+          brew reinstall --build-from-source --no-binaries --force  bzip2 lz4 lzo snappy zstd zlib
           brew link --overwrite --force bzip2 zlib
 
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade cibuildwheel
 
-      - name: Build wheels for Linux or macOS (64-bit | aarch64)
+      - name: Build wheels for Linux or macOS (64-bit)
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch == 'aarch64' && 'arm64' || 'x86_64'}}
           CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
-          CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y epel-release && yum install -y hdf5-devel zlib-devel bzip2-devel lzo-devel blosc-devel"
+          CIBW_BEFORE_ALL_LINUX: "yum -y update && yum install -y zlib-devel bzip2-devel lzo-devel ${{ matrix.arch == 'aarch64' && 'blosc-devel' || ''}} && ./ci/github/get_hdf5_if_needed.sh"
+          CIBW_BEFORE_ALL_MACOS: "./ci/github/get_hdf5_if_needed.sh"
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
-          CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE'"
+          CIBW_ENVIRONMENT: "DISABLE_AVX2='TRUE' HDF5_DIR=/tmp/hdf5 HDF5_VERSION=${{ env.HDF5_VERSION }} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/"
           MACOSX_DEPLOYMENT_TARGET: "10.9"
-          CIBW_ENVIRONMENT_MACOS: BZIP2_DIR=/usr/local/opt/bzip2 LDFLAGS+="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib" CPPFLAGS+="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include" PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
+          CIBW_ENVIRONMENT_MACOS: HDF5_DIR=/tmp/hdf5 HDF5_VERSION=${{ env.HDF5_VERSION }} LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/tmp/hdf5/lib/ BZIP2_DIR=/usr/local/opt/bzip2 LDFLAGS+="-L/usr/local/opt/bzip2/lib -L/usr/local/opt/zlib/lib" CPPFLAGS+="-I/usr/local/opt/bzip2/include -I/usr/local/opt/zlib/include" PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
           CIBW_SKIP: '*-musllinux_*'
 
       - uses: actions/upload-artifact@v2

--- a/ci/github/get_hdf5_if_needed.sh
+++ b/ci/github/get_hdf5_if_needed.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# vendored from https://github.com/h5py/h5py/blob/master/ci/get_hdf5_if_needed.sh
+
+set -e
+
+if [ -z ${HDF5_DIR+x} ]; then
+    echo "Using OS HDF5"
+else
+    echo "Using downloaded HDF5"
+    if [ -z ${HDF5_MPI+x} ]; then
+        echo "Building serial"
+        EXTRA_MPI_FLAGS=''
+    else
+        echo "Building with MPI"
+        EXTRA_MPI_FLAGS="--enable-parallel --enable-shared"
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        lib_name=libhdf5.dylib
+    else
+        lib_name=libhdf5.so
+    fi
+
+    if [ -f $HDF5_DIR/lib/$lib_name ]; then
+        echo "using cached build"
+    else
+        pushd /tmp
+        #                                   Remove trailing .*, to get e.g. '1.12' ↓
+        curl -fsSLO "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION%.*}/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz"
+        tar -xzvf hdf5-$HDF5_VERSION.tar.gz
+        pushd hdf5-$HDF5_VERSION
+        chmod u+x autogen.sh
+        if [[ "${HDF5_VERSION%.*}" = "1.12" ]]; then
+          ./configure --prefix $HDF5_DIR $EXTRA_MPI_FLAGS --enable-build-mode=production
+        else
+          ./configure --prefix $HDF5_DIR $EXTRA_MPI_FLAGS
+        fi
+        make -j $(nproc)
+        make install
+        popd
+        popd
+    fi
+fi


### PR DESCRIPTION
This PR will add building hdf5 from source (therefore upgrading hdf5 to 1.12.1 - as requested in #912).
It'll also use the builtin blosc library for x86 wheels (this is optional and could be removed / reverted).


Wheels from my last run can be found [here](https://github.com/xmatthias/PyTables/actions/runs/1591055325) in the artifact download.

unfortunately, it does also include #929 - as i'm unable to build wheels from source on arm macos (and they didn't work anyway). 
I could make CI more complicated to keep this part separate, but i'm not sure that will make sense.

it'll also increase runtime for the wheel CI quite some - as the build on aarch64 happnes as cross-compile, which can only utilize one core. with 2.5 hours it's however still well within range of the 6h github action runtime limit.

---
Building blosc from the vendored source on ARM64 is not possible at the moment.
The failure on this can be found [in this run](https://github.com/xmatthias/PyTables/runs/4552313972?check_suite_focus=true).

final errors for this are the following:

```
    /project/c-blosc/blosc/shuffle.c:153:3: error: impossible constraint in ‘asm’
      153 |   __asm__ __volatile__ (
          |   ^~~~~~~
    /project/c-blosc/blosc/shuffle.c:153:3: error: impossible constraint in ‘asm’
      153 |   __asm__ __volatile__ (
          |   ^~~~~~~
    /project/c-blosc/blosc/shuffle.c:185:3: error: impossible constraint in ‘asm’
      185 |   __asm__ __volatile__ (
          |   ^~~~~~~
    error: command 'gcc' failed with exit status 1
```

Therefore, aarch64 wheels do still include blosc-devel from the yum source (as they do now).

I suspect this has to do with the blosc version that is vendored, which might need an update to properly support compiling on arm64 - but didn't investigate further.


---

Important before merging:
 
On linux x86_64, all extension files become  rather huge (16MB). 
This does not happen on arm64, nor on macos - but i have no idea what causes it - as the building itself runs as expected (nothing that stands out to me in the logs).

I'm out of ideas for the moment, therefore i'm posting this here so maybe someone can jump in and give me a hint, or even provide a fix for this.
Maybe it's because of the updated hdf5 version - but i doubt that can cause such a huge spike.

Because of this, I think it might make sense to hold off merging this until we have found the root for the huge .so files. Maybe it's normal / expected - but it seems quite strange as it's only happening on one environment - where the macOS build is not significantly different (other than being another system, obviously).

