### PR TITLE
Optimization for iter chunk

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build ${{ matrix.os }} wheels for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:
-      HDF5_VERSION: 1.12.2
+      HDF5_VERSION: 1.14.0  # needed for H5Dchunk_iter
       MACOSX_DEPLOYMENT_TARGET: "10.9"
       # Skip 3.6 and 3.7 wheels
       CIBW_SKIP: "*-musllinux_* cp36-* cp37-*"

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -154,7 +154,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
   void* outbuf = NULL;
   int64_t status = 0;                /* Return code from Blosc2 routines */
-  size_t blocksize;
+  // size_t blocksize;
   size_t typesize;
   size_t outbuf_size;
   int clevel = 5;                /* Compression level default */
@@ -162,7 +162,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
   int compcode = BLOSC_BLOSCLZ;  /* Codec by default */
 
   /* Filter params that are always set */
-  blocksize = cd_values[1];      /* The block size */
+  // blocksize = cd_values[1];      /* The block size */
   typesize = cd_values[2];      /* The datatype size */
   outbuf_size = cd_values[3];   /* Precomputed buffer guess */
 

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -51,7 +51,7 @@ int register_blosc2(char **version, char **date){
     };
 
     retval = H5Zregister(&filter_class);
-    if(retval<0){
+    if (retval < 0){
         PUSH_ERR("register_blosc2", H5E_CANTREGISTER, "Can't register Blosc2 filter");
     }
     if (version != NULL && date != NULL) {
@@ -116,16 +116,6 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
     basetypesize = typesize;
   }
 
-  /* Limit large typesizes (they are pretty expensive to shuffle
-     and, in addition, Blosc2 does not handle typesizes larger than
-     255 bytes). */
-  /* But for reads, it is useful to have the original typesize here.
-   * And there is no harm in storing the original typesize here, as Blosc2
-   * will decide internally to reduce it to 1 if > BLOSC_MAX_TYPESIZE.
-   */
-  /* if (basetypesize > BLOSC_MAX_TYPESIZE)
-   *  basetypesize = 1;
-   */
   values[2] = basetypesize;
 
   /* Get the size of the chunk */
@@ -154,7 +144,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
   void* outbuf = NULL;
   int64_t status = 0;                /* Return code from Blosc2 routines */
-  // size_t blocksize;
+  size_t blocksize;
   size_t typesize;
   size_t outbuf_size;
   int clevel = 5;                /* Compression level default */
@@ -162,7 +152,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
   int compcode = BLOSC_BLOSCLZ;  /* Codec by default */
 
   /* Filter params that are always set */
-  // blocksize = cd_values[1];      /* The block size */
+  blocksize = cd_values[1];      /* The block size */
   typesize = cd_values[2];      /* The datatype size */
   outbuf_size = cd_values[3];   /* Precomputed buffer guess */
 
@@ -195,6 +185,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
     blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
     cparams.compcode = compcode;
+    cparams.blocksize = blocksize;
     cparams.typesize = (int32_t) typesize;
     cparams.filters[BLOSC_LAST_FILTER] = doshuffle;
     cparams.clevel = clevel;

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -62,8 +62,7 @@ int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
   return 0;
 }
 
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op) {
-  chunk_op.itemsize = itemsize;
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op) {
 #if H5_VERS_MAJOR >=1 && H5_VERS_MINOR >= 14
   chunk_op.addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
   // Fill the addresses for the chunks in this dataset
@@ -393,9 +392,9 @@ herr_t read_records_blosc2( char* filename,
                             hsize_t nrecords,
                             uint8_t *data )
 {
- int32_t typesize = chunk_op.itemsize;
- int32_t chunklen = chunk_op.chunkshape;
- int32_t chunksize = chunklen * typesize;
+ size_t typesize = chunk_op.itemsize;
+ size_t chunklen = chunk_op.chunkshape;
+ size_t chunksize = chunklen * typesize;
 
  hsize_t total_records = 0;
  hsize_t start_nchunk = start / chunklen;

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -62,6 +62,22 @@ int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
   return 0;
 }
 
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op) {
+  chunk_op.itemsize = itemsize;
+#if H5_VERS_MAJOR >=1 && H5_VERS_MINOR >= 14
+  chunk_op.addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
+  // Fill the addresses for the chunks in this dataset
+  H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)&chunk_op);
+#endif
+}
+
+int clean_chunk_addrs(chunk_iter_op chunk_op) {
+  if (chunk_op.addrs != NULL) {
+    free(chunk_op.addrs);
+  }
+  chunk_op.addrs = NULL;
+}
+
 
 /*-------------------------------------------------------------------------
  *
@@ -381,17 +397,6 @@ herr_t read_records_blosc2( char* filename,
  int32_t chunklen = chunk_op.chunkshape;
  int32_t chunksize = chunklen * typesize;
 
-#if H5_VERS_MAJOR >= 1 && H5_VERS_MINOR >= 14
- // Fill the addresses for chunks
- hsize_t nrows;
- if ( H5Sget_simple_extent_dims( space_id, &nrows, NULL) < 0 )
-  goto out;
- hsize_t nchunks = nrows / chunklen + 1;
- chunk_op.addrs = (haddr_t *) malloc(nchunks * sizeof(haddr_t));
- if (H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)&chunk_op) < 0)
-  goto out;
-#endif
-
  hsize_t total_records = 0;
  hsize_t start_nchunk = start / chunklen;
  int32_t start_chunk = start % chunklen;
@@ -467,14 +472,9 @@ herr_t read_records_blosc2( char* filename,
   start_chunk = 0;
  }
 
- if (chunk_op.addrs != NULL)
-  free(chunk_op.addrs);
-
  return 0;
 
  out:
- if (chunk_op.addrs != NULL)
-  free(chunk_op.addrs);
  return -1;
 }
 

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -54,27 +54,27 @@
 #endif
 
 // Callback for H5Dchunk_iter
-int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
-             haddr_t addr, uint32_t nbytes, void *op_data) {
+static int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
+                    haddr_t addr, uint32_t nbytes, void *op_data) {
   chunk_iter_op *chunk_op = (chunk_iter_op*)op_data;
   hsize_t nchunk = offset[0] / chunk_op->chunkshape;
   chunk_op->addrs[nchunk] = addr;
   return 0;
 }
 
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op) {
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op *chunk_op) {
 #if H5_VERS_MAJOR >=1 && H5_VERS_MINOR >= 14
-  chunk_op.addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
+  chunk_op->addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
   // Fill the addresses for the chunks in this dataset
-  H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)&chunk_op);
+  H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)chunk_op);
 #endif
 }
 
-int clean_chunk_addrs(chunk_iter_op chunk_op) {
-  if (chunk_op.addrs != NULL) {
-    free(chunk_op.addrs);
+int clean_chunk_addrs(chunk_iter_op *chunk_op) {
+  if (chunk_op->addrs != NULL) {
+    free(chunk_op->addrs);
   }
-  chunk_op.addrs = NULL;
+  chunk_op->addrs = NULL;
 }
 
 

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -57,7 +57,7 @@
 int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
              haddr_t addr, uint32_t nbytes, void *op_data) {
   chunk_iter_op *chunk_op = (chunk_iter_op*)op_data;
-  hsize_t nchunk = offset[0] / chunk_op->chunksize;
+  hsize_t nchunk = offset[0] / chunk_op->chunkshape;
   chunk_op->addrs[nchunk] = addr;
   return 0;
 }
@@ -424,7 +424,7 @@ herr_t read_records_blosc2( char* filename,
  }
  else {
   typesize = chunk_op.itemsize;
-  chunklen = chunk_op.chunksize;
+  chunklen = chunk_op.chunkshape;
   chunksize = chunklen * typesize;
  }
 

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -57,25 +57,8 @@
 int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
              haddr_t addr, uint32_t nbytes, void *op_data) {
   chunk_iter_op *chunk_op = (chunk_iter_op*)op_data;
-  hsize_t nchunk = offset[0] / chunk_op->chunkshape;
-  chunk_op->addrs[nchunk] = addr;
+  chunk_op->addrs = addr;
   return 0;
-}
-
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op) {
-  chunk_op.itemsize = itemsize;
-#if H5_VERS_MAJOR >=1 && H5_VERS_MINOR >= 14
-  chunk_op.addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
-  // Fill the addresses for the chunks in this dataset
-  H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)&chunk_op);
-#endif
-}
-
-int clean_chunk_addrs(chunk_iter_op chunk_op) {
-  if (chunk_op.addrs != NULL) {
-    free(chunk_op.addrs);
-  }
-  chunk_op.addrs = NULL;
 }
 
 
@@ -393,47 +376,9 @@ herr_t read_records_blosc2( char* filename,
                             hsize_t nrecords,
                             uint8_t *data )
 {
- uint8_t *buffer_out = NULL;
-
- size_t cd_nelmts = 7;
- unsigned cd_values[7];
- char name[7];
- int32_t typesize;
- int32_t chunklen;
- int32_t chunksize;
- hid_t dcpl;
- if (chunk_op.addrs == NULL) {
-  /* Chunk meta info not available */
-  /* Get blosc2 params */
-  dcpl = H5Dget_create_plist(dataset_id);
-  if (dcpl == H5I_INVALID_HID) {
-   BLOSC_TRACE_ERROR("Fail getting plist");
-   goto out;
-  }
-  if (H5Pget_filter_by_id2(dcpl, FILTER_BLOSC2, NULL, &cd_nelmts, cd_values, 7, name, NULL) < 0) {
-   H5Pclose(dcpl);
-   BLOSC_TRACE_ERROR("Fail getting blosc2 params");
-   goto out;
-  }
-  if (H5Pclose(dcpl) < 0)
-   goto out;
-
-  typesize = cd_values[2];
-  chunksize = cd_values[3];
-  chunklen = chunksize / typesize;
- }
- else {
-  typesize = chunk_op.itemsize;
-  chunklen = chunk_op.chunkshape;
-  chunksize = chunklen * typesize;
- }
-
- /* Buffer for reading a chunk */
- buffer_out = malloc(chunksize);
- if (buffer_out == NULL) {
-  BLOSC_TRACE_ERROR("Malloc failed for buffer_out");
-  return -1;
- }
+ int32_t typesize = chunk_op.itemsize;
+ int32_t chunklen = chunk_op.chunkshape;
+ int32_t chunksize = chunklen * typesize;
 
  hsize_t total_records = 0;
  hsize_t start_nchunk = start / chunklen;
@@ -444,16 +389,16 @@ herr_t read_records_blosc2( char* filename,
   haddr_t address;
   hsize_t cframe_size;
   hsize_t chunk_offset;
-  if (chunk_op.addrs == NULL) {
+#if H5_VERS_MAJOR >= 1 && H5_VERS_MINOR >= 14
+   H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)&chunk_op);
+   address = chunk_op.addrs;
+#else
    if (H5Dget_chunk_info(dataset_id, space_id, nchunk, &chunk_offset, &flt_msk,
                          &address, &cframe_size) < 0) {
     BLOSC_TRACE_ERROR("Get chunk info failed!\n");
     goto out;
    }
-  }
-  else {
-   address = chunk_op.addrs[nchunk];
-  }
+#endif
 
   /* Open the schunk on-disk */
   blosc2_schunk *schunk = blosc2_schunk_open_offset(filename, (int64_t) address);
@@ -510,14 +455,9 @@ herr_t read_records_blosc2( char* filename,
   start_chunk = 0;
  }
 
- free(buffer_out);
-
  return 0;
 
  out:
- if (buffer_out != NULL) {
-  free(buffer_out);
- }
  return -1;
 }
 

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -12,6 +12,9 @@ typedef struct {
 } chunk_iter_op;
 
 
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op);
+int clean_chunk_addrs(chunk_iter_op chunk_op);
+
 hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,
                         const char *dset_name,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -12,8 +12,8 @@ typedef struct {
 } chunk_iter_op;
 
 
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op);
-int clean_chunk_addrs(chunk_iter_op chunk_op);
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op *chunk_op);
+int clean_chunk_addrs(chunk_iter_op *chunk_op);
 
 hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -7,7 +7,7 @@ extern "C" {
 // For H5Dchunk_iter() callback
 typedef struct {
   size_t itemsize;
-  size_t chunksize;
+  size_t chunkshape;
   haddr_t *addrs;
 } chunk_iter_op;
 

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -4,6 +4,18 @@
 extern "C" {
 #endif
 
+// For H5Dchunk_iter() callback
+typedef struct {
+  size_t itemsize;
+  size_t chunksize;
+  haddr_t *addrs;
+} chunk_iter_op;
+
+
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op);
+
+int clean_chunk_addrs(chunk_iter_op chunk_op);
+
 hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,
                         const char *dset_name,
@@ -24,6 +36,7 @@ hid_t H5TBOmake_table(  const char *table_title,
 
 herr_t H5TBOread_records( char *filename,
                           hbool_t blosc2_support,
+                          chunk_iter_op chunk_op,
                           hid_t dataset_id,
                           hid_t mem_type_id,
                           hsize_t start,
@@ -31,6 +44,7 @@ herr_t H5TBOread_records( char *filename,
                           void *data );
 
 herr_t read_records_blosc2( char* filename,
+                            chunk_iter_op chunk_op,
                             hid_t dataset_id,
                             hid_t mem_type_id,
                             hid_t space_id,
@@ -83,6 +97,7 @@ herr_t H5TBOwrite_elements( hid_t dataset_id,
 
 herr_t H5TBOdelete_records( char* filename,
                             hbool_t blosc2_support,
+                            chunk_iter_op chunk_op,
                             hid_t   dataset_id,
                             hid_t   mem_type_id,
                             hsize_t ntotal_records,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -8,7 +8,7 @@ extern "C" {
 typedef struct {
   int32_t itemsize;
   int32_t chunkshape;
-  haddr_t addrs;
+  haddr_t *addrs;
 } chunk_iter_op;
 
 

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -6,15 +6,11 @@ extern "C" {
 
 // For H5Dchunk_iter() callback
 typedef struct {
-  size_t itemsize;
-  size_t chunkshape;
-  haddr_t *addrs;
+  int32_t itemsize;
+  int32_t chunkshape;
+  haddr_t addrs;
 } chunk_iter_op;
 
-
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op);
-
-int clean_chunk_addrs(chunk_iter_op chunk_op);
 
 hid_t H5TBOmake_table(  const char *table_title,
                         hid_t loc_id,

--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -6,13 +6,13 @@ extern "C" {
 
 // For H5Dchunk_iter() callback
 typedef struct {
-  int32_t itemsize;
-  int32_t chunkshape;
+  size_t itemsize;
+  size_t chunkshape;
   haddr_t *addrs;
 } chunk_iter_op;
 
 
-int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op);
+int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op);
 int clean_chunk_addrs(chunk_iter_op chunk_op);
 
 hid_t H5TBOmake_table(  const char *table_title,

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -40,8 +40,6 @@ cdef extern from "hdf5.h" nogil:
   ctypedef int hbool_t
   ctypedef int herr_t
   ctypedef int htri_t
-  # hsize_t should be unsigned, but Windows platform does not support
-  # such an unsigned long long type.
   ctypedef unsigned long long hsize_t
   ctypedef signed long long hssize_t
   ctypedef long long int64_t

--- a/tables/table.py
+++ b/tables/table.py
@@ -3,6 +3,7 @@
 import functools
 import math
 import operator
+import platform
 import sys
 import warnings
 from pathlib import Path
@@ -816,6 +817,19 @@ class Table(tableextension.Table, Leaf):
         # `Leaf._g_post_init_hook()`.
         self._flavor, self._descflavor = self._descflavor, None
         super()._g_post_init_hook()
+
+        self.blosc2_support_write = (
+                (self.byteorder == sys.byteorder) and
+                (self.filters.complib != None) and
+                (self.filters.complib.startswith("blosc2")))
+        # For reading, Windows does not support re-opening a file twice
+        # in not read-only mode (for good reason), so we cannot use the
+        # blosc2 opt
+        self.blosc2_support_read = (
+                self.blosc2_support_write and
+                ((platform.system().lower() != 'windows') or
+                ((self._v_file.mode == 'r')))
+        )
 
         # Create a cols accessor.
         self.cols = Cols(self, self.description)

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -72,7 +72,7 @@ cdef extern from "H5TB-opt.h" nogil:
 
   ctypedef struct chunk_iter_op:
     size_t itemsize
-    size_t chunksize
+    size_t chunkshape
     haddr_t *addrs
 
   int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op)

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -71,11 +71,11 @@ from .lrucacheextension cimport ObjectCache, NumCache
 cdef extern from "H5TB-opt.h" nogil:
 
   ctypedef struct chunk_iter_op:
-    int32_t itemsize
-    int32_t chunkshape
+    size_t itemsize
+    size_t chunkshape
     haddr_t *addrs
 
-  int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op)
+  int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op)
   int clean_chunk_addrs(chunk_iter_op chunk_op)
 
   herr_t H5TBOmake_table( char *table_title, hid_t loc_id, char *dset_name,
@@ -894,7 +894,7 @@ cdef class Row:
     if table.blosc2_support_read:
       # Grab the addresses for the blosc2 frames (HDF5 chunks)
       nchunks = math.ceil(self.nrows / self.table.chunkshape[0])
-      fill_chunk_addrs(table.dataset_id, nchunks, self.dtype.itemsize, table.chunk_op)
+      fill_chunk_addrs(table.dataset_id, nchunks, table.chunk_op)
 
     if coords is not None and 0 < step:
       self.nrowsread = start
@@ -1230,7 +1230,7 @@ cdef class Row:
 
     # Clean address cache
     if table.blosc2_support_read:
-        clean_chunk_addrs(table.chunk_op)
+      clean_chunk_addrs(table.chunk_op)
 
     self.rfieldscache = {}     # empty rfields cache
     self.wfieldscache = {}     # empty wfields cache

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -20,11 +20,10 @@ Functions:
 Misc variables:
 
 """
-
+import math
 import sys
 import numpy
 from time import time
-import platform
 
 from .description import Col
 from .exceptions import HDF5ExtError
@@ -42,10 +41,11 @@ from hdf5extension cimport Leaf
 from cpython cimport PyErr_Clear
 from libc.stdio cimport snprintf
 from libc.stdlib cimport malloc, free
+from libc.stdint cimport uint32_t
 from libc.string cimport memcpy, strdup, strcmp, strlen
 from numpy cimport (import_array, ndarray, npy_intp, PyArray_GETITEM,
   PyArray_SETITEM, PyArray_BYTES, PyArray_DATA, PyArray_NDIM, PyArray_STRIDE)
-from .definitions cimport (hid_t, herr_t, hsize_t, htri_t, hbool_t,
+from .definitions cimport (hid_t, herr_t, hsize_t, haddr_t, htri_t, hbool_t,
   H5F_ACC_RDONLY, H5P_DEFAULT, H5D_CHUNKED, H5T_DIR_DEFAULT,
   H5F_SCOPE_LOCAL, H5F_SCOPE_GLOBAL, H5T_COMPOUND, H5Tget_order,
   H5Fflush, H5Dget_create_plist, H5T_ORDER_LE,
@@ -70,6 +70,14 @@ from .lrucacheextension cimport ObjectCache, NumCache
 # Optimized HDF5 API for PyTables
 cdef extern from "H5TB-opt.h" nogil:
 
+  ctypedef struct chunk_iter_op:
+    size_t itemsize
+    size_t chunksize
+    haddr_t *addrs
+
+  int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, size_t itemsize, chunk_iter_op chunk_op)
+  int clean_chunk_addrs(chunk_iter_op chunk_op)
+
   herr_t H5TBOmake_table( char *table_title, hid_t loc_id, char *dset_name,
                           char *version, char *class_,
                           hid_t mem_type_id, hsize_t nrecords,
@@ -80,6 +88,7 @@ cdef extern from "H5TB-opt.h" nogil:
                           void *data )
 
   herr_t H5TBOread_records( char* filename, hbool_t blosc2_support,
+                            chunk_iter_op chunk_op,
                             hid_t dataset_id, hid_t mem_type_id,
                             hsize_t start, hsize_t nrecords, void *data )
 
@@ -102,8 +111,9 @@ cdef extern from "H5TB-opt.h" nogil:
                               hsize_t nrecords, void *coords, void *data )
 
   herr_t H5TBOdelete_records( char* filename, hbool_t blosc2_support,
-                              hid_t   dataset_id, hid_t   mem_type_id,
-                              hsize_t ntotal_records, size_t  src_size,
+                              chunk_iter_op chunk_op,
+                              hid_t dataset_id, hid_t mem_type_id,
+                              hsize_t ntotal_records, size_t src_size,
                               hsize_t start, hsize_t nrecords,
                               hsize_t maxtuples )
 
@@ -153,7 +163,8 @@ cdef join_path(object parent, object name):
 
 cdef class Table(Leaf):
   # instance variables
-  cdef void     *wbuf
+  cdef void *wbuf
+  cdef chunk_iter_op chunk_op
 
   def _create_table(self, title, complib, obversion):
     cdef int     offset
@@ -205,11 +216,13 @@ cdef class Table(Leaf):
     else:
       data = NULL
 
+    blosc2_support_write = (
+            (self.byteorder == sys.byteorder) and
+            (self.filters.complib != None) and
+            (self.filters.complib.startswith("blosc2")))
+
     class_ = self._c_classid.encode('utf-8')
     cdef hsize_t blocksize = self._v_blocksize if hasattr(self, "_v_blocksize") else 0
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2"))
     self.dataset_id = H5TBOmake_table(ctitle, self.parent_id, encoded_name,
                                       cobversion, class_, self.disk_type_id,
                                       self.nrows, self.chunkshape[0],
@@ -218,7 +231,7 @@ cdef class Table(Leaf):
                                       self.filters.shuffle_bitshuffle,
                                       self.filters.fletcher32,
                                       self._want_track_times,
-                                      blosc2_support, data)
+                                      blosc2_support_write, data)
     if self.dataset_id < 0:
       raise HDF5ExtError("Problems creating the table")
 
@@ -265,6 +278,9 @@ cdef class Table(Leaf):
 
     # If created in PyTables, the table is always chunked
     self._chunked = True  # Accessible from python
+
+    # Initialize blosc2 struct for chunk addresses
+    self.chunk_op = chunk_iter_op(0, self.chunkshape[0], NULL)
 
     # Finally, return the object identifier.
     return self.dataset_id
@@ -388,9 +404,8 @@ cdef class Table(Leaf):
     cdef H5D_layout_t layout
     cdef bytes encoded_name
 
-    encoded_name = self.name.encode('utf-8')
-
     # Open the dataset
+    encoded_name = self.name.encode('utf-8')
     self.dataset_id = H5Dopen(self.parent_id, encoded_name, H5P_DEFAULT)
     if self.dataset_id < 0:
       raise HDF5ExtError("Non-existing node ``%s`` under ``%s``" %
@@ -434,6 +449,8 @@ cdef class Table(Leaf):
       # Trailing padding, set the itemsize to the correct type_size (see #765)
       desc['_v_itemsize'] = type_size
 
+    # Initialize blosc2 struct for chunk addresses
+    self.chunk_op = chunk_iter_op(0, chunksize[0], NULL)
 
     # Return the object ID and the description
     return (self.dataset_id, desc, SizeType(chunksize[0]))
@@ -494,14 +511,12 @@ cdef class Table(Leaf):
   def _append_records(self, hsize_t nrecords):
     cdef int ret
     cdef hsize_t nrows
+    cdef hbool_t blosc2_support = self.blosc2_support_write
 
     # Convert some NumPy types to HDF5 before storing.
     self._convert_types(self._v_recarray, nrecords, 0)
 
     nrows = self.nrows
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2"))
     # release GIL (allow other threads to use the Python interpreter)
     with nogil:
         # Append the records:
@@ -547,13 +562,10 @@ cdef class Table(Leaf):
     # Convert some NumPy types to HDF5 before storing.
     self._convert_types(recarr, nrecords, 0)
     # Update the records:
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2") and
-                                   (step == 1))
+    cdef hbool_t blosc2_support = (self.blosc2_support_write and (step == 1))
     with nogil:
         ret = H5TBOwrite_records(blosc2_support, self.dataset_id,
-                                 self.type_id, start, nrecords, step, rbuf )
+                                 self.type_id, start, nrecords, step, rbuf)
 
     if ret < 0:
       raise HDF5ExtError("Problems updating the records.")
@@ -592,6 +604,7 @@ cdef class Table(Leaf):
     cdef int ret
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
+    cdef hbool_t blosc2_support = self.blosc2_support_read
 
     # Correct the number of records to read, if needed
     if (start + nrecords) > self.nrows:
@@ -601,15 +614,10 @@ cdef class Table(Leaf):
     rbuf = PyArray_DATA(recarr)
 
     # Read the records from disk
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2") and
-                                   ((platform.system().lower() != 'windows') or
-                                    ((self._v_file.mode == 'r'))))
-
     with nogil:
-        ret = H5TBOread_records(filename, blosc2_support, self.dataset_id,
-                                self.type_id, start, nrecords, rbuf)
+        ret = H5TBOread_records(filename, blosc2_support, self.chunk_op,
+                                self.dataset_id, self.type_id, start,
+                                nrecords, rbuf)
 
     if ret < 0:
       raise HDF5ExtError("Problems reading records.")
@@ -627,11 +635,7 @@ cdef class Table(Leaf):
     cdef NumCache chunkcache
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2") and
-                                   ((platform.system().lower() != 'windows') or
-                                    ((self._v_file.mode == 'r'))))
+    cdef hbool_t blosc2_support = self.blosc2_support_read
 
     chunkcache = self._chunkcache
     chunkshape = chunkcache.slotsize
@@ -648,8 +652,9 @@ cdef class Table(Leaf):
     else:
       # Chunk is not in cache. Read it and put it in the LRU cache.
       with nogil:
-          ret = H5TBOread_records(filename, blosc2_support, self.dataset_id,
-                                  self.type_id, start, nrecords, rbuf)
+          ret = H5TBOread_records(filename, blosc2_support, self.chunk_op,
+                                  self.dataset_id, self.type_id, start,
+                                  nrecords, rbuf)
 
       if ret < 0:
         raise HDF5ExtError("Problems reading chunk records.")
@@ -687,17 +692,12 @@ cdef class Table(Leaf):
     cdef hsize_t i
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
-    cdef hbool_t blosc2_support = ((self.byteorder == sys.byteorder) and
-                                   (self.filters.complib != None) and
-                                   (self.filters.complib[0:6] == "blosc2") and
-                                   ((platform.system().lower() != 'windows') or
-                                    ((self._v_file.mode == 'r'))))
-
     if step == 1:
       nrecords = stop - start
       rowsize = self.rowsize
       # Using self.disk_type_id should be faster (i.e. less conversions)
-      if (H5TBOdelete_records(filename, blosc2_support, self.dataset_id,
+      if (H5TBOdelete_records(filename, self.blosc2_support_read, self.chunk_op,
+                              self.dataset_id,
                               self.disk_type_id, self.nrows, rowsize,
                               start, nrecords, self.nrowsinbuf) < 0):
         raise HDF5ExtError("Problems deleting records.")
@@ -873,7 +873,7 @@ cdef class Row:
   cdef _init_loop(self, long long start, long long stop, long long step,
                  object coords, object chunkmap):
     """Initialization for the __iter__ iterator"""
-    table = self.table
+    cdef Table table = self.table
     self._riterator = 1   # We are inside a read iterator
     self.start = start
     self.stop = stop
@@ -890,6 +890,10 @@ cdef class Row:
     self._nrow = start - self.step
     self.wherecond = 0
     self.indexed = 0
+    if table.blosc2_support_read:
+      # Grab the addresses for the blosc2 frames (HDF5 chunks)
+      nchunks = math.ceil(self.nrows / self.table.chunkshape[0])
+      fill_chunk_addrs(table.dataset_id, nchunks, self.dtype.itemsize, table.chunk_op)
 
     self.nrows = table.nrows   # Update the row counter
 
@@ -1223,6 +1227,11 @@ cdef class Row:
   cdef _finish_riterator(self):
     """Clean-up things after iterator has been done"""
     cdef ObjectCache seqcache
+    cdef Table table = self.table
+
+    # Clean address cache
+    if table.blosc2_support_read:
+      clean_chunk_addrs(table.chunk_op)
 
     self.rfieldscache = {}     # empty rfields cache
     self.wfieldscache = {}     # empty wfields cache

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -73,7 +73,7 @@ cdef extern from "H5TB-opt.h" nogil:
   ctypedef struct chunk_iter_op:
     int32_t itemsize
     int32_t chunkshape
-    haddr_t addrs
+    haddr_t *addrs
 
   herr_t H5TBOmake_table( char *table_title, hid_t loc_id, char *dset_name,
                           char *version, char *class_,
@@ -277,7 +277,7 @@ cdef class Table(Leaf):
     self._chunked = True  # Accessible from python
 
     # Initialize blosc2 struct for chunk addresses
-    self.chunk_op = chunk_iter_op(self.description._v_itemsize, self.chunkshape[0], 0)
+    self.chunk_op = chunk_iter_op(self.description._v_itemsize, self.chunkshape[0], NULL)
 
     # Finally, return the object identifier.
     return self.dataset_id
@@ -447,7 +447,7 @@ cdef class Table(Leaf):
       desc['_v_itemsize'] = type_size
 
     # Initialize blosc2 struct for chunk addresses
-    self.chunk_op = chunk_iter_op(type_size, chunksize[0], 0)
+    self.chunk_op = chunk_iter_op(type_size, chunksize[0], NULL)
 
     # Return the object ID and the description
     return (self.dataset_id, desc, SizeType(chunksize[0]))

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -75,8 +75,8 @@ cdef extern from "H5TB-opt.h" nogil:
     size_t chunkshape
     haddr_t *addrs
 
-  int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op chunk_op)
-  int clean_chunk_addrs(chunk_iter_op chunk_op)
+  int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op *chunk_op)
+  int clean_chunk_addrs(chunk_iter_op *chunk_op)
 
   herr_t H5TBOmake_table( char *table_title, hid_t loc_id, char *dset_name,
                           char *version, char *class_,
@@ -894,7 +894,7 @@ cdef class Row:
     if table.blosc2_support_read:
       # Grab the addresses for the blosc2 frames (HDF5 chunks)
       nchunks = math.ceil(self.nrows / self.table.chunkshape[0])
-      fill_chunk_addrs(table.dataset_id, nchunks, table.chunk_op)
+      fill_chunk_addrs(table.dataset_id, nchunks, &table.chunk_op)
 
     if coords is not None and 0 < step:
       self.nrowsread = start
@@ -1230,7 +1230,7 @@ cdef class Row:
 
     # Clean address cache
     if table.blosc2_support_read:
-      clean_chunk_addrs(table.chunk_op)
+      clean_chunk_addrs(&table.chunk_op)
 
     self.rfieldscache = {}     # empty rfields cache
     self.wfieldscache = {}     # empty wfields cache


### PR DESCRIPTION
Here there is an optimization for using `H5Dchunk_iter`.  This was originally suggested in https://github.com/PyTables/PyTables/issues/991 by @mkitti.

This should be only useful when there is a large number of chunks on a dataset, and one wants to walk all or a large part of it.  Preliminary benchmarks are suggesting that we can get up to 10% of speedup for datasets of 270 GB (7731 chunks when they are 36 MB in size), when using the optimized path for Blosc2.  Probably we can get more speedup for larger datasets (to be tested).