### PR TITLE
Run osx arm64 and x86 builds in different containers to prevent binary clash

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,13 +58,14 @@ jobs:
       CIBW_SKIP: "cp36-* cp37-*"
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
+        os: [ 'ubuntu-latest' ]
         arch: [ 'x86_64',  'aarch64' ]
         cibw_python: [ "cp*" ]
-        exclude:
-          # This will be handled via CIBW_ARCHS_MACOS env var
+        include:
           - os: macos-latest
-            arch: aarch64
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v3
@@ -117,7 +118,6 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: CC=/usr/bin/clang CXX=/usr/bin/clang HDF5_DIR=/tmp/hdf5 LZO_DIR=/tmp/hdf5 BZIP2_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CIBW_SKIP: "*-musllinux_* ${{ env.CIBW_SKIP}}"
           CIBW_BEFORE_ALL_MACOS: cp -r `pwd`/hdf5_build /tmp/hdf5
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BEFORE_ALL_LINUX: >
             cp -r `pwd`/hdf5_build /tmp/hdf5 &&
             yum -y update &&


### PR DESCRIPTION
See https://github.com/PyTables/PyTables/pull/979.