### PR TITLE
Build wheels for 3.11

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,6 +75,9 @@ jobs:
            - arch: aarch64
              cibw_python: cp310-*
              os: ubuntu-latest
+           - arch: aarch64
+             cibw_python: cp311-*
+             os: ubuntu-latest
            - arch: arm64
              cibw_python: "cp*"
              os: macos-latest
@@ -174,7 +177,7 @@ jobs:
       - name: Build wheels for Windows (${{ matrix.arch }})
         run: cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp36-${{ matrix.arch }} cp37-${{ matrix.arch }} cp38-${{ matrix.arch }} cp39-${{ matrix.arch }} cp310-${{ matrix.arch }}"
+          CIBW_BUILD: "cp36-${{ matrix.arch }} cp37-${{ matrix.arch }} cp38-${{ matrix.arch }} cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }}"
           CIBW_BEFORE_ALL_WINDOWS: "conda create --yes --name=build && conda activate build && conda config --env --set subdir ${{ matrix.arch == 'win32' && 'win-32' || 'win-64' }} && conda install --yes blosc bzip2 hdf5 lz4 lzo snappy zstd zlib"
           CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
           CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
@@ -193,7 +196,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        python-version: ['3.7', '3.8', '3.9','3.10']
+        python-version: ['3.7', '3.8', '3.9','3.10', '3.11-dev']
         arch: ['x64', 'x86']
         exclude:
         - os: 'ubuntu-latest'


### PR DESCRIPTION
As Python 3.11 is comming out by the end of the month - i think pytables should have wheels ready for this.

This PR will add wheel building for 3.11 for all supported platforms.
Tests for the wheels currently run on 3.11-dev (which is 3.11.0rc2 at this moment) - but it's supposed to be near identical to the final version, so i think it'll suffice to test automatically built wheels for now.

It would obviously be great if we could have a new minor release for this (on pypi and other platforms)- as many other projects a already did (Release which simply adds wheels for 3.11).
