### PR TITLE
WIP: Build HDF5 as universal binary on osx

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.1
+      HDF5_VERSION: 1.13.1
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
@@ -114,7 +114,7 @@ jobs:
     name: Build ${{ matrix.cibw_python }} wheels on ${{matrix.arch}} for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.1
+      HDF5_VERSION: 1.13.1
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]

--- a/ci/github/get_hdf5_if_needed.sh
+++ b/ci/github/get_hdf5_if_needed.sh
@@ -15,8 +15,14 @@ else
         EXTRA_MPI_FLAGS="--enable-parallel --enable-shared"
     fi
 
+    MINOR_V=$(sed -e "s/.[0-9]\+\$//; s/^[0-9]\+.//" <<< $HDF5_VERSION)
+    MAJOR_V=${HDF5_VERSION/%.*.*}
     if [[ "$OSTYPE" == "darwin"* ]]; then
         lib_name=libhdf5.dylib
+        # universal binaries is only supported for v1.13+
+        if [[ $MAJOR_V -gt 1 || $MINOR_V -ge 13 ]]; then
+          export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
+        else
     else
         lib_name=libhdf5.so
     fi
@@ -30,13 +36,16 @@ else
         tar -xzvf hdf5-$HDF5_VERSION.tar.gz
         pushd hdf5-$HDF5_VERSION
         chmod u+x autogen.sh
-        if [[ "${HDF5_VERSION%.*}" = "1.12" ]]; then
-          ./configure --prefix $HDF5_DIR $EXTRA_MPI_FLAGS --enable-build-mode=production
+        # production is supported from 1.12
+        if [[ $MAJOR_V -gt 1 || $MINOR_V -ge 12 ]]; then
+          ./configure --prefix $HDF5_DIR $EXTRA_MPI_FLAGS --enable-build-mode=production 
         else
           ./configure --prefix $HDF5_DIR $EXTRA_MPI_FLAGS
         fi
         make -j $(nproc)
         make install
+        
+        file $HDF5_DIR/lib/$lib_name
         popd
         popd
     fi


### PR DESCRIPTION
This PR builds the HDF5 binaries and the wheels as universal on osx, so that it can support arm64. It depends on https://github.com/PyTables/PyTables/pull/942.

Currently it only builds the HDF5 binary in universal mode, if that works I can add the wheel part.