### PR TITLE
Use the blosc2 python package for the blosc2 binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: pip sdist
 
 on: [push, pull_request]
 
@@ -30,10 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         conda install setuptools pip wheel build packaging numpy cython bzip2 hdf5 lzo 'typing_extensions<4.2'
-        # We can use either the c-blosc2 package in conda/conda-forge or the official wheel (blosc2 in PyPI).
+        # We can use either the c-blosc2 package in conda/conda-forge or the official wheel (blosc2 in PyPI) from requirements.
         # conda install c-blosc2
-        pip install -r requirements.txt
-        # conda install sphinx sphinx_rtd_theme numpydoc ipython
     - name: Source distribution
       run: |
         python -m build --sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: pip sdist
+name: sdist
 
 on: [push, pull_request]
 
@@ -29,15 +29,49 @@ jobs:
         channel-priority: strict
     - name: Install dependencies
       run: |
+        # get blosc2 through python
         conda install setuptools pip wheel build packaging numpy cython bzip2 hdf5 lzo 'typing_extensions<4.2'
-        # We can use either the c-blosc2 package in conda/conda-forge or the official wheel (blosc2 in PyPI) from requirements.
-        # conda install c-blosc2
     - name: Source distribution
       run: |
         python -m build --sdist
     - name: Installation
       run: |
         pip install -v dist/*.tar.gz
+    - name: 'Run test'
+      run: |
+        cd .. && python -m tables.tests.test_all -v
+        pt2to3 -h
+        ptrepack -h
+        ptdump -h
+        pttree -h
+
+  build_cblosc:
+    name: Sdist with cblosc2
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Set up Python
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+    - name: Install dependencies
+      run: |
+        conda install setuptools pip wheel build packaging py-cpuinfo numpy cython numexpr bzip2 hdf5 lzo 'typing_extensions<4.2' c-blosc2
+    - name: Source distribution
+      run: |
+        python -m build --sdist
+    - name: Installation
+      run: |
+        pip install -v dist/*.tar.gz --no-deps
     - name: 'Run test'
       run: |
         cd .. && python -m tables.tests.test_all -v

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: ubuntu
+name: makefile
 
 on: [push, pull_request]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,18 +46,18 @@ jobs:
           path: dist/*
 
   build_wheels:
-    name: Build ${{ matrix.os }} ${{ matrix.cibw_python }} wheels for ${{ matrix.arch }}
+    name: Build ${{ matrix.os }} wheels for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
       HDF5_VERSION: 1.12.2
       MACOSX_DEPLOYMENT_TARGET: "10.9"
       # Skip 3.6 and 3.7 wheels
-      CIBW_SKIP: "cp36-* cp37-*"
+      CIBW_SKIP: "*-musllinux_* cp36-* cp37-*"
+      CIBW_BUILD: "cp*"
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
         arch: [ 'x86_64',  'aarch64' ]
-        cibw_python: [ "cp*" ]
         include:
           - os: macos-latest
             arch: x86_64
@@ -109,10 +109,8 @@ jobs:
           CFLAGS: -g0
           CIBW_BUILD_VERBOSITY_MACOS: 3
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ENVIRONMENT: DISABLE_AVX2='TRUE' CFLAGS=-g0 HDF5_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CIBW_ENVIRONMENT_MACOS: CC=/usr/bin/clang CXX=/usr/bin/clang HDF5_DIR=/tmp/hdf5 LZO_DIR=/tmp/hdf5 BZIP2_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
-          CIBW_SKIP: "*-musllinux_* ${{ env.CIBW_SKIP}}"
           CIBW_BEFORE_ALL_MACOS: cp -r `pwd`/hdf5_build /tmp/hdf5
           CIBW_BEFORE_ALL_LINUX: >
             cp -r `pwd`/hdf5_build /tmp/hdf5 &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Wheels
+name: wheels
 
 # Publish when a (published) GitHub Release is created.
 on:
@@ -37,12 +37,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade setuptools pip wheel build
-          python -m pip install -r requirements.txt
-          python -m pip install cython
-          python -m pip install sphinx>=1.1 sphinx_rtd_theme numpydoc ipython
 
       - name: Build sdist
-        run: make PYTHON=python dist
+        run: python -m build --sdist
 
       - uses: actions/upload-artifact@v3
         with:
@@ -113,7 +110,6 @@ jobs:
           CIBW_BUILD_VERBOSITY_MACOS: 3
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_BEFORE_BUILD: "pip install -r requirements.txt"
           CIBW_ENVIRONMENT: DISABLE_AVX2='TRUE' CFLAGS=-g0 HDF5_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CIBW_ENVIRONMENT_MACOS: CC=/usr/bin/clang CXX=/usr/bin/clang HDF5_DIR=/tmp/hdf5 LZO_DIR=/tmp/hdf5 BZIP2_DIR=/tmp/hdf5 LD_LIBRARY_PATH="/tmp/hdf5/lib:${LD_LIBRARY_PATH}" PKG_CONFIG_PATH="/tmp/hdf5/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CIBW_SKIP: "*-musllinux_* ${{ env.CIBW_SKIP}}"
@@ -166,7 +162,7 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: "conda create --yes --name=build && conda activate build && conda config --env --set subdir ${{ matrix.arch == 'win32' && 'win-32' || 'win-64' }} && conda install --yes blosc bzip2 hdf5 lz4 lzo snappy zstd zlib"
           CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
           CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
-          CIBW_BEFORE_BUILD: "pip install -r requirements.txt delvewheel"
+          CIBW_BEFORE_BUILD: "pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v3
@@ -201,9 +197,11 @@ jobs:
           architecture: ${{ matrix.arch }}
 
       - name: Install tables on ${{ matrix.python-version }}
+        shell: bash
         run: |
-          pip install cython>=0.29.21 numpy>=1.19.0 numexpr>=2.6.2 packaging py-cpuinfo>=9.0.0 blosc2
-          pip install --no-index --find-links wheelhouse/artifact/ tables
+          pip install tables --dry-run --no-deps --no-index --report install_rep.json --quiet --find-links wheelhouse/artifact/
+          whl=$(python -c 'import json;print(json.load(open("install_rep.json"))["install"][0]["download_info"]["url"])')
+          pip install $whl
 
       - name: Run tests on ${{ matrix.python-version }}
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,9 +118,10 @@ jobs:
             cp -r `pwd`/hdf5_build /tmp/hdf5 &&
             yum -y update &&
             yum install -y zlib-devel bzip2-devel lzo-devel
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libblosc2.so --exclude libblosc2.so.2 -w {dest_dir} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_FALLBACK_LIBRARY_PATH=/tmp/hdf5/lib delocate-listdeps {wheel} &&
-            DYLD_FALLBACK_LIBRARY_PATH=/tmp/hdf5/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+            DYLD_FALLBACK_LIBRARY_PATH=/tmp/hdf5/lib delocate-wheel --ignore-missing-dependencies --require-archs {delocate_archs} -w {dest_dir} {wheel}
 
       - uses: actions/upload-artifact@v3
         with:
@@ -163,7 +164,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: 'CONDA_PREFIX="C:\\Miniconda\\envs\\build" PATH="$PATH;C:\\Miniconda\\envs\\build\\Library\\bin"'
           CIBW_ENVIRONMENT: "PYTABLES_NO_EMBEDDED_LIBS=true DISABLE_AVX2=true"
           CIBW_BEFORE_BUILD: "pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --no-dll libblosc2.dll -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ requires = [
     "packaging",
     "py-cpuinfo",
     "Cython >=0.29.21",
-    "blosc2 >=0.6.6"
+    "blosc2 ~=0.6.6"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy>=1.19.0
 numexpr>=2.6.2
 # blosc2 wheel is actually only needed when compiling on conda envs.
 # Otherwise, lib comes bundled in PyTables wheels (but it doesn't hurt either).
-blosc2>=0.6.6
+blosc2~=0.6.6
 packaging
 py-cpuinfo

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,12 @@ project_urls =
 [options]
 python_requires = >=3.8
 zip_safe = False
-# install_requires =
-#     numpy>=1.19.0
-#     numexpr>=2.6.2
-#     packaging
+install_requires =
+    numpy>=1.19.0
+    numexpr>=2.6.2
+    blosc2~=0.6.6
+    packaging
+    py-cpuinfo
 packages = find:
 include_package_data = True
 

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -15,7 +15,7 @@ try:
     import blosc2
     for f in import_metadata_files('blosc2'):
         if f.name in {"libblosc2.dll", "libblosc2.so", "libblosc2.dylib"}:
-            cdll.LoadLibrary(str(f.locate().resolve().parent))
+            cdll.LoadLibrary(str(f.locate().resolve()))
             break
     else:
         raise FileNotFoundError('Unable to locate the blosc2 binary')


### PR DESCRIPTION
The goal here is for pytables to not package at all the blosc2.dll/so/dylib in our wheel, because we end up repackaging the wrong arch. Instead, we will rely on blosc2's wheel to provide the binary and we made blosc2 a hard dependency. Then, at runtime, using the package metadata we find the blosc2.dll/so/dylib and load it as before. 

Changes:

* It uses `importlib.metadata` to locate the `blosc2` binaries and header files in setup.py so we don't have to manually search for them in the RECORD.
* Similarly it uses it to locate the binary when tables is imported and loads it into memory. This way, we don't package it all and instead rely on `blosc2` providing the binary.
* Changed the version specifier from `blosc2>=0.6.6` to `blosc2~=0.6.6`. This ensures that users install the same major/minor version of `blosc2` that tables was built against to prevent forward incompatibility.
* Instead of manually listing all the deps in the CI for each install, or using requirements.txt, I've added the deps as `required_deps`. This will ensure users get the required blosc2 and other libraries when installing normally with pip.

  This would potentially only be an issue on conda, where we want to get the deps from conda, not pip. But already, we manually install deps in conda before installing tables, so this should not be an issue.

  In fact, we can remove the explicit deps list in the dev guide and instead tell people, get the deps listed in pyproject.toml/setup.cfg so that we don't have to list them there as well.

  The only reason for having a requirement.txt at all in the current scheme is when installing using the makefile, which doesn't use pip.
* To prevent the wheel repair from choking on the blosc2 dlls and to make sure they are not included in our wheel (so that we don't get the wrong arch in our wheel), I explicitly excluded them. For windows and linux there's option in the auditwheel/delvewheel for this. There isn't currently an option for mac so I had to rely on `--ignore-missing-dependencies` for now. Eventually we should use https://github.com/matthew-brett/delocate/pull/106 instead once merged.


Here's the wheels being generatedl: https://github.com/matham/PyTables/actions/runs/3744274349.