### PR TITLE
Fix open C++ extern block in optimized array header file

### DIFF
--- a/src/H5TB-opt.h
+++ b/src/H5TB-opt.h
@@ -104,3 +104,7 @@ herr_t H5TBOdelete_records( char* filename,
                             hsize_t start,
                             hsize_t nrecords,
                             hsize_t maxtuples );
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Not super-important (probably no C++ code imports this), but still missing.