### PR TITLE
Bump HDF5 to v1.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -44,4 +44,3 @@ jobs:
         ptrepack -h
         ptdump -h
         pttree -h
-

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: 3.x
 
       - name: Install APT packages
         if: contains(${{ matrix.os }}, 'ubuntu')
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: 3.x
 
       - uses: docker/setup-qemu-action@v1
         if: runner.os == 'Linux'
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: 3.x
 
       - name: Install Miniconda
         uses: conda-incubator/setup-miniconda@v2
@@ -192,7 +192,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        python-version: ['3.8', '3.9','3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         arch: ['x64', 'x86']
         exclude:
         - os: 'ubuntu-latest'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build ${{ matrix.os }} ${{ matrix.cibw_python }} wheels for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.1
+      HDF5_VERSION: 1.12.2
       MACOSX_DEPLOYMENT_TARGET: "10.9"
       # Skip 3.6 and 3.7 wheels
       CIBW_SKIP: "cp36-* cp37-*"

--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -16,7 +16,6 @@ export PKG_CONFIG_PATH="$HDF5_DIR/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
 
 LZO_VERSION="2.10"
-SNAPPY_VERSION="1.1.9"
 ZSTD_VERSION="1.5.2"
 LZ4_VERSION="1.9.3"
 BZIP_VERSION="1.0.8"
@@ -95,18 +94,6 @@ EOF
     make install
     popd
 
-    popd
-
-    # snappy
-    git clone https://github.com/google/snappy.git --branch $SNAPPY_VERSION --depth 1
-    pushd snappy
-    git submodule update --init
-    mkdir build
-    cd build
-    CC= CXX= CPPFLAGS= CXXFLAGS= CFLAGS="$CFLAGS_ORIG" cmake -DCMAKE_INSTALL_PREFIX="$HDF5_DIR" -DRUN_HAVE_STD_REGEX=0 \
-        -DRUN_HAVE_POSIX_REGEX=0 -DENABLE_SHARED:bool=on -DCMAKE_OSX_ARCHITECTURES="$CMAKE_ARCHES" ../
-    CC= CXX= CPPFLAGS= CXXFLAGS= CFLAGS="$CFLAGS_ORIG" make
-    make install
     popd
 else
     yum -y update

--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -131,32 +131,9 @@ if [[ "$OSTYPE" == "darwin"* && "$CIBW_ARCHS" = "arm64"  ]]; then
     export hdf5_cv_disable_some_ldouble_conv=no
     export hdf5_cv_system_scope_threads=yes
     export hdf5_cv_printf_ll="l"
-    export PAC_FC_MAX_REAL_PRECISION=15
-    export PAC_C_MAX_REAL_PRECISION=17
-    export PAC_FC_ALL_INTEGER_KINDS="{1,2,4,8,16}"
-    export PAC_FC_ALL_REAL_KINDS="{4,8}"
-    export H5CONFIG_F_NUM_RKIND="INTEGER, PARAMETER :: num_rkinds = 2"
-    export H5CONFIG_F_NUM_IKIND="INTEGER, PARAMETER :: num_ikinds = 5"
-    export H5CONFIG_F_RKIND="INTEGER, DIMENSION(1:num_rkinds) :: rkind = (/4,8/)"
-    export H5CONFIG_F_IKIND="INTEGER, DIMENSION(1:num_ikinds) :: ikind = (/1,2,4,8,16/)"
-    export PAC_FORTRAN_NATIVE_INTEGER_SIZEOF="                    4"
-    export PAC_FORTRAN_NATIVE_INTEGER_KIND="           4"
-    export PAC_FORTRAN_NATIVE_REAL_SIZEOF="                    4"
-    export PAC_FORTRAN_NATIVE_REAL_KIND="           4"
-    export PAC_FORTRAN_NATIVE_DOUBLE_SIZEOF="                    8"
-    export PAC_FORTRAN_NATIVE_DOUBLE_KIND="           8"
-    export PAC_FORTRAN_NUM_INTEGER_KINDS="5"
-    export PAC_FC_ALL_REAL_KINDS_SIZEOF="{4,8}"
-    export PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{1,2,4,8,16}"
 
-    curl -sLO https://github.com/conda-forge/hdf5-feedstock/raw/2cb83b63965985fa8795b0a13150bf0fd2525ebd/recipe/patches/osx_cross_configure.patch
-    curl -sLO https://github.com/conda-forge/hdf5-feedstock/raw/2cb83b63965985fa8795b0a13150bf0fd2525ebd/recipe/patches/osx_cross_fortran_src_makefile.patch
-    curl -sLO https://github.com/conda-forge/hdf5-feedstock/raw/2cb83b63965985fa8795b0a13150bf0fd2525ebd/recipe/patches/osx_cross_hl_fortran_src_makefile.patch
-    curl -sLO https://github.com/conda-forge/hdf5-feedstock/raw/2cb83b63965985fa8795b0a13150bf0fd2525ebd/recipe/patches/osx_cross_src_makefile.patch
-    patch -p0 < osx_cross_configure.patch
-    patch -p0 < osx_cross_fortran_src_makefile.patch
-    patch -p0 < osx_cross_hl_fortran_src_makefile.patch
-    patch -p0 < osx_cross_src_makefile.patch
+    patch -p0 < ../osx_cross_configure.patch
+    patch -p0 < ../osx_cross_src_makefile.patch
 
     ./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" "$EXTRA_MPI_FLAGS" --enable-build-mode=production \
         --host=aarch64-apple-darwin --enable-tests=no

--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -3,6 +3,7 @@
 
 set -e -x
 
+PROJECT_DIR="$(pwd)"
 EXTRA_MPI_FLAGS=''
 if [ -z ${HDF5_MPI+x} ]; then
     echo "Building serial"
@@ -119,8 +120,8 @@ if [[ "$OSTYPE" == "darwin"* && "$CIBW_ARCHS" = "arm64"  ]]; then
     export hdf5_cv_system_scope_threads=yes
     export hdf5_cv_printf_ll="l"
 
-    patch -p0 < ../osx_cross_configure.patch
-    patch -p0 < ../osx_cross_src_makefile.patch
+    patch -p0 < "$PROJECT_DIR/ci/osx_cross_configure.patch"
+    patch -p0 < "$PROJECT_DIR/ci/osx_cross_src_makefile.patch"
 
     ./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" "$EXTRA_MPI_FLAGS" --enable-build-mode=production \
         --host=aarch64-apple-darwin --enable-tests=no

--- a/ci/osx_cross_configure.patch
+++ b/ci/osx_cross_configure.patch
@@ -1,0 +1,209 @@
+--- configure.orig	2022-04-19 12:44:19.000000000 -0400
++++ configure	2022-05-18 14:54:28.621115700 -0400
+@@ -670,6 +670,7 @@
+ DEPRECATED_SYMBOLS
+ BUILD_ALL_CONDITIONAL_FALSE
+ BUILD_ALL_CONDITIONAL_TRUE
++cross_compiling
+ ROOT
+ JAVA_VERSION
+ CXX_VERSION
+@@ -6686,12 +6687,7 @@
+ }
+ 
+ _ACEOF
+-        if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
++if test "$cross_compiling" = no; then :
+   if ac_fn_c_try_run "$LINENO"; then :
+ 
+             LDBL_DIG=$(./conftest$EXEEXT 2>&1 | sed -n '1p')
+@@ -6710,13 +6706,15 @@
+ 
+ 
+ 
+-if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
++if [ -z "$PAC_C_MAX_REAL_PRECISION" ]; then
++  if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
+ 
+ $as_echo "#define HAVE_FLOAT128 1" >>confdefs.h
+ 
+-  PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
+-else
+-  PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
++    PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
++  else
++    PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
++  fi
+ fi
+ 
+ cat >>confdefs.h <<_ACEOF
+@@ -8177,10 +8175,32 @@
+ 
+ TEST_SRC="`sed -n '/PROGRAM FC_AVAIL_KINDS/,/END PROGRAM FC_AVAIL_KINDS/p' $srcdir/m4/aclocal_fc.f90`"
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++
++cat >>confdefs.h <<_ACEOF
++#define PAC_FC_MAX_REAL_PRECISION $PAC_FC_MAX_REAL_PRECISION
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_NUM_RKIND $H5CONFIG_F_NUM_RKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_NUM_IKIND $H5CONFIG_F_NUM_IKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_RKIND $H5CONFIG_F_RKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_IKIND $H5CONFIG_F_IKIND
++_ACEOF
++
++
+ else
+   cat > conftest.$ac_ext <<_ACEOF
+ $TEST_SRC
+@@ -8332,92 +8352,6 @@
+ ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+ 
+-TEST_SRC="`sed -n '/PROGRAM FC_AVAIL_KINDS/,/END PROGRAM FC_AVAIL_KINDS/p' $srcdir/m4/aclocal_fc.f90`"
+-if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  cat > conftest.$ac_ext <<_ACEOF
+-$TEST_SRC
+-_ACEOF
+-if ac_fn_fc_try_run "$LINENO"; then :
+-
+-
+-        pac_validIntKinds=$(./conftest$EXEEXT 2>&1 | sed -n '1p')
+-        pac_validRealKinds=$(./conftest$EXEEXT 2>&1 | sed -n '2p')
+-        PAC_FC_MAX_REAL_PRECISION=$(./conftest$EXEEXT 2>&1 | sed -n '3p')
+-
+-cat >>confdefs.h <<_ACEOF
+-#define PAC_FC_MAX_REAL_PRECISION $PAC_FC_MAX_REAL_PRECISION
+-_ACEOF
+-
+-
+-        PAC_FC_ALL_INTEGER_KINDS="{`echo $pac_validIntKinds`}"
+-        PAC_FC_ALL_REAL_KINDS="{`echo $pac_validRealKinds`}"
+-
+-        PAC_FORTRAN_NUM_INTEGER_KINDS=$(./conftest$EXEEXT 2>&1 | sed -n '4p')
+-        H5CONFIG_F_NUM_IKIND="INTEGER, PARAMETER :: num_ikinds = `echo $PAC_FORTRAN_NUM_INTEGER_KINDS`"
+-        H5CONFIG_F_IKIND="INTEGER, DIMENSION(1:num_ikinds) :: ikind = (/`echo $pac_validIntKinds`/)"
+-        H5CONFIG_F_NUM_RKIND="INTEGER, PARAMETER :: num_rkinds = $(./conftest$EXEEXT 2>&1 | sed -n '5p')"
+-        H5CONFIG_F_RKIND="INTEGER, DIMENSION(1:num_rkinds) :: rkind = (/`echo $pac_validRealKinds`/)"
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_NUM_RKIND $H5CONFIG_F_NUM_RKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_NUM_IKIND $H5CONFIG_F_NUM_IKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_RKIND $H5CONFIG_F_RKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_IKIND $H5CONFIG_F_IKIND
+-_ACEOF
+-
+-
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Number of Fortran INTEGER KINDs" >&5
+-$as_echo_n "checking for Number of Fortran INTEGER KINDs... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FORTRAN_NUM_INTEGER_KINDS" >&5
+-$as_echo "$PAC_FORTRAN_NUM_INTEGER_KINDS" >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran INTEGER KINDs" >&5
+-$as_echo_n "checking for Fortran INTEGER KINDs... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_INTEGER_KINDS" >&5
+-$as_echo "$PAC_FC_ALL_INTEGER_KINDS" >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran REAL KINDs" >&5
+-$as_echo_n "checking for Fortran REAL KINDs... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_REAL_KINDS" >&5
+-$as_echo "$PAC_FC_ALL_REAL_KINDS" >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran REALs maximum decimal precision" >&5
+-$as_echo_n "checking for Fortran REALs maximum decimal precision... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_MAX_REAL_PRECISION" >&5
+-$as_echo "$PAC_FC_MAX_REAL_PRECISION" >&6; }
+-
+-else
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Error" >&5
+-$as_echo "Error" >&6; }
+-    as_fn_error $? "Failed to run Fortran program to determine available KINDs" "$LINENO" 5
+-
+-fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+-
+-
+-ac_ext=${ac_fc_srcext-f}
+-ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+-ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+-
+ 
+   ## Find all sizeofs for available KINDs
+ 
+@@ -8465,7 +8399,9 @@
+ fi
+ 
+ done
+-PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{`echo $pack_int_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++if [ -z "$PAC_FC_ALL_INTEGER_KINDS_SIZEOF" ]; then
++  PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{`echo $pack_int_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_INTEGER_KINDS_SIZEOF" >&5
+ $as_echo "$PAC_FC_ALL_INTEGER_KINDS_SIZEOF" >&6; }
+ ac_ext=${ac_fc_srcext-f}
+@@ -8519,7 +8455,9 @@
+ fi
+ 
+ done
+-PAC_FC_ALL_REAL_KINDS_SIZEOF="{`echo $pack_real_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++if [ -z "$PAC_FC_ALL_REAL_KINDS_SIZEOF" ]; then
++  PAC_FC_ALL_REAL_KINDS_SIZEOF="{`echo $pack_real_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_REAL_KINDS_SIZEOF" >&5
+ $as_echo "$PAC_FC_ALL_REAL_KINDS_SIZEOF" >&6; }
+ ac_ext=${ac_fc_srcext-f}
+@@ -33937,8 +33875,10 @@
+ 
+ if test "$cross_compiling" = yes; then :
+ 
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown, assuming yes" >&5
+-$as_echo "unknown, assuming yes" >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown, assuming no" >&5
++$as_echo "unknown, assuming no" >&6; }
++
++$as_echo "#define NO_ALIGNMENT_RESTRICTIONS 1" >>confdefs.h
+ 
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/ci/osx_cross_src_makefile.patch
+++ b/ci/osx_cross_src_makefile.patch
@@ -1,0 +1,34 @@
+--- src/Makefile.in.orig	2020-12-29 22:15:29.000000000 -0800
++++ src/Makefile.in	2020-12-29 22:16:23.000000000 -0800
+@@ -108,6 +108,13 @@
+ host_triplet = @host@
+ noinst_PROGRAMS = H5detect$(EXEEXT) H5make_libsettings$(EXEEXT)
+ 
++cross_compiling = @cross_compiling@
++ifeq ($(cross_compiling),yes)
++  src_run = 
++else
++  src_run = ./
++endif
++
+ # Only compile parallel sources if necessary
+ @BUILD_PARALLEL_CONDITIONAL_TRUE@am__append_1 = H5mpi.c H5ACmpio.c H5Cmpio.c H5Dmpio.c H5Fmpi.c H5FDmpi.c H5FDmpio.c H5Smpio.c
+ 
+@@ -1937,7 +1944,7 @@
+ H5Tinit.c: H5detect$(EXEEXT)
+ 	LD_LIBRARY_PATH="$$LD_LIBRARY_PATH`echo $(LDFLAGS) |                  \
+ 		sed -e 's/-L/:/g' -e 's/ //g'`"                               \
+-	$(RUNSERIAL) ./H5detect$(EXEEXT)  $@  ||                               \
++	$(RUNSERIAL) $(src_run)H5detect$(EXEEXT)  $@  ||                               \
+ 	    (test $$HDF5_Make_Ignore && echo "*** Error ignored") ||          \
+ 	    ($(RM) $@ ; exit 1)
+ 
+@@ -1949,7 +1956,7 @@
+ H5lib_settings.c: H5make_libsettings$(EXEEXT) libhdf5.settings
+ 	LD_LIBRARY_PATH="$$LD_LIBRARY_PATH`echo $(LDFLAGS) |                  \
+ 		sed -e 's/-L/:/g' -e 's/ //g'`"                               \
+-	$(RUNSERIAL) ./H5make_libsettings$(EXEEXT)  $@  ||                               \
++	$(RUNSERIAL) $(src_run)H5make_libsettings$(EXEEXT)  $@  ||                               \
+ 	    (test $$HDF5_Make_Ignore && echo "*** Error ignored") ||          \
+ 	    ($(RM) $@ ; exit 1)
+ 


### PR DESCRIPTION
- Bumps HDF5 to v1.12.2 and includes the required patch files in the repo instead of downloading it.
- It also removes some unneeded patches and env variables.
- Also spruced up the python versions used in the CI when testing or the baseline python.