### PR TITLE
Fix build errors when compiled using cython 3.0.0b1.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "oldest-supported-numpy",
     "packaging",
     "py-cpuinfo",
-    "Cython >=0.29.21",
+    "Cython >=0.29.32",
     # Included here for seamless wheel builds.
     # Packagers can choose to replace it by externally provided
     # c-blosc2 library and headers

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -37,7 +37,7 @@ from .utils import SizeType
 from .utilsextension cimport get_native_type, cstr_to_pystr
 
 # numpy functions & objects
-from hdf5extension cimport Leaf
+from .hdf5extension cimport Leaf
 from cpython cimport PyErr_Clear
 from libc.stdio cimport snprintf
 from libc.stdlib cimport malloc, free

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -344,7 +344,7 @@ except ImportError:
 #---------------------------------------------------------------------
 
 # Error handling helpers
-cdef herr_t e_walk_cb(unsigned n, const H5E_error_t *err, void *data) with gil:
+cdef herr_t e_walk_cb(unsigned n, const H5E_error_t *err, void *data) noexcept with gil:
     cdef object bt = <object>data   # list
     #cdef char major_msg[256]
     #cdef char minor_msg[256]


### PR DESCRIPTION
Two issues were fixed:
* cython 3 changes default exception handling: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept
* Cython supports namespace packages: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#namespace-packages

Fixes: #1003
