### PR TITLE
Direct chunking blosc2

### DIFF
--- a/bench/evaluate.py
+++ b/bench/evaluate.py
@@ -9,8 +9,8 @@ import tables as tb
 
 shape = (1000, 160_000)
 #shape = (10,1600)
-filters = tb.Filters(complevel=1, complib="blosc", shuffle=0)
-ofilters = tb.Filters(complevel=1, complib="blosc", shuffle=0)
+filters = tb.Filters(complevel=1, complib="blosc2", shuffle=1)
+ofilters = tb.Filters(complevel=1, complib="blosc2", shuffle=1)
 #filters = tb.Filters(complevel=1, complib="lzo", shuffle=0)
 #ofilters = tb.Filters(complevel=1, complib="lzo", shuffle=0)
 
@@ -108,7 +108,7 @@ def evaluate(ex, out=None, local_dict=None, global_dict=None, **kwargs):
     print("signature-->", signature)
 
     # Compile the expression
-    compiled_ex = ne.necompiler.NumExpr(ex, signature, [], **kwargs)
+    compiled_ex = ne.necompiler.NumExpr(ex, signature, **kwargs)
     print("fullsig-->", compiled_ex.fullsig)
 
     _compute(out, compiled_ex, arguments)
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     doprofile = 1
     dokprofile = 0
 
-    f = tb.open_file("/scratch2/faltet/evaluate.h5", "w")
+    f = tb.open_file("evaluate.h5", "w")
 
     # Create some arrays
     if iarrays:

--- a/bench/simple-table.py
+++ b/bench/simple-table.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import numpy as np
+import tables as tb
+from time import time
+
+# Size of the buffer to be appended
+M = 1_000_000
+# Number of rows in table
+N = 100 * M
+
+filename = "simple-table.h5"
+filters = tb.Filters(9, "blosc2", shuffle=True)
+#filters = tb.Filters(9, "zlib", shuffle=True)
+#dt = np.dtype([('int32', np.int32), ('float32', np.float32, 10)])
+dt = np.dtype([('int32', np.int32), ('float32', np.float32)])
+
+a = np.fromiter(((i, i) for i in range(M)), dtype=dt)
+#a = np.zeros(M, dtype=dt)
+
+if 1:
+    output_file = tb.open_file(filename, mode="w", PYTABLES_SYS_ATTRS=False)
+    table = output_file.create_table("/", "test", dt, filters=filters, expectedrows=N)#, chunkshape=131072)
+    chunkshape = table.chunkshape[0]
+    print("chunkshape:", chunkshape)
+
+    t0 = time()
+    for i in range(0, N, M):
+        table.append(a)
+    #table.append(a[1:-1])
+    table.flush()
+    print(f"Time for storing: {time() - t0 : .3f}s")
+
+    output_file.close()
+
+print("Start reads:")
+
+output_file = tb.open_file(filename)
+table = output_file.root.test
+
+t0 = time()
+result = 0
+# for i in range(0, N, 8192):
+#   result += table[i]['int32']
+# for row in table:
+#     result += row['int32']
+b = table[:]
+print(f"Time for reading: {time() - t0 : .3f}s")
+print("result:", result)
+
+output_file.close()

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     from time import perf_counter as clock
     from time import process_time as cpuclock
 
-    usage = """usage: %s [-v] [-P] [-R range] [-r] [-w] [-s recsize] [-f field] [-c level] [-l complib] [-i iterations] [-S] [-B] [-F] file
+    usage = """usage: %s [-v] [-P] [-R range] [-r] [-w] [-s recsize] [-f field] [-c level] [-l complib] [-n nrows] [-S] [-B] [-F] file
             -v verbose
             -P do profile
             -R select a range in a field in the form "start,stop,step"
@@ -287,10 +287,10 @@ if __name__ == "__main__":
             -B activate bitshuffle filter
             -F activate fletcher32 filter
             -l sets the compression library to be used ("zlib", "lzo", "blosc", "bzip2")
-            -i sets the number of rows in each table\n""" % sys.argv[0]
+            -n sets the number of rows in each table\n""" % sys.argv[0]
 
     try:
-        opts, pargs = getopt.getopt(sys.argv[1:], 'vPSBFR:rwf:s:c:l:i:')
+        opts, pargs = getopt.getopt(sys.argv[1:], 'vPSBFR:rwf:s:c:l:n:')
     except:
         sys.stderr.write(usage)
         sys.exit(0)
@@ -312,7 +312,7 @@ if __name__ == "__main__":
     shuffle = 0
     fletcher32 = 0
     complib = "blosc2:blosclz"
-    iterations = 1_000_000
+    nrows = 1_000_000
 
     # Get the options
     for option in opts:
@@ -343,8 +343,8 @@ if __name__ == "__main__":
             complevel = int(option[1])
         elif option[0] == '-l':
             complib = option[1]
-        elif option[0] == '-i':
-            iterations = int(option[1])
+        elif option[0] == '-n':
+            nrows = int(option[1])
 
     # Build the Filters instance
     filters = tb.Filters(complevel=complevel, complib=complib,
@@ -372,7 +372,7 @@ if __name__ == "__main__":
             import profile as prof
             import pstats
             prof.run(
-                '(rowsw, rowsz) = createFile(file, iterations, filters, '
+                '(rowsw, rowsz) = createFile(file, nrows, filters, '
                 'recsize)',
                 'table-bench.prof')
             stats = pstats.Stats('table-bench.prof')
@@ -380,7 +380,7 @@ if __name__ == "__main__":
             stats.sort_stats('time', 'calls')
             stats.print_stats(20)
         else:
-            (rowsw, rowsz) = createFile(file, iterations, filters, recsize)
+            (rowsw, rowsz) = createFile(file, nrows, filters, recsize)
         t2 = clock()
         cpu2 = cpuclock()
         tapprows = t2 - t1

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -405,7 +405,7 @@ if __name__ == "__main__":
         cpu2 = cpuclock()
         treadrows = t2 - t1
         cpureadrows = cpu2 - cpu1
-        print(f"Rows read: {rowsw}  Row size: {rowsz}")
+        print(f"Rows read: {rowsr}  Row size: {rowsz}")
         print(
             f"Time reading rows: {treadrows:.3f} s (real) "
             f"{cpureadrows:.3f} s (cpu)  {cpureadrows / treadrows:.0%}")

--- a/bench/table-bench.py
+++ b/bench/table-bench.py
@@ -3,8 +3,6 @@
 import numpy as np
 import tables as tb
 
-# This class is accessible only for the examples
-
 
 class Small(tb.IsDescription):
     var1 = tb.StringCol(itemsize=4, pos=2)

--- a/bench/table-copy.py
+++ b/bench/table-copy.py
@@ -3,9 +3,9 @@ from time import perf_counter as clock
 import numpy as np
 import tables as tb
 
-N = 144_000
-#N = 144
+N = 10_000_000
 
+filters = tb.Filters(9, "blosc2", shuffle=True)
 
 def timed(func, *args, **kwargs):
     start = clock()
@@ -16,12 +16,12 @@ def timed(func, *args, **kwargs):
 
 def create_table(output_path):
     print("creating array...", end=' ')
-    dt = np.dtype([('field%d' % i, int) for i in range(320)])
+    dt = np.dtype([('field%d' % i, int) for i in range(32)])
     a = np.zeros(N, dtype=dt)
     print("done.")
 
     output_file = tb.open_file(output_path, mode="w")
-    table = output_file.create_table("/", "test", dt)  # , filters=blosc4)
+    table = output_file.create_table("/", "test", dt, filters=filters)
     print("appending data...", end=' ')
     table.append(a)
     print("flushing...", end=' ')
@@ -36,7 +36,7 @@ def copy1(input_path, output_path):
     output_file = tb.open_file(output_path, mode="w")
 
     # copy nodes as a batch
-    input_file.copy_node("/", output_file.root, recursive=True)
+    input_file.copy_node("/", output_file.root, recursive=True, filters=filters)
     output_file.close()
     input_file.close()
 
@@ -44,57 +44,57 @@ def copy1(input_path, output_path):
 def copy2(input_path, output_path):
     print(f"copying data from {input_path} to {output_path}...")
     input_file = tb.open_file(input_path, mode="r")
-    input_file.copy_file(output_path, overwrite=True)
+    input_file.copy_file(output_path, overwrite=True, filters=filters)
     input_file.close()
 
 
 def copy3(input_path, output_path):
     print(f"copying data from {input_path} to {output_path}...")
     input_file = tb.open_file(input_path, mode="r")
-    output_file = tb.open_file(output_path, mode="w")
+    output_file = tb.open_file(output_path, mode="w", filters=filters)
     table = input_file.root.test
     table.copy(output_file.root)
     output_file.close()
     input_file.close()
 
 
-def copy4(input_path, output_path, complib='zlib', complevel=0):
+def copy4(input_path, output_path):
     print(f"copying data from {input_path} to {output_path}...")
     input_file = tb.open_file(input_path, mode="r")
-    output_file = tb.open_file(output_path, mode="w")
+    output_file = tb.open_file(output_path, mode="w", filters=filters)
 
     input_table = input_file.root.test
     print("reading data...", end=' ')
+    start = clock()
     data = input_file.root.test.read()
+    print(f"{clock() - start:.3f}s elapsed.")
     print("done.")
 
-    filter = tb.Filters(complevel=complevel, complib=complib)
-    output_table = output_file.create_table("/", "test", input_table.dtype,
-                                            filters=filter)
+    output_table = output_file.create_table("/", "test", input_table.dtype)
     print("appending data...", end=' ')
+    start = clock()
     output_table.append(data)
     print("flushing...", end=' ')
     output_table.flush()
+    print(f"{clock() - start:.3f}s elapsed.")
     print("done.")
 
     input_file.close()
     output_file.close()
 
 
-def copy5(input_path, output_path, complib='zlib', complevel=0):
+def copy5(input_path, output_path):
     print(f"copying data from {input_path} to {output_path}...")
     input_file = tb.open_file(input_path, mode="r")
-    output_file = tb.open_file(output_path, mode="w")
+    output_file = tb.open_file(output_path, mode="w", filters=filters)
 
     input_table = input_file.root.test
+    output_table = output_file.create_table("/", "test", input_table.dtype)
 
-    filter = tb.Filters(complevel=complevel, complib=complib)
-    output_table = output_file.create_table("/", "test", input_table.dtype,
-                                            filters=filter)
-    chunksize = 10_000
+    chunksize = 100_000
     rowsleft = len(input_table)
     start = 0
-    for chunk in range((len(input_table) / chunksize) + 1):
+    for chunk in range(int(len(input_table) / chunksize) + 1):
         stop = start + min(chunksize, rowsleft)
         data = input_table.read(start, stop)
         output_table.append(data)
@@ -108,8 +108,8 @@ def copy5(input_path, output_path, complib='zlib', complevel=0):
 
 if __name__ == '__main__':
     timed(create_table, 'tmp.h5')
-#    timed(copy1, 'tmp.h5', 'test1.h5')
+    timed(copy1, 'tmp.h5', 'test1.h5')
     timed(copy2, 'tmp.h5', 'test2.h5')
-#    timed(copy3, 'tmp.h5', 'test3.h5')
+    timed(copy3, 'tmp.h5', 'test3.h5')
     timed(copy4, 'tmp.h5', 'test4.h5')
     timed(copy5, 'tmp.h5', 'test5.h5')

--- a/hdf5-blosc/src/blosc_filter.c
+++ b/hdf5-blosc/src/blosc_filter.c
@@ -224,9 +224,8 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
         /* Extract the exact outbuf_size from the buffer header.
          *
          * NOTE: the guess value got from "cd_values" corresponds to the
-         * uncompressed chunk size but it should not be used in a general
-         * cases since other filters in the pipeline can modify the buffere
-         *  size.
+         * uncompressed chunk size but it should not be used in general
+         * since other filters in the pipeline can modify it.
          */
         blosc_cbuffer_sizes(*buf, &outbuf_size, &cbytes, &blocksize);
 

--- a/hdf5-blosc/src/blosc_filter.c
+++ b/hdf5-blosc/src/blosc_filter.c
@@ -165,14 +165,6 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
     }
     if (cd_nelmts >= 6) {
         doshuffle = cd_values[5];  /* BLOSC_SHUFFLE, BLOSC_BITSHUFFLE */
-	/* bitshuffle is only meant for production in >= 1.8.0 */
-#if ( (BLOSC_VERSION_MAJOR <= 1) && (BLOSC_VERSION_MINOR < 8) )
-	if (doshuffle == BLOSC_BITSHUFFLE) {
-	  PUSH_ERR("blosc_filter", H5E_CALLBACK,
-		   "this Blosc library version is not supported.  Please update to >= 1.8");
-	  goto failed;
-	}
-#endif
     }
     if (cd_nelmts >= 7) {
         const char *complist;

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -124,8 +124,9 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
    * And there is no harm in storing the original typesize here, as Blosc2
    * will decide internally to reduce it to 1 if > BLOSC_MAX_TYPESIZE.
    */
-  // if (basetypesize > BLOSC_MAX_TYPESIZE)
-  //   basetypesize = 1;
+  /* if (basetypesize > BLOSC_MAX_TYPESIZE)
+   *  basetypesize = 1;
+   */
   values[2] = basetypesize;
 
   /* Get the size of the chunk */
@@ -194,7 +195,11 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
     cparams.typesize = typesize;
     cparams.filters[BLOSC_LAST_FILTER] = doshuffle;
     cparams.clevel = clevel;
-    cparams.nthreads = 1;
+    cparams.nthreads = 4;
+    /* Use 64 KB for the blocksize.  In the future it should be allowed to
+     * set this for the public API.
+     */
+    cparams.blocksize = 65536;
     blosc2_context *cctx = blosc2_create_cctx(cparams);
     blosc2_storage storage = {.cparams=&cparams, .contiguous=false};
     blosc2_schunk* schunk = blosc2_schunk_new(&storage);
@@ -255,7 +260,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
     }
 
     blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
-    dparams.nthreads = 1;
+    dparams.nthreads = 4;
     blosc2_context *dctx = blosc2_create_dctx(dparams);
     status = blosc2_decompress_ctx(dctx, chunk, cbytes, outbuf, outbuf_size);
     if (status <= 0) {

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -1,0 +1,265 @@
+/*
+    Copyright (C) 2022  Blosc Development Team
+    http://blosc.org
+    License: MIT (see LICENSE.txt)
+
+    Filter program that allows the use of the Blosc2 filter in HDF5.
+
+*/
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include "hdf5.h"
+#include "blosc2_filter.h"
+
+#if defined(__GNUC__)
+#define PUSH_ERR(func, minor, str, ...) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, str, ##__VA_ARGS__)
+#elif defined(_MSC_VER)
+#define PUSH_ERR(func, minor, str, ...) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, str, __VA_ARGS__)
+#else
+/* This version is portable but it's better to use compiler-supported
+   approaches for handling the trailing comma issue when possible. */
+#define PUSH_ERR(func, minor, ...) H5Epush(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLINE, minor, __VA_ARGS__)
+#endif	/* defined(__GNUC__) */
+
+#define GET_FILTER(a, b, c, d, e, f, g) H5Pget_filter_by_id(a,b,c,d,e,f,g,NULL)
+
+
+size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
+                              const unsigned cd_values[], size_t nbytes,
+                              size_t* buf_size, void** buf);
+
+herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space);
+
+
+/* Register the filter, passing on the HDF5 return value */
+int register_blosc2(char **version, char **date){
+
+    int retval;
+
+    H5Z_class_t filter_class = {
+        H5Z_CLASS_T_VERS,
+        (H5Z_filter_t)(FILTER_BLOSC2),
+        1, 1,
+        "blosc2",
+        NULL,
+        (H5Z_set_local_func_t)(blosc2_set_local),
+        (H5Z_func_t)(blosc2_filter_function)
+    };
+
+    retval = H5Zregister(&filter_class);
+    if(retval<0){
+        PUSH_ERR("register_blosc2", H5E_CANTREGISTER, "Can't register Blosc2 filter");
+    }
+    if (version != NULL && date != NULL) {
+        *version = strdup(BLOSC2_VERSION_STRING);
+        *date = strdup(BLOSC2_VERSION_DATE);
+    }
+    return 1; /* lib is available */
+}
+
+/*  Filter setup.  Records the following inside the DCPL:
+
+    1. If version information is not present, set slots 0 and 1 to the filter
+       revision and Blosc2 version, respectively.
+
+    2. Compute the type size in bytes and store it in slot 2.
+
+    3. Compute the chunk size in bytes and store it in slot 3.
+*/
+herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
+
+  int ndims;
+  int i;
+  herr_t r;
+
+  unsigned int typesize, basetypesize;
+  unsigned int bufsize;
+  hsize_t chunkdims[32];
+  unsigned int flags;
+  size_t nelements = 8;
+  unsigned int values[] = {0, 0, 0, 0, 0, 0, 0, 0};
+  hid_t super_type;
+  H5T_class_t classt;
+
+  r = GET_FILTER(dcpl, FILTER_BLOSC2, &flags, &nelements, values, 0, NULL);
+  if (r < 0) return -1;
+
+  if (nelements < 4)
+    nelements = 4;  /* First 4 slots reserved. */
+
+  /* Set Blosc2 info in first two slots */
+  values[0] = FILTER_BLOSC2_VERSION;
+  values[1] = BLOSC2_VERSION_FORMAT;
+
+  ndims = H5Pget_chunk(dcpl, 32, chunkdims);
+  if (ndims < 0)
+    return -1;
+  if (ndims > 32) {
+    PUSH_ERR("blosc2_set_local", H5E_CALLBACK, "Chunk rank exceeds limit");
+    return -1;
+  }
+
+  typesize = H5Tget_size(type);
+  if (typesize == 0) return -1;
+  /* Get the size of the base type, even for ARRAY types */
+  classt = H5Tget_class(type);
+  if (classt == H5T_ARRAY) {
+    /* Get the array base component */
+    super_type = H5Tget_super(type);
+    basetypesize = H5Tget_size(super_type);
+    /* Release resources */
+    H5Tclose(super_type);
+  } else {
+    basetypesize = typesize;
+  }
+
+  /* Limit large typesizes (they are pretty expensive to shuffle
+     and, in addition, Blosc2 does not handle typesizes larger than
+     255 bytes). */
+  if (basetypesize > BLOSC_MAX_TYPESIZE)
+    basetypesize = 1;
+  values[2] = basetypesize;
+
+  /* Get the size of the chunk */
+  bufsize = typesize;
+  for (i = 0; i < ndims; i++) {
+    bufsize *= chunkdims[i];
+  }
+  values[3] = bufsize;
+
+#ifdef BLOSC2_DEBUG
+  fprintf(stderr, "Blosc2: Computed buffer size %d\n", bufsize);
+#endif
+
+  r = H5Pmodify_filter(dcpl, FILTER_BLOSC2, flags, nelements, values);
+  if (r < 0)
+    return -1;
+
+  return 1;
+}
+
+
+/* The filter function */
+size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
+                              const unsigned cd_values[], size_t nbytes,
+                              size_t* buf_size, void** buf) {
+
+  void* outbuf = NULL;
+  int status = 0;                /* Return code from Blosc2 routines */
+  size_t typesize;
+  size_t outbuf_size;
+  int clevel = 5;                /* Compression level default */
+  int doshuffle = 1;             /* Shuffle default */
+  int compcode;                  /* Blosc2 compressor */
+  int code;
+  const char* compname = "blosclz";    /* The compressor by default */
+  const char* complist;
+  char errmsg[256];
+
+  /* Filter params that are always set */
+  typesize = cd_values[2];      /* The datatype size */
+  outbuf_size = cd_values[3];   /* Precomputed buffer guess */
+  /* Optional params */
+  if (cd_nelmts >= 5) {
+    clevel = cd_values[4];        /* The compression level */
+  }
+  if (cd_nelmts >= 6) {
+    doshuffle = cd_values[5];  /* BLOSC_SHUFFLE, BLOSC_BITSHUFFLE */
+  }
+  if (cd_nelmts >= 7) {
+    compcode = cd_values[6];     /* The Blosc2 compressor used */
+    /* Check that we actually have support for the compressor code */
+    complist = blosc1_list_compressors();
+    code = blosc1_compcode_to_compname(compcode, &compname);
+    if (code == -1) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "this Blosc2 library does not have support for "
+                 "the '%s' compressor, but only for: %s",
+               compname, complist);
+      goto failed;
+    }
+  }
+
+  /* We're compressing */
+  if (!(flags & H5Z_FLAG_REVERSE)) {
+
+    /* Allocate an output buffer exactly as long as the input data; if
+       the result is larger, we simply return 0.  The filter is flagged
+       as optional, so HDF5 marks the chunk as uncompressed and
+       proceeds.
+    */
+
+    outbuf_size = (*buf_size);
+
+#ifdef BLOSC2_DEBUG
+    fprintf(stderr, "Blosc2: Compress %zd chunk w/buffer %zd\n",
+    nbytes, outbuf_size);
+#endif
+
+    outbuf = malloc(outbuf_size);
+
+    if (outbuf == NULL) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK,
+               "Can't allocate compression buffer");
+      goto failed;
+    }
+
+    blosc1_set_compressor(compname);
+    status = blosc1_compress(clevel, doshuffle, typesize, nbytes,
+                            *buf, outbuf, nbytes);
+    if (status < 0) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Blosc2 compression error");
+      goto failed;
+    }
+
+    /* We're decompressing */
+  } else {
+    /* declare dummy variables */
+    size_t cbytes, blocksize;
+
+    free(outbuf);
+
+    /* Extract the exact outbuf_size from the buffer header.
+     *
+     * NOTE: the guess value got from "cd_values" corresponds to the
+     * uncompressed chunk size but it should not be used in a general
+     * cases since other filters in the pipeline can modify the buffere
+     *  size.
+     */
+    blosc1_cbuffer_sizes(*buf, &outbuf_size, &cbytes, &blocksize);
+
+#ifdef BLOSC2_DEBUG
+    fprintf(stderr, "Blosc2: Decompress %zd chunk w/buffer %zd\n", nbytes, outbuf_size);
+#endif
+
+    outbuf = malloc(outbuf_size);
+
+    if (outbuf == NULL) {
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Can't allocate decompression buffer");
+      goto failed;
+    }
+
+    status = blosc1_decompress(*buf, outbuf, outbuf_size);
+    if (status <= 0) {    /* decompression failed */
+      PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Blosc2 decompression error");
+      goto failed;
+    } /* if !status */
+
+  } /* compressing vs decompressing */
+
+  if (status != 0) {
+    free(*buf);
+    *buf = outbuf;
+    *buf_size = outbuf_size;
+    return status;  /* Size of compressed/decompressed data */
+  }
+
+  failed:
+  free(outbuf);
+  return 0;
+
+} /* End filter function */

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -120,8 +120,12 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
   /* Limit large typesizes (they are pretty expensive to shuffle
      and, in addition, Blosc2 does not handle typesizes larger than
      255 bytes). */
-  if (basetypesize > BLOSC_MAX_TYPESIZE)
-    basetypesize = 1;
+  /* But for reads, it is useful to have the original typesize here.
+   * And there is no harm in storing the original typesize here, as Blosc2
+   * will decide internally to reduce it to 1 if > BLOSC_MAX_TYPESIZE.
+   */
+  // if (basetypesize > BLOSC_MAX_TYPESIZE)
+  //   basetypesize = 1;
   values[2] = basetypesize;
 
   /* Get the size of the chunk */

--- a/hdf5-blosc2/src/blosc2_filter.h
+++ b/hdf5-blosc2/src/blosc2_filter.h
@@ -1,0 +1,26 @@
+#ifndef FILTER_BLOSC2_H
+#define FILTER_BLOSC2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "blosc2.h"
+
+/* Filter revision number, starting at 1 */
+#define FILTER_BLOSC2_VERSION 1
+
+/* Filter ID registered with the HDF Group */
+#define FILTER_BLOSC2 256  /* Register with THG later on */
+
+/* Registers the filter with the HDF5 library. */
+#if defined(_MSC_VER)
+__declspec(dllexport)
+#endif	/* defined(_MSC_VER) */
+int register_blosc2(char **version, char **date);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hdf5-blosc2/src/blosc2_plugin.c
+++ b/hdf5-blosc2/src/blosc2_plugin.c
@@ -1,0 +1,40 @@
+/*
+ * Dynamically loaded filter plugin for HDF5 blosc2 filter.
+ *
+ * For compiling, use:
+ * $ h5cc -fPIC -shared blosc2_plugin.c blosc2_filter.c -o libH5Zblosc2.so -lblosc2
+ *
+ */
+
+
+#include "blosc2_plugin.h"
+#include "blosc2_filter.h"
+
+
+/* Prototypes for filter function in blosc2_filter.c. */
+size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
+                              const unsigned cd_values[], size_t nbytes,
+                              size_t* buf_size, void** buf);
+
+herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space);
+
+
+H5Z_class_t blosc2_H5Filter[1] = {
+    {
+        H5Z_CLASS_T_VERS,
+        (H5Z_filter_t)(FILTER_BLOSC2),
+        1,                   /* encoder_present flag (set to true) */
+        1,                   /* decoder_present flag (set to true) */
+        "blosc2",
+        /* Filter info  */
+        NULL,                           /* The "can apply" callback */
+        (H5Z_set_local_func_t)(blosc2_set_local), /* The "set local" callback */
+        (H5Z_func_t)(blosc2_filter_function),    /* The filter function */
+    }
+};
+
+
+H5PL_type_t H5PLget_plugin_type(void) { return H5PL_TYPE_FILTER; }
+
+
+const void* H5PLget_plugin_info(void) { return blosc2_H5Filter; }

--- a/hdf5-blosc2/src/blosc2_plugin.h
+++ b/hdf5-blosc2/src/blosc2_plugin.h
@@ -1,0 +1,32 @@
+/*
+ * Dynamically loaded filter plugin for HDF5 blosc2 filter.
+ *
+ * Header file
+ * -----------
+ *
+ * This provides dynamically loaded HDF5 filter functionality (introduced
+ * in HDF5-1.8.11, May 2013) to the blosc2 HDF5 filter.
+ *
+ * Usage: compile as a shared library and install either to the default
+ * search location for HDF5 filter plugins (on Linux 
+ * /usr/local/hdf5/lib/plugin) or to a location pointed to by the
+ * HDF5_PLUGIN_PATH environment variable.
+ *
+ */
+
+
+#ifndef PLUGIN_BLOSC2_H
+#define PLUGIN_BLOSC2_H
+
+#include "H5PLextern.h"
+
+
+H5PL_type_t H5PLget_plugin_type(void);
+
+
+const void* H5PLget_plugin_info(void);
+
+
+#endif    // PLUGIN_BLOSC2_H
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 # doc/source/usersguide/installation.rst
 numpy>=1.19.0
 numexpr>=2.6.2
+blosc2>=2.2.0
 packaging

--- a/setup.py
+++ b/setup.py
@@ -212,9 +212,6 @@ if __name__ == "__main__":
     exec((ROOT / "tables" / "req_versions.py").read_text(), _min_versions)
     min_hdf5_version = _min_versions["min_hdf5_version"]
     min_blosc_version = _min_versions["min_blosc_version"]
-    min_blosc_bitshuffle_version = _min_versions[
-        "min_blosc_bitshuffle_version"
-    ]
 
     # ----------------------------------------------------------------------
 
@@ -745,13 +742,6 @@ if __name__ == "__main__":
                     f"Unsupported Blosc version installed! Blosc "
                     f"{min_blosc_version}+ required. Found version "
                     f"{blosc_version}.  Using internal Blosc sources."
-                )
-            if blosc_version < min_blosc_bitshuffle_version:
-                print_warning(
-                    f"This Blosc version does not support the BitShuffle "
-                    f"filter. Minimum desirable version is "
-                    f"{min_blosc_bitshuffle_version}.  "
-                    f"Found version: {blosc_version}"
                 )
 
         if not rundir:

--- a/src/H5ARRAY.c
+++ b/src/H5ARRAY.c
@@ -5,6 +5,7 @@
 #include "H5Zlzo.h"                    /* Import FILTER_LZO */
 #include "H5Zbzip2.h"                  /* Import FILTER_BZIP2 */
 #include "blosc_filter.h"              /* Import FILTER_BLOSC */
+#include "blosc2_filter.h"             /* Import FILTER_BLOSC2 */
 
 #include <string.h>
 #include <stdlib.h>
@@ -129,6 +130,23 @@ hid_t H5ARRAYmake(  hid_t loc_id,
      /* The default compressor in HDF5 (zlib) */
      if (strcmp(complib, "zlib") == 0) {
        if ( H5Pset_deflate( plist_id, compress) < 0 )
+         return -1;
+     }
+     /* The Blosc2 compressor does accept parameters */
+     else if (strcmp(complib, "blosc2") == 0) {
+       cd_values[4] = compress;
+       cd_values[5] = shuffle;
+       if ( H5Pset_filter( plist_id, FILTER_BLOSC2, H5Z_FLAG_OPTIONAL, 6, cd_values) < 0 )
+         return -1;
+      }
+      /* The Blosc2 compressor can use other compressors */
+     else if (strncmp(complib, "blosc2:", 7) == 0) {
+       cd_values[4] = compress;
+       cd_values[5] = shuffle;
+       blosc_compname = complib + 7;
+       blosc_compcode = blosc1_compname_to_compcode(blosc_compname);
+       cd_values[6] = blosc_compcode;
+       if ( H5Pset_filter( plist_id, FILTER_BLOSC2, H5Z_FLAG_OPTIONAL, 7, cd_values) < 0 )
          return -1;
      }
      /* The Blosc compressor does accept parameters */

--- a/src/H5ATTR.c
+++ b/src/H5ATTR.c
@@ -449,9 +449,6 @@ static herr_t find_attr( hid_t loc_id,
 
  char *attr_name = (char*)op_data;
 
- /* Shut the compiler up */
- loc_id=loc_id;
-
  /* Define a positive value for return value if the attribute was
   * found. This will cause the iterator to immediately return that
   * positive value, indicating short-circuit success

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -361,7 +361,7 @@ herr_t read_records_blosc2( char* filename,
   //printf("Cannot find filter id 256 (blosc2)\n");
   goto out;
  }
- printf("Filter name: %s\n", name);
+ //printf("Filter name: %s\n", name);
  if (strcmp(name, "blosc2") != 0) {
   printf("Filter %s is not blosc2\n", name);
   goto out;
@@ -382,7 +382,7 @@ herr_t read_records_blosc2( char* filename,
   printf("Cannot open schunk in %s\n", filename);
   goto out;
  }
- printf("chunk logical offset: %zd\n", chunk_offset);
+ //printf("chunk logical offset: %zd\n", chunk_offset);
 
  /* Get the exact chunk size from the chunk header */
  int32_t typesize1 = cd_values[2];
@@ -390,11 +390,9 @@ herr_t read_records_blosc2( char* filename,
  int32_t typesize = schunk->typesize;
  int32_t chunksize = schunk->chunksize;
  int32_t blocksize = schunk->blocksize;
- printf("typesizes: %d, %d\n", typesize1, typesize);
- printf("chunksizes: %d, %d\n", chunksize1, chunksize);
- if (typesize1 != typesize) {
-  printf("Blosc2: typesizes differ (%d != %d).  Using the actual one for retrieving data!\n", typesize1, typesize);
- }
+// if (typesize1 != typesize) {
+//  printf("Blosc2: typesizes differ (%d != %d).  Using the actual one for retrieving data!\n", typesize1, typesize);
+// }
  int32_t rowsize = typesize1;
 
  bool needs_free;
@@ -402,8 +400,6 @@ herr_t read_records_blosc2( char* filename,
  int32_t cbytes = blosc2_schunk_get_lazychunk(schunk, (int64_t)chunk_idx, &chunk, &needs_free);
  if (cbytes < 0)
   goto out;
-
- printf("needs_free: %d\n", needs_free);
 
  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
  dparams.nthreads = 1;
@@ -428,7 +424,7 @@ herr_t read_records_blosc2( char* filename,
  if (needs_free) {
   free(chunk);
  }
- printf("Read %d bytes\n", rbytes);
+ //printf("Read %d bytes\n", rbytes);
 
  return 0;
 

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -712,5 +712,3 @@ herr_t H5TBOdelete_records( hid_t   dataset_id,
 out:
  return -1;
 }
-
-

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -274,6 +274,7 @@ out:
  */
 
 herr_t H5TBOread_records( char* filename,
+                          hbool_t native_order,
                           hid_t dataset_id,
                           hid_t mem_type_id,
                           hsize_t start,
@@ -290,10 +291,12 @@ herr_t H5TBOread_records( char* filename,
  if ( (space_id = H5Dget_space( dataset_id )) < 0 )
   goto out;
 
- /* Try to read using blosc2 */
- if (read_records_blosc2(filename, dataset_id, mem_type_id, space_id,
-                         start, nrecords, data) >= 0)
-  goto success;
+ if (native_order) {
+  /* Try to read using blosc2 (only supports native byteorder) */
+  if (read_records_blosc2(filename, dataset_id, mem_type_id, space_id,
+                          start, nrecords, data) >= 0)
+   goto success;
+ }
 
  /* Define a hyperslab in the dataset of the size of the records */
  offset[0] = start;
@@ -778,6 +781,7 @@ out:
  */
 
 herr_t H5TBOdelete_records( char* filename,
+                            hbool_t native_order,
                             hid_t   dataset_id,
                             hid_t   mem_type_id,
                             hsize_t ntotal_records,
@@ -829,7 +833,7 @@ herr_t H5TBOdelete_records( char* filename,
        return -1;
 
      /* Read the records after the deleted one(s) */
-     if ( H5TBOread_records(filename, dataset_id, mem_type_id, read_start,
+     if ( H5TBOread_records(filename, native_order, dataset_id, mem_type_id, read_start,
                             read_nbuf, tmp_buf ) < 0 )
        return -1;
 

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -17,14 +17,23 @@ hid_t H5TBOmake_table(  const char *table_title,
                         char *complib,
                         int shuffle,
                         int fletcher32,
-			hbool_t track_times,
+			                     hbool_t track_times,
                         const void *data );
 
-herr_t H5TBOread_records( hid_t dataset_id,
+herr_t H5TBOread_records( char *filename,
+                          hid_t dataset_id,
                           hid_t mem_type_id,
                           hsize_t start,
                           hsize_t nrecords,
                           void *data );
+
+herr_t read_records_blosc2( char* filename,
+                            hid_t dataset_id,
+                            hid_t mem_type_id,
+                            hid_t space_id,
+                            hsize_t start,
+                            hsize_t nrecords,
+                            void *data );
 
 herr_t H5TBOread_elements( hid_t dataset_id,
                            hid_t mem_type_id,
@@ -51,7 +60,8 @@ herr_t H5TBOwrite_elements( hid_t dataset_id,
                             const void *coords,
                             const void *data );
 
-herr_t H5TBOdelete_records( hid_t   dataset_id,
+herr_t H5TBOdelete_records( char* filename,
+                            hid_t   dataset_id,
                             hid_t   mem_type_id,
                             hsize_t ntotal_records,
                             size_t  src_size,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -21,6 +21,7 @@ hid_t H5TBOmake_table(  const char *table_title,
                         const void *data );
 
 herr_t H5TBOread_records( char *filename,
+                          hbool_t native_order,
                           hid_t dataset_id,
                           hid_t mem_type_id,
                           hsize_t start,
@@ -61,6 +62,7 @@ herr_t H5TBOwrite_elements( hid_t dataset_id,
                             const void *data );
 
 herr_t H5TBOdelete_records( char* filename,
+                            hbool_t native_order,
                             hid_t   dataset_id,
                             hid_t   mem_type_id,
                             hsize_t ntotal_records,

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -10,7 +10,6 @@ to efficiently cope with extremely large amounts of data.
 # Necessary imports to get versions stored on the cython extension
 from .utilsextension import get_hdf5_version as _get_hdf5_version
 
-
 __version__ = "3.7.1.dev0"
 """The PyTables version number."""
 
@@ -24,6 +23,7 @@ hdf5_version = _get_hdf5_version()
 from .utilsextension import (
     blosc_compcode_to_compname_ as blosc_compcode_to_compname,
     blosc_get_complib_info_ as blosc_get_complib_info,
+    blosc2_get_complib_info_ as blosc2_get_complib_info,
 )
 
 from .utilsextension import (

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -22,13 +22,19 @@ hdf5_version = _get_hdf5_version()
 
 from .utilsextension import (
     blosc_compcode_to_compname_ as blosc_compcode_to_compname,
+    blosc2_compcode_to_compname_ as blosc2_compcode_to_compname,
     blosc_get_complib_info_ as blosc_get_complib_info,
     blosc2_get_complib_info_ as blosc2_get_complib_info,
 )
 
 from .utilsextension import (
-    blosc_compressor_list, is_hdf5_file, is_pytables_file, which_lib_version,
-    set_blosc_max_threads, silence_hdf5_messages,
+    blosc_compressor_list,
+    blosc2_compressor_list,
+    is_hdf5_file,
+    is_pytables_file,
+    which_lib_version,
+    set_blosc_max_threads,
+    silence_hdf5_messages,
 )
 
 from .misc.enum import Enum

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -566,7 +566,7 @@ cdef extern from "typeconv.h" nogil:
 # Blosc2 registration
 cdef extern from "blosc2_filter.h" nogil:
   int register_blosc2(char **version, char **date)
-  int FILTER_BLOSC
+  int FILTER_BLOSC2
 
 
 # Blosc registration

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -563,6 +563,12 @@ cdef extern from "typeconv.h" nogil:
                               unsigned long nelements,
                               int sense)
 
+# Blosc2 registration
+cdef extern from "blosc2_filter.h" nogil:
+  int register_blosc2(char **version, char **date)
+  int FILTER_BLOSC
+
+
 # Blosc registration
 cdef extern from "blosc_filter.h" nogil:
   int register_blosc(char **version, char **date)

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -3,20 +3,28 @@
 import warnings
 import numpy as np
 
-from . import utilsextension, blosc_compressor_list, blosc_compcode_to_compname
+from . import (
+    utilsextension,
+    blosc_compressor_list,
+    blosc_compcode_to_compname,
+    blosc2_compressor_list,
+    blosc2_compcode_to_compname,
+)
 from .exceptions import FiltersWarning
 from packaging.version import Version
 
 import tables as tb
 
 blosc_version = Version(tb.which_lib_version("blosc")[1])
+blosc2_version = Version(tb.which_lib_version("blosc2")[1])
 
 
 __docformat__ = 'reStructuredText'
 """The format of documentation strings in this module."""
 
-all_complibs = ['zlib', 'lzo', 'bzip2', 'blosc']
+all_complibs = ['zlib', 'lzo', 'bzip2', 'blosc', 'blosc2']
 all_complibs += ['blosc:%s' % cname for cname in blosc_compressor_list()]
+all_complibs += ['blosc2:%s' % cname for cname in blosc2_compressor_list()]
 
 
 """List of all compression libraries."""
@@ -51,24 +59,29 @@ class Filters:
         compression.
     complib : str
         Specifies the compression library to be used. Right now, 'zlib' (the
-        default), 'lzo', 'bzip2' and 'blosc' are supported. Additional
-        compressors for Blosc like 'blosc:blosclz' ('blosclz' is the default in
-        case the additional compressor is not specified), 'blosc:lz4',
-        'blosc:lz4hc', 'blosc:snappy', 'blosc:zlib' and 'blosc:zstd' are
-        supported too. Specifying a compression library which is not available
+        default), 'lzo', 'bzip2', 'blosc' and 'blosc2' are supported.
+        Additional compressors for Blosc like 'blosc:blosclz' ('blosclz' is
+        the default in case the additional compressor is not specified),
+        'blosc:lz4', 'blosc:lz4hc', 'blosc:zlib' and 'blosc:zstd' are
+        supported too.
+        Also, additional compressors for Blosc2 like 'blosc2:blosclz'
+        ('blosclz' is the default in case the additional compressor is not
+        specified), 'blosc2:lz4', 'blosc2:lz4hc', 'blosc2:zlib' and
+        'blosc2:zstd' are supported too.
+        Specifying a compression library which is not available
         in the system issues a FiltersWarning and sets the library to the
         default one.
     shuffle : bool
-        Whether or not to use the *Shuffle* filter in the HDF5
-        library. This is normally used to improve the compression
-        ratio. A false value disables shuffling and a true one enables
+        Whether to use the *Shuffle* filter in the HDF5 library.
+        This is normally used to improve the compression ratio.
+        A false value disables shuffling and a true one enables
         it. The default value depends on whether compression is
         enabled or not; if compression is enabled, shuffling defaults
         to be enabled, else shuffling is disabled. Shuffling can only
         be used when compression is enabled.
     bitshuffle : bool
-        Whether to use the *BitShuffle* filter in the Blosc
-        library. This is normally used to improve the compression
+        Whether to use the *BitShuffle* filter in the Blosc/Blosc2
+        libraries. This is normally used to improve the compression
         ratio. A false value disables bitshuffling and a true one
         enables it. The default value is disabled.
     fletcher32 : bool
@@ -147,7 +160,7 @@ class Filters:
 
     .. attribute:: bitshuffle
 
-        Whether the *BitShuffle* filter is active or not (Blosc only).
+        Whether the *BitShuffle* filter is active or not (Blosc/Blosc2 only).
 
     """
 
@@ -182,18 +195,22 @@ class Filters:
                 name = 'zlib'
             if name in all_complibs:
                 kwargs['complib'] = name
-                if name == "blosc":
+                if name in ('blosc', 'blosc2'):
                     kwargs['complevel'] = values[4]
                     if values[5] == 1:
-                        # Shuffle filter is internal to blosc
+                        # Shuffle filter is internal to blosc/blosc2
                         kwargs['shuffle'] = True
                     elif values[5] == 2:
-                        # Shuffle filter is internal to blosc
+                        # Shuffle filter is internal to blosc/blosc2
                         kwargs['bitshuffle'] = True
                     # From Blosc 1.3 on, parameter 6 is used for the compressor
                     if len(values) > 6:
-                        cname = blosc_compcode_to_compname(values[6])
-                        kwargs['complib'] = "blosc:%s" % cname
+                        if name == "blosc":
+                            cname = blosc_compcode_to_compname(values[6])
+                            kwargs['complib'] = "blosc:%s" % cname
+                        else:
+                            cname = blosc2_compcode_to_compname(values[6])
+                            kwargs['complib'] = "blosc2:%s" % cname
                 else:
                     kwargs['complevel'] = values[0]
             elif name in foreign_complibs:

--- a/tables/filters.py
+++ b/tables/filters.py
@@ -67,13 +67,12 @@ class Filters:
         to be enabled, else shuffling is disabled. Shuffling can only
         be used when compression is enabled.
     bitshuffle : bool
-        Whether or not to use the *BitShuffle* filter in the Blosc
+        Whether to use the *BitShuffle* filter in the Blosc
         library. This is normally used to improve the compression
         ratio. A false value disables bitshuffling and a true one
         enables it. The default value is disabled.
     fletcher32 : bool
-        Whether or not to use the
-        *Fletcher32* filter in the HDF5 library.
+        Whether to use the *Fletcher32* filter in the HDF5 library.
         This is used to add a checksum on each data chunk. A false
         value (the default) disables the checksum.
     least_significant_digit : int
@@ -341,18 +340,11 @@ class Filters:
         if (self.complib and
                 self.bitshuffle and
                 not self.complib.startswith('blosc')):
-            raise ValueError("BitShuffle can only be used inside Blosc")
+            raise ValueError("BitShuffle can only be used inside Blosc/Blosc2")
 
         if self.shuffle and self.bitshuffle:
             # BitShuffle has priority in case both are specified
             self.shuffle = False
-
-        if (self.bitshuffle and
-                blosc_version < tb.req_versions.min_blosc_bitshuffle_version):
-            raise ValueError(f"This Blosc library does not have support for "
-                             f"the bitshuffle filter.  Please update to "
-                             f"Blosc >= "
-                             f"{tb.req_versions.min_blosc_bitshuffle_version}")
 
         self.fletcher32 = fletcher32
         """Whether the *Fletcher32* filter is active or not."""

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -321,7 +321,7 @@ class Leaf(Node):
         if complib is not None and complib.startswith("blosc2"):
             # Blosc2 can introspect into blocks, so we can increase the
             # chunksize for improving HDF5 perf for its internal btree.
-            chunksize *= 16
+            chunksize *= 32
 
         maindim = self.maindim
         # Compute the chunknitems

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -19,7 +19,7 @@ def csformula(expected_mb):
     # For a basesize of 8 KB, this will return:
     # 8 KB for datasets <= 1 MB
     # 1 MB for datasets >= 10 TB
-    basesize = 8 * 1024   # 8 KB is a good minimum
+    basesize = 8 * 1024  # 8 KB is a good minimum
     return basesize * int(2**math.log10(expected_mb))
 
 
@@ -317,6 +317,11 @@ class Leaf(Node):
         MB = 1024 * 1024
         expected_mb = (expectedrows * rowsize) // MB
         chunksize = calc_chunksize(expected_mb)
+        complib = self.filters.complib
+        if complib is not None and complib.startswith("blosc2"):
+            # Blosc2 can introspect into blocks, so no need to restrict
+            # chunksize too much.
+            chunksize *= 32
 
         maindim = self.maindim
         # Compute the chunknitems

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -319,9 +319,9 @@ class Leaf(Node):
         chunksize = calc_chunksize(expected_mb)
         complib = self.filters.complib
         if complib is not None and complib.startswith("blosc2"):
-            # Blosc2 can introspect into blocks, so no need to restrict
-            # chunksize too much.
-            chunksize *= 32
+            # Blosc2 can introspect into blocks, so we can increase the
+            # chunksize for improving HDF5 perf for its internal btree.
+            chunksize *= 16
 
         maindim = self.maindim
         # Compute the chunknitems

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -9,7 +9,5 @@ from packaging.version import Version
 # Minimum recommended versions for mandatory packages
 min_numpy_version = Version('1.9.3')
 min_numexpr_version = Version('2.6.2')
-min_hdf5_version = Version('1.8.4')
-min_blosc_version = Version("1.4.1")
-min_blosc_bitshuffle_version = Version("1.8.0")
-"""The minumum Blosc version where BitShuffle can be used safely."""
+min_hdf5_version = Version('1.10.2')
+min_blosc_version = Version('1.11.1')

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -11,4 +11,4 @@ min_numpy_version = Version('1.9.3')
 min_numexpr_version = Version('2.6.2')
 min_hdf5_version = Version('1.10.2')
 min_blosc_version = Version('1.11.1')
-min_blosc2_version = Version('2.2.0')  # FIXME: bump to 2.3.0 when published
+min_blosc2_version = Version('2.3.0')

--- a/tables/req_versions.py
+++ b/tables/req_versions.py
@@ -11,3 +11,4 @@ min_numpy_version = Version('1.9.3')
 min_numexpr_version = Version('2.6.2')
 min_hdf5_version = Version('1.10.2')
 min_blosc_version = Version('1.11.1')
+min_blosc2_version = Version('2.2.0')  # FIXME: bump to 2.3.0 when published

--- a/tables/scripts/ptrepack.py
+++ b/tables/scripts/ptrepack.py
@@ -319,8 +319,11 @@ def _get_parser():
     parser.add_argument(
         '--complib', choices=(
             "zlib", "lzo", "bzip2", "blosc", "blosc:blosclz",
-            "blosc:lz4", "blosc:lz4hc", "blosc:snappy",
-            "blosc:zlib", "blosc:zstd"), default='zlib',
+            "blosc:lz4", "blosc:lz4hc", "blosc:zlib", "blosc:zstd",
+            "blosc2", "blosc2:blosclz",
+            "blosc2:lz4", "blosc2:lz4hc", "blosc2:zlib", "blosc2:zstd"
+        ),
+        default='zlib',
         help='''set the compression library to be used during the copy.
         Defaults to %(default)s''',
     )

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -76,7 +76,7 @@ cdef extern from "H5TB-opt.h" nogil:
                           char *complib, int shuffle, int fletcher32,
                           hbool_t track_times, void *data )
 
-  herr_t H5TBOread_records( hid_t dataset_id, hid_t mem_type_id,
+  herr_t H5TBOread_records( char* filename, hid_t dataset_id, hid_t mem_type_id,
                             hsize_t start, hsize_t nrecords, void *data )
 
   herr_t H5TBOread_elements( hid_t dataset_id, hid_t mem_type_id,
@@ -93,7 +93,8 @@ cdef extern from "H5TB-opt.h" nogil:
   herr_t H5TBOwrite_elements( hid_t dataset_id, hid_t mem_type_id,
                               hsize_t nrecords, void *coords, void *data )
 
-  herr_t H5TBOdelete_records( hid_t   dataset_id, hid_t   mem_type_id,
+  herr_t H5TBOdelete_records( char* filename,
+                              hid_t   dataset_id, hid_t   mem_type_id,
                               hsize_t ntotal_records, size_t  src_size,
                               hsize_t start, hsize_t nrecords,
                               hsize_t maxtuples )
@@ -569,6 +570,8 @@ cdef class Table(Leaf):
   def _read_records(self, hsize_t start, hsize_t nrecords, ndarray recarr):
     cdef void *rbuf
     cdef int ret
+    cdef bytes fname = self._v_file.filename.encode('utf8')
+    cdef char* filename = fname
 
     # Correct the number of records to read, if needed
     if (start + nrecords) > self.nrows:
@@ -579,8 +582,8 @@ cdef class Table(Leaf):
 
     # Read the records from disk
     with nogil:
-        ret = H5TBOread_records(self.dataset_id, self.type_id, start,
-                                nrecords, rbuf)
+        ret = H5TBOread_records(filename, self.dataset_id,
+                                self.type_id, start, nrecords, rbuf)
 
     if ret < 0:
       raise HDF5ExtError("Problems reading records.")
@@ -596,6 +599,8 @@ cdef class Table(Leaf):
     cdef int ret
     cdef void *rbuf
     cdef NumCache chunkcache
+    cdef bytes fname = self._v_file.filename.encode('utf8')
+    cdef char* filename = fname
 
     chunkcache = self._chunkcache
     chunkshape = chunkcache.slotsize
@@ -612,8 +617,8 @@ cdef class Table(Leaf):
     else:
       # Chunk is not in cache. Read it and put it in the LRU cache.
       with nogil:
-          ret = H5TBOread_records(self.dataset_id, self.type_id,
-                                  start, nrecords, rbuf)
+          ret = H5TBOread_records(filename, self.dataset_id,
+                                  self.type_id, start, nrecords, rbuf)
 
       if ret < 0:
         raise HDF5ExtError("Problems reading chunk records.")
@@ -649,12 +654,14 @@ cdef class Table(Leaf):
     cdef size_t rowsize
     cdef hsize_t nrecords=0, nrecords2
     cdef hsize_t i
+    cdef bytes fname = self._v_file.filename.encode('utf8')
+    cdef char* filename = fname
 
     if step == 1:
       nrecords = stop - start
       rowsize = self.rowsize
       # Using self.disk_type_id should be faster (i.e. less conversions)
-      if (H5TBOdelete_records(self.dataset_id, self.disk_type_id,
+      if (H5TBOdelete_records(filename, self.dataset_id, self.disk_type_id,
                               self.nrows, rowsize, start, nrecords,
                               self.nrowsinbuf) < 0):
         raise HDF5ExtError("Problems deleting records.")

--- a/tables/tests/__init__.py
+++ b/tables/tests/__init__.py
@@ -8,3 +8,5 @@ functionality.
 
 from tables.tests.common import print_versions
 from tables.tests.test_suite import test, suite
+# Necessary for the test suite
+import tables.req_versions

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -54,6 +54,7 @@ zlib_avail = tb.which_lib_version("zlib") is not None
 lzo_avail = tb.which_lib_version("lzo") is not None
 bzip2_avail = tb.which_lib_version("bzip2") is not None
 blosc_avail = tb.which_lib_version("blosc") is not None
+blosc2_avail = tb.which_lib_version("blosc2") is not None
 
 
 def print_heavy(heavy):

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -19,6 +19,7 @@ import tables as tb
 
 hdf5_version = Version(tb.hdf5_version)
 blosc_version = Version(tb.which_lib_version("blosc")[1])
+blosc2_version = Version(tb.which_lib_version("blosc2")[1])
 
 
 verbose = os.environ.get("VERBOSE", "FALSE") == "TRUE"

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -16,7 +16,6 @@ import numexpr as ne
 import numpy as np
 
 import tables as tb
-from tables.req_versions import min_blosc_bitshuffle_version
 
 hdf5_version = Version(tb.hdf5_version)
 blosc_version = Version(tb.which_lib_version("blosc")[1])
@@ -102,10 +101,19 @@ def print_versions():
             "{} ({})".format(k, v[1]) for k, v in sorted(blosc_cinfo.items())
         ]
         print("Blosc compressors:   %s" % ', '.join(blosc_cinfo))
-        blosc_finfo = ['shuffle']
-        if Version(tinfo[1]) >= tb.req_versions.min_blosc_bitshuffle_version:
-            blosc_finfo.append('bitshuffle')
+        blosc_finfo = ['shuffle', 'bitshuffle']
         print("Blosc filters:       %s" % ', '.join(blosc_finfo))
+    tinfo = tb.which_lib_version("blosc2")
+    if tinfo is not None:
+        blosc2_date = tinfo[2].split()[1]
+        print("Blosc2 version:      {} ({})".format(tinfo[1], blosc2_date))
+        blosc2_cinfo = tb.blosc2_get_complib_info()
+        blosc2_cinfo = [
+            "{} ({})".format(k, v[1]) for k, v in sorted(blosc2_cinfo.items())
+        ]
+        print("Blosc2 compressors:  %s" % ', '.join(blosc2_cinfo))
+        blosc2_finfo = ['shuffle', 'bitshuffle', 'FIXME: add the complete list here']
+        print("Blosc2 filters:      %s" % ', '.join(blosc2_finfo))
     try:
         from Cython import __version__ as cython_version
         print('Cython version:      %s' % cython_version)

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -665,9 +665,6 @@ class BloscShuffleTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(
-    common.blosc_version < common.min_blosc_bitshuffle_version,
-    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class BloscBitShuffleTestCase(BasicTestCase):
     shape = (20, 30)
     compress = 1

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -678,9 +678,6 @@ class FiltersCaseBloscZstd(FiltersTreeTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(
-    common.blosc_version < common.min_blosc_bitshuffle_version,
-    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class FiltersCaseBloscBitShuffle(FiltersTreeTestCase):
     filters = tb.Filters(shuffle=False, complevel=1, complib="blosc:blosclz")
     gfilters = tb.Filters(complevel=5, shuffle=False, bitshuffle=True,

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1123,10 +1123,6 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def test03_endianess(self):
         """Checking if table is endianess aware."""
 
-        if self.complib.startswith("blosc2"):
-            # TODO: Blosc2 does not support byteorder changes (yet)
-            return
-
         if common.verbose:
             print('\n', '-=' * 30)
             print("Running %s.test03_endianess..." % self.__class__.__name__)

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1123,6 +1123,10 @@ class BasicTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def test03_endianess(self):
         """Checking if table is endianess aware."""
 
+        if self.complib.startswith("blosc2"):
+            # TODO: Blosc2 does not support byteorder changes (yet)
+            return
+
         if common.verbose:
             print('\n', '-=' * 30)
             print("Running %s.test03_endianess..." % self.__class__.__name__)
@@ -1708,6 +1712,13 @@ class CompressBloscTablesTestCase(BasicTestCase):
     compress = 6
     complib = "blosc"
 
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+class CompressBlosc2TablesTestCase(BasicTestCase):
+    title = "Compress2BloscTables"
+    compress = 6
+    complib = "blosc2"
+
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
@@ -1716,6 +1727,15 @@ class CompressBloscShuffleTablesTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
     complib = "blosc"
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+class CompressBlosc2ShuffleTablesTestCase(BasicTestCase):
+    title = "CompressBloscTables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2"
 
 
 @common.unittest.skipIf(not common.blosc_avail,
@@ -1728,6 +1748,16 @@ class CompressBloscBitShuffleTablesTestCase(BasicTestCase):
     complib = "blosc:blosclz"
 
 
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+class CompressBlosc2BitShuffleTablesTestCase(BasicTestCase):
+    title = "CompressBloscBit2ShuffleTables"
+    compress = 1
+    shuffle = 0
+    bitshuffle = 1
+    complib = "blosc2:blosclz"
+
+
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
 class CompressBloscBloscLZTablesTestCase(BasicTestCase):
@@ -1735,6 +1765,15 @@ class CompressBloscBloscLZTablesTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
     complib = "blosc:blosclz"
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC compression library not available')
+class CompressBlosc2BloscLZTablesTestCase(BasicTestCase):
+    title = "CompressBloscLZTables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2:blosclz"
 
 
 @common.unittest.skipIf(not common.blosc_avail,
@@ -1748,6 +1787,17 @@ class CompressBloscLZ4TablesTestCase(BasicTestCase):
     complib = "blosc:lz4"
 
 
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc2_compressor_list(), 'lz4 required')
+class CompressBlosc2LZ4TablesTestCase(BasicTestCase):
+    title = "CompressLZ4Tables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2:lz4"
+
+
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
 @common.unittest.skipIf(
@@ -1757,6 +1807,17 @@ class CompressBloscLZ4HCTablesTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
     complib = "blosc:lz4hc"
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+@common.unittest.skipIf(
+    'lz4' not in tb.blosc2_compressor_list(), 'lz4 required')
+class CompressBlosc2LZ4HCTablesTestCase(BasicTestCase):
+    title = "CompressLZ4HCTables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2:lz4hc"
 
 
 @common.unittest.skipIf(not common.blosc_avail,
@@ -1781,6 +1842,17 @@ class CompressBloscZlibTablesTestCase(BasicTestCase):
     complib = "blosc:zlib"
 
 
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+@common.unittest.skipIf(
+    'zlib' not in tb.blosc2_compressor_list(), 'zlib required')
+class CompressBlosc2ZlibTablesTestCase(BasicTestCase):
+    title = "CompressZlibTables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2:zlib"
+
+
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
 @common.unittest.skipIf(
@@ -1790,6 +1862,17 @@ class CompressBloscZstdTablesTestCase(BasicTestCase):
     compress = 1
     shuffle = 1
     complib = "blosc:zstd"
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
+@common.unittest.skipIf(
+    'zstd' not in tb.blosc2_compressor_list(), 'zstd required')
+class CompressBlosc2ZstdTablesTestCase(BasicTestCase):
+    title = "CompressZstdTables"
+    compress = 1
+    shuffle = 1
+    complib = "blosc2:zstd"
 
 
 @common.unittest.skipIf(not common.lzo_avail,
@@ -6544,22 +6627,38 @@ def suite():
             common.unittest.makeSuite(RecArrayAlignedWriteTestCase))
         theSuite.addTest(
             common.unittest.makeSuite(CompressBloscTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBlosc2TablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
             CompressBloscShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
+            CompressBlosc2ShuffleTablesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
             CompressBloscBitShuffleTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(
+            CompressBlosc2BitShuffleTablesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
             CompressBloscBloscLZTablesTestCase))
+        theSuite.addTest(common.unittest.makeSuite(
+            CompressBlosc2BloscLZTablesTestCase))
         theSuite.addTest(
             common.unittest.makeSuite(CompressBloscLZ4TablesTestCase))
         theSuite.addTest(
+            common.unittest.makeSuite(CompressBlosc2LZ4TablesTestCase))
+        theSuite.addTest(
             common.unittest.makeSuite(CompressBloscLZ4HCTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBlosc2LZ4HCTablesTestCase))
         theSuite.addTest(
             common.unittest.makeSuite(CompressBloscSnappyTablesTestCase))
         theSuite.addTest(
             common.unittest.makeSuite(CompressBloscZlibTablesTestCase))
         theSuite.addTest(
+            common.unittest.makeSuite(CompressBlosc2ZlibTablesTestCase))
+        theSuite.addTest(
             common.unittest.makeSuite(CompressBloscZstdTablesTestCase))
+        theSuite.addTest(
+            common.unittest.makeSuite(CompressBlosc2ZstdTablesTestCase))
         theSuite.addTest(common.unittest.makeSuite(CompressLZOTablesTestCase))
         theSuite.addTest(
             common.unittest.makeSuite(CompressLZOShuffleTablesTestCase))

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -1720,9 +1720,6 @@ class CompressBloscShuffleTablesTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(
-    common.blosc_version < common.min_blosc_bitshuffle_version,
-    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class CompressBloscBitShuffleTablesTestCase(BasicTestCase):
     title = "CompressBloscBitShuffleTables"
     compress = 1

--- a/tables/tests/test_vlarray.py
+++ b/tables/tests/test_vlarray.py
@@ -274,9 +274,6 @@ class BloscShuffleComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc_avail,
                         'BLOSC compression library not available')
-@common.unittest.skipIf(
-    common.blosc_version < common.min_blosc_bitshuffle_version,
-    f'BLOSC >= {common.min_blosc_bitshuffle_version} required')
 class BloscBitShuffleComprTestCase(BasicTestCase):
     compress = 9
     bitshuffle = 1

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -35,6 +35,25 @@ from libc.string cimport strchr, strcmp, strncmp, strlen
 from cpython.bytes cimport PyBytes_Check, PyBytes_FromStringAndSize
 from cpython.unicode cimport PyUnicode_DecodeUTF8, PyUnicode_Check
 
+# For some reason, Blosc2 headers must precede Blosc1 headers
+# Functions from Blosc2
+cdef extern from "blosc2.h" nogil:
+  void blosc1_init()
+  int blosc1_set_nthreads(int nthreads)
+  const char* blosc1_list_compressors()
+  int blosc1_compcode_to_compname(int compcode, char **compname)
+  int blosc1_get_complib_info(char *compname, char **complib, char **version)
+
+
+# Functions from Blosc
+cdef extern from "blosc.h" nogil:
+  void blosc_init()
+  int blosc_set_nthreads(int nthreads)
+  const char* blosc_list_compressors()
+  int blosc_compcode_to_compname(int compcode, char **compname)
+  int blosc_get_complib_info(char *compname, char **complib, char **version)
+
+
 from numpy cimport (import_array, ndarray, dtype,
   npy_int64, PyArray_DATA, PyArray_GETPTR1, PyArray_DescrFromType, npy_intp,
   NPY_BOOL, NPY_STRING, NPY_INT8, NPY_INT16, NPY_INT32, NPY_INT64,
@@ -68,7 +87,7 @@ from .definitions cimport (H5ARRAYget_info, H5ARRAYget_ndims,
   PyArray_Scalar, create_ieee_complex128, create_ieee_complex64,
   create_ieee_float16, create_ieee_complex192, create_ieee_complex256,
   get_len_of_range, get_order, herr_t, hid_t, hsize_t,
-  hssize_t, htri_t, is_complex, register_blosc, set_order,
+  hssize_t, htri_t, is_complex, register_blosc, register_blosc2, set_order,
   pt_H5free_memory, H5T_STD_REF_OBJ, H5Rdereference, H5R_OBJECT, H5I_DATASET, H5I_REFERENCE,
   H5Iget_type, hobj_ref_t, H5Oclose)
 
@@ -184,14 +203,6 @@ cdef extern from "utils.h":
                              hid_t *type_id, hid_t *dataset_id) nogil
 
 
-# Functions from Blosc
-cdef extern from "blosc.h" nogil:
-  void blosc_init()
-  int blosc_set_nthreads(int nthreads)
-  const char* blosc_list_compressors()
-  int blosc_compcode_to_compname(int compcode, char **compname)
-  int blosc_get_complib_info(char *compname, char **complib, char **version)
-
 cdef extern from "H5ARRAY.h" nogil:
   herr_t H5ARRAYread(hid_t dataset_id, hid_t type_id,
                      hsize_t start, hsize_t nrows, hsize_t step,
@@ -266,25 +277,19 @@ cdef register_blosc_():
 
 blosc_version = register_blosc_()
 
-# Old versions (<1.4) of the blosc compression library
-# rely on unaligned memory access, so they are not functional on some
-# platforms (see https://github.com/FrancescAlted/blosc/issues/3 and
-# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=661286).
-# This function has been written by Julian Taylor <jtaylor@ubuntu.com>.
-def _arch_without_blosc():
-  import platform
-  arch = platform.machine().lower()
-  for a in ("arm", "sparc", "mips", "aarch64"):
-    if a in arch:
-      return True
-  return False
+cdef register_blosc2_():
+  cdef char *version
+  cdef char *date
 
-if blosc_version and blosc_version < ('1', '4') and _arch_without_blosc():
-  # Only use bloc compressor on platforms that actually support it.
-  H5Zunregister(FILTER_BLOSC)
-  blosc_version = None
-else:
-  blosc_init()  # from 1.2 on, Blosc library must be initialized
+  register_blosc2(&version, &date)
+  compinfo = (version, date)
+  free(version)
+  free(date)
+  return compinfo[0].decode('ascii'), compinfo[1].decode('ascii')
+
+blosc2_version = register_blosc2_()
+
+blosc_init()  # from 1.2 on, Blosc library must be initialized
 
 
 # Important: Blosc calls that modifies global variables in Blosc must be
@@ -624,6 +629,10 @@ def which_lib_version(str name):
     if bzip2_version:
       (bzip2_version_string, bzip2_version_date) = bzip2_version
       return (bzip2_version, bzip2_version_string, bzip2_version_date)
+  elif strncmp(cname, "blosc2", 6) == 0:
+    if blosc2_version:
+      (blosc2_version_string, blosc2_version_date) = blosc2_version
+      return (blosc2_version, blosc2_version_string, blosc2_version_date)
   elif strncmp(cname, "blosc", 5) == 0:
     if blosc_version:
       (blosc_version_string, blosc_version_date) = blosc_version
@@ -638,11 +647,9 @@ def which_lib_version(str name):
 
 
 
-# A function returning all the compressors supported by local Blosc
+# A function returning all the compressors supported by Blosc
 def blosc_compressor_list():
   """
-  blosc_compressor_list()
-
   Returns a list of compressors available in the Blosc build.
 
   Parameters
@@ -659,11 +666,28 @@ def blosc_compressor_list():
   return clist
 
 
+# A function returning all the compressors supported by Blosc2
+def blosc2_compressor_list():
+  """
+  Returns a list of compressors available in the Blosc build.
+
+  Parameters
+  ----------
+  None
+
+  Returns
+  -------
+  out : list
+      The list of names.
+  """
+  list_compr = blosc1_list_compressors().decode()
+  clist = [str(cname) for cname in list_compr.split(',')]
+  return clist
+
+
 # Convert compressor code to compressor name
 def blosc_compcode_to_compname_(compcode):
   """
-  blosc_compcode_to_compname()
-
   Returns the compressor name associated with compressor code.
 
   Parameters
@@ -684,9 +708,31 @@ def blosc_compcode_to_compname_(compcode):
   return compname.decode()
 
 
+# Convert compressor code to compressor name
+def blosc2_compcode_to_compname_(compcode):
+  """
+  Returns the compressor name associated with compressor code.
+
+  Parameters
+  ----------
+  None
+
+  Returns
+  -------
+  out : string
+      The name of the compressor.
+  """
+  cdef const char *cname
+  cdef object compname
+
+  compname = b"unknown (report this to developers)"
+  if blosc1_compcode_to_compname(compcode, &cname) >= 0:
+    compname = cname
+  return compname.decode()
+
+
 def blosc_get_complib_info_():
-  """Get info from compression libraries included in the current build
-  of blosc.
+  """Get info from compression libraries included in Blosc.
 
   Returns a mapping containing the compressor names as keys and the
   tuple (complib, version) as values.
@@ -699,6 +745,31 @@ def blosc_get_complib_info_():
   cinfo = {}
   for name in blosc_list_compressors().split(b','):
     ret = blosc_get_complib_info(name, &complib, &version)
+    if ret < 0:
+      continue
+    if isinstance(name, str):
+      cinfo[name] = (complib, version)
+    else:
+      cinfo[name.decode()] = (complib.decode(), version.decode())
+    free(complib)
+    free(version)
+
+  return cinfo
+
+def blosc2_get_complib_info_():
+  """Get info from compression libraries included in Blosc2.
+
+  Returns a mapping containing the compressor names as keys and the
+  tuple (complib, version) as values.
+
+  """
+
+  cdef char *complib
+  cdef char *version
+
+  cinfo = {}
+  for name in blosc1_list_compressors().split(b','):
+    ret = blosc1_get_complib_info(name, &complib, &version)
     if ret < 0:
       continue
     if isinstance(name, str):

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -83,7 +83,7 @@ from .definitions cimport (H5ARRAYget_info, H5ARRAYget_ndims,
   H5Tget_member_offset,
   H5Tget_precision, H5Tget_sign, H5Tget_size, H5Tget_super, H5Tinsert,
   H5Tis_variable_str, H5Tpack, H5Tset_precision, H5Tset_size, H5Tvlen_create,
-  H5Zunregister, FILTER_BLOSC,
+  H5Zunregister, FILTER_BLOSC, FILTER_BLOSC2,
   PyArray_Scalar, create_ieee_complex128, create_ieee_complex64,
   create_ieee_float16, create_ieee_complex192, create_ieee_complex256,
   get_len_of_range, get_order, herr_t, hid_t, hsize_t,
@@ -613,7 +613,7 @@ def which_lib_version(str name):
   # get the C pointer
   cname = encoded_name
 
-  libnames = ('hdf5', 'zlib', 'lzo', 'bzip2', 'blosc')
+  libnames = ('hdf5', 'zlib', 'lzo', 'bzip2', 'blosc', 'blosc2')
 
   if strcmp(cname, "hdf5") == 0:
     binver, strver = getHDF5VersionInfo()


### PR DESCRIPTION
Preliminary version of direct chunking I/O with Blosc2.  Only tables are supported for now, but blosc2 should be usable from all containers too (earray, carray, vlarray), although only from the integrated blosc2 filter. 