### PR TITLE
DOC: fix get_node docstring formatting

### DIFF
--- a/tables/file.py
+++ b/tables/file.py
@@ -1579,6 +1579,8 @@ class File(hdf5extension.File):
             a class derived from Node (e.g. Table). If the node is found but it
             is not an instance of that class, a NoSuchNodeError is also raised.
 
+        Notes
+        -----
         If the node to be returned does not exist, a NoSuchNodeError is
         raised. Please note that hidden nodes are also considered.
 


### PR DESCRIPTION
Currently the documentation of [`get_node`](https://www.pytables.org/usersguide/libref/file_class.html#tables.File.get_node) is a bit garbled as Sphinx tries to format the last paragraph as parameters:
![image](https://github.com/PyTables/PyTables/assets/19879328/27e2cad5-56bc-4ab2-8759-ed8728ffa75c)

Fixed by formatting this paragraph as a note.
