### PR TITLE
Ci/drop 37 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python: ['3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,11 +49,13 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build ${{ matrix.os }} wheels for ${{ matrix.arch }}
+    name: Build ${{ matrix.os }} ${{ matrix.cibw_pythonn }} wheels for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
       HDF5_VERSION: 1.12.1
       MACOSX_DEPLOYMENT_TARGET: "10.9"
+      # Skip 3.6 and 3.7 wheels
+      CIBW_SKIP: "cp36-* cp37-*"
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
@@ -125,7 +127,7 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21"
           CIBW_ENVIRONMENT: DISABLE_AVX2='TRUE' CFLAGS=-g0 HDF5_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CIBW_ENVIRONMENT_MACOS: CC=/usr/bin/clang CXX=/usr/bin/clang HDF5_DIR=/tmp/hdf5 LZO_DIR=/tmp/hdf5 BZIP2_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
-          CIBW_SKIP: "*-musllinux_*"
+          CIBW_SKIP: "*-musllinux_* ${{ env.CIBW_SKIP}}"
           CIBW_BEFORE_ALL_MACOS: cp -r `pwd`/hdf5_build /tmp/hdf5
           CIBW_BEFORE_ALL_LINUX: >
             cp -r `pwd`/hdf5_build /tmp/hdf5 &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -44,7 +44,7 @@ jobs:
       - name: Build sdist
         run: make PYTHON=python dist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*
 
@@ -77,7 +77,7 @@ jobs:
              os: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -135,7 +135,7 @@ jobs:
             DYLD_FALLBACK_LIBRARY_PATH=/tmp/hdf5/lib delocate-listdeps {wheel} &&
             DYLD_FALLBACK_LIBRARY_PATH=/tmp/hdf5/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -148,7 +148,7 @@ jobs:
         arch: [win32, win_amd64]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -178,7 +178,7 @@ jobs:
           CIBW_BEFORE_BUILD: "pip install -r requirements.txt cython>=0.29.21 delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -199,7 +199,7 @@ jobs:
           arch: 'x86'
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ./wheelhouse/
 
@@ -224,7 +224,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ./wheelhouse/
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,10 +23,10 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install APT packages
         if: contains(${{ matrix.os }}, 'ubuntu')
@@ -61,12 +61,6 @@ jobs:
         cibw_python: [ "cp*" ]
         include:
            - arch: aarch64
-             cibw_python: cp36-*
-             os: ubuntu-latest
-           - arch: aarch64
-             cibw_python: cp37-*
-             os: ubuntu-latest
-           - arch: aarch64
              cibw_python: cp38-*
              os: ubuntu-latest
            - arch: aarch64
@@ -88,7 +82,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -159,7 +153,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -177,7 +171,7 @@ jobs:
       - name: Build wheels for Windows (${{ matrix.arch }})
         run: cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp36-${{ matrix.arch }} cp37-${{ matrix.arch }} cp38-${{ matrix.arch }} cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }}"
+          CIBW_BUILD: "cp38-${{ matrix.arch }} cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }}"
           CIBW_BEFORE_ALL_WINDOWS: "conda create --yes --name=build && conda activate build && conda config --env --set subdir ${{ matrix.arch == 'win32' && 'win-32' || 'win-64' }} && conda install --yes blosc bzip2 hdf5 lz4 lzo snappy zstd zlib"
           CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
           CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
@@ -196,7 +190,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        python-version: ['3.7', '3.8', '3.9','3.10', '3.11-dev']
+        python-version: ['3.8', '3.9','3.10', '3.11-dev']
         arch: ['x64', 'x86']
         exclude:
         - os: 'ubuntu-latest'
@@ -210,7 +204,7 @@ jobs:
           path: ./wheelhouse/
 
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
@@ -235,7 +229,7 @@ jobs:
           path: ./wheelhouse/
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,7 +49,7 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build ${{ matrix.os }} ${{ matrix.cibw_pythonn }} wheels for ${{ matrix.arch }}
+    name: Build ${{ matrix.os }} ${{ matrix.cibw_python }} wheels for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
       HDF5_VERSION: 1.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,11 +29,10 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Database
     Topic :: Software Development :: Libraries :: Python Modules
 platforms = any
@@ -44,7 +43,7 @@ project_urls =
     Tracker = https://github.com/PyTables/PyTables/issues
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 zip_safe = False
 # install_requires =
 #     numpy>=1.19.0


### PR DESCRIPTION
Drop python 37 wheels 
as mentioned in https://github.com/PyTables/PyTables/pull/962#issuecomment-1269962300 - there's only really a point in having wheels for 3.8, 3.9, 3.10 and 3.11 (supported versions of python).

Based on this, this PR will aim to
* Remove CI for 3.6 and 3.7
* Remove wheel building for 3.6 and 3.7
* Update the pypi classifier to match the supported versions
* Update CI actions to avoid action deprecation warnings


About this last point, only [conda-incubator/setup-miniconda ](https://github.com/conda-incubator/setup-miniconda/issues/248) is still left - due to the issue linked above (they didn't release an updated new version so far).

The resulting artifact.zip file will contain the following files (notice that 3.6 and 3.7 are now gone).

![screenshot](https://user-images.githubusercontent.com/5024695/197694625-36c38d1a-c91c-4f28-b538-79ed28cb9c2b.png)

