### PR TITLE
fixes #938 (ptrepack fails with ExternalLinks)

### DIFF
--- a/tables/linkextension.pyx
+++ b/tables/linkextension.pyx
@@ -265,6 +265,10 @@ cdef class ExternalLink(Link):
     free(clinkval)
     return 0  # Object ID is zero'ed, as HDF5 does not assign one for links
 
+  def _get_obj_info(self):
+    # ExternalLink do not have ObjectId. Hardcode addr and rc to 0, 1
+    return 0, 1
+
 
 ## Local Variables:
 ## mode: python

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -574,6 +574,18 @@ class ExternalLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
             if Path(h5fname2).is_file():
                 Path(h5fname2).unlink()
 
+    def test11_copy_entire_file_with_hardlink_option(self):
+        """Checking copying the entire file (that contains external links)
+        in a similar way ptrepack does (with hardlink kwargs activated) """
+
+        h5fname2 = tempfile.mktemp(".h5")
+        try:
+            with tb.open_file(h5fname2, "a") as h5file2:
+                self.h5file.root._f_copy_children(h5file2.root, recursive=True, use_hardlinks=True)
+                self.assertIn('/lgroup1', h5file2)
+        finally:
+            if Path(h5fname2).is_file():
+                Path(h5fname2).unlink()
 
 def suite():
     """Return a test suite consisting of all the test cases in the module."""

--- a/tables/tests/test_links.py
+++ b/tables/tests/test_links.py
@@ -587,6 +587,7 @@ class ExternalLinkTestCase(common.TempFileMixin, common.PyTablesTestCase):
             if Path(h5fname2).is_file():
                 Path(h5fname2).unlink()
 
+
 def suite():
     """Return a test suite consisting of all the test cases in the module."""
 


### PR DESCRIPTION
Hi,

this PR fixes the mentioned issue. ptrepack copies nodes recursively with the `use_hardlink` flag activated. This flag calls the _get_obj_info() method to check the address and reference count (rc). As ExternalLinks do no get an objectid assigned by HDF5, this call fails. 

my fix overwrites the _get_obj_info() method for ExternalLinks and returns a fix tuple (0, 1).

Note that for SoftLinks this fix is not needed as the _get_obj_info() method gets evaluated on the target node as the __getattribute__ method dereferences all method calls. 