### PR TITLE
support NUMEXPR_MAX_THREADS environment variable

### DIFF
--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -205,7 +205,7 @@ system attributes are not considered for guessing the class of the node
 during its loading from disk (this work is delegated to the PyTables'
 class discoverer function for general HDF5 files)."""
 
-MAX_NUMEXPR_THREADS = _os.environ.get("NUMEXPR_MAX_THREADS", 4)
+MAX_NUMEXPR_THREADS = int(_os.environ.get("NUMEXPR_MAX_THREADS", 4))
 """The maximum number of threads that PyTables should use internally in
 Numexpr.  If `None`, it is automatically set to the number of cores in
 your machine. In general, it is a good idea to set this to the number of


### PR DESCRIPTION
With mkl installed, setting this environment variable will trigger a "TypeError: an integer is required (got type str)" from numexpr's `set_vml_num_threads` call that comes from the last line of `File.__init__,` since environment variables are strings. 

Here's the code relevant code flow without this patch supposing I set `NUMEXPR_MAX_THREADS=8` before running python:

On import of parameters module, the variable gets set to a string.
https://github.com/PyTables/PyTables/blob/b9c9ac1a06341e0e80753b2ac72d50fd3d38da88/tables/parameters.py#L208

So `parameters.MAX_NUMEXPR_THREADS = '8'` and then in File's `__init__` it gets copied over
https://github.com/PyTables/PyTables/blob/b9c9ac1a06341e0e80753b2ac72d50fd3d38da88/tables/file.py#L727-L729

before finally being passed along to numexpr (which will not be happy to take a string as it expects an integer).
https://github.com/PyTables/PyTables/blob/b9c9ac1a06341e0e80753b2ac72d50fd3d38da88/tables/file.py#L801