### PR TITLE
Fix for HDF5 version problems (Invalid version) (#940)

### DIFF
--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -8,7 +8,7 @@ import platform
 import tempfile
 from pathlib import Path
 from time import perf_counter as clock
-from packaging.version import Version
+from packaging import version
 
 import unittest
 
@@ -18,8 +18,8 @@ import numpy as np
 import tables as tb
 from tables.req_versions import min_blosc_bitshuffle_version
 
-hdf5_version = Version(tb.hdf5_version)
-blosc_version = Version(tb.which_lib_version("blosc")[1])
+hdf5_version = version.parse(tb.hdf5_version)
+blosc_version = version.parse(tb.which_lib_version("blosc")[1])
 
 
 verbose = os.environ.get("VERBOSE", "FALSE") == "TRUE"

--- a/tables/tests/common.py
+++ b/tables/tests/common.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from time import perf_counter as clock
 from packaging import version
+from packaging.version import Version
 
 import unittest
 


### PR DESCRIPTION
PR for #940 as suggested here: https://github.com/PyTables/PyTables/issues/940#issuecomment-1062793552

Decided to use [packaging.version.parse()](https://packaging.pypa.io/en/stable/version.html#packaging.version.parse) since it does what was suggested in the comment.

I had the same exception seen in #940, and this change fixed it for me.