### PR TITLE
Bump HDF5 version to 1.13.1.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.1
+      HDF5_VERSION: 1.13.1
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
@@ -114,7 +114,7 @@ jobs:
     name: Build ${{ matrix.cibw_python }} wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.1
+      HDF5_VERSION: 1.13.1
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]


### PR DESCRIPTION
Bumps HDF5 version to 1.13.1.

1.13.0 introduced universal binaries for macos. I'm hoping if the upgrade works that we can also add universal wheel support.