### PR TITLE
Set github workflow permissions to least privileges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   sdist:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,9 @@ name: ubuntu
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,6 +13,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build_sdist:
     name: Build source distribution


### PR DESCRIPTION
### Changes

Closes #1006 

- ubuntu.yml - success run https://github.com/joycebrum/PyTables/actions/runs/4418480233
- ci.yml - success run https://github.com/joycebrum/PyTables/actions/runs/4418480235
- wheels.yml - it is with the same errors https://github.com/joycebrum/PyTables/actions/runs/4418480249. I believe the permissions granted (`contents: read`) will be enough to this workflow, looking at the jobs.

If you have any problem with wheels.yml permission after fixing it feel free to ping me and I'll be happy to help. I also tried to figure out why it is not working but also not sure about it 😥 .