### PR TITLE
Optimize for H5Dchunk_iter for random reads

### DIFF
--- a/bench/read-table.py
+++ b/bench/read-table.py
@@ -1,0 +1,50 @@
+import tables as tb
+import numpy as np
+from time import time
+import sys
+
+
+N = 200
+NBUNCH = 100_000_000
+NREADS = 100_000
+filename = "read-table.h5"
+
+
+class Particle(tb.IsDescription):
+    lati = tb.Int32Col()
+    longi = tb.Int32Col()
+    pressure = tb.Float32Col()
+    temperature = tb.Float32Col()
+
+if len(sys.argv) > 1 and sys.argv[1] == "w":
+    # Open a file in "w"rite mode
+    print(f"Creating {filename} with {NBUNCH * N / 1_000_000} Mrows...")
+    t0 = time()
+    fileh = tb.open_file(filename, mode="w")
+    # Create a new table in newgroup group
+    table = fileh.create_table(fileh.root, 'table', Particle, "A table",
+                               tb.Filters(complevel=1, complib="blosc2"),
+                               expectedrows=NBUNCH * N)
+    # A bunch of particles
+    particles = np.zeros(NBUNCH, dtype=table.dtype)
+
+    # Fill the table with N chunks of particles
+    for i in range(N):
+        table.append(particles)
+    table.flush()
+    print(f"Time to create: {time() - t0:.3f}s")
+else:
+    fileh = tb.open_file(filename)
+    table = fileh.root.table
+
+t0 = time()
+idxs_to_read = np.random.randint(0, NBUNCH, NREADS)
+print(f"Time to create indexes: {time() - t0:.3f}s")
+
+print(f"Reading {NREADS / 1_000} Krows...")
+t0 = time()
+for i in idxs_to_read:
+    row = table[i]
+print(f"Time to read: {time() - t0:.3f}s")
+
+fileh.close()

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -64,9 +64,12 @@ static int chunk_cb(const hsize_t *offset, uint32_t filter_mask,
 
 int fill_chunk_addrs(hid_t dataset_id, hsize_t nchunks, chunk_iter_op *chunk_op) {
 #if H5_VERS_MAJOR >=1 && H5_VERS_MINOR >= 14
-  chunk_op->addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
-  // Fill the addresses for the chunks in this dataset
-  H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)chunk_op);
+  // Only fill the address cache when needed
+  if (chunk_op->addrs == NULL) {
+    chunk_op->addrs = (haddr_t*)malloc(nchunks * sizeof(haddr_t));
+    // Fill the addresses for the chunks in this dataset
+    H5Dchunk_iter(dataset_id, H5P_DEFAULT, (H5D_chunk_iter_op_t)chunk_cb, (void*)chunk_op);
+  }
 #endif
 }
 

--- a/tables/table.py
+++ b/tables/table.py
@@ -2962,6 +2962,9 @@ very small/large chunksize, you may want to increase/decrease it."""
         if cols is not None:
             cols._g_close()
 
+        # Clean address cache
+        self._clean_chunk_addrs()
+
         # Close myself as a leaf.
         super()._f_close(False)
 

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -514,8 +514,7 @@ cdef class Table(Leaf):
     cdef hbool_t blosc2_support = self.blosc2_support_write
 
     # Clean address cache
-    if self.blosc2_support_write:
-      clean_chunk_addrs(&self.chunk_op)
+    self._clean_chunk_addrs()
 
     # Convert some NumPy types to HDF5 before storing.
     self._convert_types(self._v_recarray, nrecords, 0)
@@ -545,9 +544,7 @@ cdef class Table(Leaf):
     # Set the caches to dirty (in fact, and for the append case,
     # it should be only the caches based on limits, but anyway)
     self._dirtycache = True
-    # Clean address cache
-    if self.blosc2_support_write:
-      clean_chunk_addrs(&self.chunk_op)
+    self._clean_chunk_addrs()
     # Delete the reference to recarray as we doesn't need it anymore
     self._v_recarray = None
 
@@ -579,9 +576,7 @@ cdef class Table(Leaf):
 
     # Set the caches to dirty
     self._dirtycache = True
-    # Clean address cache
-    if self.blosc2_support_read:
-      clean_chunk_addrs(&self.chunk_op)
+    self._clean_chunk_addrs()
 
 
   def _update_elements(self, hsize_t nrecords, ndarray coords,
@@ -609,9 +604,7 @@ cdef class Table(Leaf):
 
     # Set the caches to dirty
     self._dirtycache = True
-    # Clean address cache
-    if self.blosc2_support_read:
-      clean_chunk_addrs(&self.chunk_op)
+    self._clean_chunk_addrs()
 
 
   def _read_records(self, hsize_t start, hsize_t nrecords, ndarray recarr):
@@ -736,9 +729,7 @@ cdef class Table(Leaf):
                             0, NULL, <char *>&nrecords2)
       # Set the caches to dirty
       self._dirtycache = True
-      # Clean address cache
-      if self.blosc2_support_read:
-        clean_chunk_addrs(&self.chunk_op)
+      self._clean_chunk_addrs()
     elif step == -1:
       nrecords = self._remove_rows(stop+1, start+1, 1)
     elif step >= 1:
@@ -754,6 +745,11 @@ cdef class Table(Leaf):
 
     # Return the number of records removed
     return nrecords
+
+  # Clean address cache
+  def _clean_chunk_addrs(self):
+    clean_chunk_addrs(&self.chunk_op)
+
 
 cdef class Row:
   """Table row iterator and field accessor.

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -513,6 +513,10 @@ cdef class Table(Leaf):
     cdef hsize_t nrows
     cdef hbool_t blosc2_support = self.blosc2_support_write
 
+    # Clean address cache
+    if self.blosc2_support_write:
+      clean_chunk_addrs(&self.chunk_op)
+
     # Convert some NumPy types to HDF5 before storing.
     self._convert_types(self._v_recarray, nrecords, 0)
 
@@ -541,6 +545,9 @@ cdef class Table(Leaf):
     # Set the caches to dirty (in fact, and for the append case,
     # it should be only the caches based on limits, but anyway)
     self._dirtycache = True
+    # Clean address cache
+    if self.blosc2_support_write:
+      clean_chunk_addrs(&self.chunk_op)
     # Delete the reference to recarray as we doesn't need it anymore
     self._v_recarray = None
 
@@ -572,6 +579,10 @@ cdef class Table(Leaf):
 
     # Set the caches to dirty
     self._dirtycache = True
+    # Clean address cache
+    if self.blosc2_support_read:
+      clean_chunk_addrs(&self.chunk_op)
+
 
   def _update_elements(self, hsize_t nrecords, ndarray coords,
                        ndarray recarr):
@@ -598,6 +609,10 @@ cdef class Table(Leaf):
 
     # Set the caches to dirty
     self._dirtycache = True
+    # Clean address cache
+    if self.blosc2_support_read:
+      clean_chunk_addrs(&self.chunk_op)
+
 
   def _read_records(self, hsize_t start, hsize_t nrecords, ndarray recarr):
     cdef void *rbuf
@@ -605,6 +620,11 @@ cdef class Table(Leaf):
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
     cdef hbool_t blosc2_support = self.blosc2_support_read
+
+    if self.blosc2_support_read:
+      # Grab the addresses for the blosc2 frames (HDF5 chunks)
+      nchunks = math.ceil(self.nrows / self.chunkshape[0])
+      fill_chunk_addrs(self.dataset_id, nchunks, &self.chunk_op)
 
     # Correct the number of records to read, if needed
     if (start + nrecords) > self.nrows:
@@ -636,6 +656,11 @@ cdef class Table(Leaf):
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
     cdef hbool_t blosc2_support = self.blosc2_support_read
+
+    if self.blosc2_support_read:
+      # Grab the addresses for the blosc2 frames (HDF5 chunks)
+      nchunks = math.ceil(self.nrows / self.chunkshape[0])
+      fill_chunk_addrs(self.dataset_id, nchunks, &self.chunk_op)
 
     chunkcache = self._chunkcache
     chunkshape = chunkcache.slotsize
@@ -692,6 +717,7 @@ cdef class Table(Leaf):
     cdef hsize_t i
     cdef bytes fname = self._v_file.filename.encode('utf8')
     cdef char* filename = fname
+
     if step == 1:
       nrecords = stop - start
       rowsize = self.rowsize
@@ -710,6 +736,9 @@ cdef class Table(Leaf):
                             0, NULL, <char *>&nrecords2)
       # Set the caches to dirty
       self._dirtycache = True
+      # Clean address cache
+      if self.blosc2_support_read:
+        clean_chunk_addrs(&self.chunk_op)
     elif step == -1:
       nrecords = self._remove_rows(stop+1, start+1, 1)
     elif step >= 1:
@@ -1227,10 +1256,6 @@ cdef class Row:
     """Clean-up things after iterator has been done"""
     cdef ObjectCache seqcache
     cdef Table table = self.table
-
-    # Clean address cache
-    if table.blosc2_support_read:
-      clean_chunk_addrs(&table.chunk_op)
 
     self.rfieldscache = {}     # empty rfields cache
     self.wfieldscache = {}     # empty wfields cache


### PR DESCRIPTION
Here it is yet another optimization for doing random reads in combination with the new `H5Dchunk_iter` introduced in HDF5 1.14 series.

The new `bench/read-table.py` script generates a table with 20 *billions* of rows, accounting for more than 2 million of chunks on my machine (as the chunk size is determined automatically based on the L3 size, this figure is machine dependent).  With that, here it is the new random speed when using HDF5 1.14.0:

```
Reading 100.0 Krows...
Time to read: 1.459s
```

which makes for 15 us per read; pretty good.

Using a build with HDF5 1.12.2 (i.e. not having the `H5Dchunk_iter` machinery), I'm getting:

```
Reading 100.0 Krows...
Time to read: 7.302s
```

so, 5x times slower.

As this depends on the square of the number of chunks, the improvement can be larger for even a larger number of chunks --in the suposition that more than 2 million of chunks (that is, more than 20 billions of rows in our case) is a realistic assumption ;-)