### PR TITLE
Raise specific subclasses of OSError when checking file access

### DIFF
--- a/tables/utils.py
+++ b/tables/utils.py
@@ -140,11 +140,11 @@ def check_file_access(filename, mode='r'):
     if mode == 'r':
         # The file should be readable.
         if not os.access(path, os.F_OK):
-            raise OSError(f"``{path}`` does not exist")
+            raise FileNotFoundError(f"``{path}`` does not exist")
         if not path.is_file():
-            raise OSError(f"``{path}`` is not a regular file")
+            raise IsADirectoryError(f"``{path}`` is not a regular file")
         if not os.access(path, os.R_OK):
-            raise OSError(f"file ``{path}`` exists but it can not be read")
+            raise PermissionError(f"file ``{path}`` exists but it can not be read")
     elif mode == 'w':
         if os.access(path, os.F_OK):
             # Since the file is not removed but replaced,
@@ -154,11 +154,11 @@ def check_file_access(filename, mode='r'):
             # A new file is going to be created,
             # so the directory should be writable.
             if not os.access(path.parent, os.F_OK):
-                raise OSError(f"``{path.parent}`` does not exist")
+                raise FileNotFoundError(f"``{path.parent}`` does not exist")
             if not path.parent.is_dir():
-                raise OSError(f"``{path.parent}`` is not a directory")
+                raise NotADirectoryError(f"``{path.parent}`` is not a directory")
             if not os.access(path.parent, os.W_OK):
-                raise OSError(
+                raise PermissionError(
                     f"directory ``{path.parent}`` exists but it can not be "
                     f"written"
                 )
@@ -170,7 +170,7 @@ def check_file_access(filename, mode='r'):
     elif mode == 'r+':
         check_file_access(path, 'r')
         if not os.access(path, os.W_OK):
-            raise OSError(f"file ``{path}`` exists but it can not be written")
+            raise PermissionError(f"file ``{path}`` exists but it can not be written")
     else:
         raise ValueError(f"invalid mode: {mode!r}")
 


### PR DESCRIPTION
Hi there! I got burned trying to catch a `FileNotFoundError` in a script that loads some data (via deepdish, which uses tables internally)... and instead getting a nondescript `OSError`. I strongly feel that a more specific exception would make the checks done in `check_file_access()` much more useful.

I propose to substitute all uses of `OSError` with the [appropriate subclass exception](https://docs.python.org/3/library/exceptions.html#os-exceptions) for the particular case encountered. Note that, since all proposed substitutions are subclasses of `OSError`, existing exception handling mechanisms along the lines of `try: ... catch OSError: ...` will work just fine.

There doesn't seem to be a `NotARegularFileError`, sadly, but chances are that things that are `not path.isfile()` are probably directories, so I've decided to raise a `IsADirectoryError` there. I don't feel strongly about this choice, but I do think it would be a pity to have to break the symmetry and raise a parent `OSError` for that particular case.