### PR TITLE
python3.12: cython: fix slice indexing

### DIFF
--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -899,9 +899,12 @@ def get_nested_field(recarray, fieldname):
   """Get the maybe nested field named `fieldname` from the `recarray`.
 
   The `fieldname` may be a simple field name or a nested field name
-  with slah-separated components.
+  with slash-separated components.
 
   """
+
+  if not isinstance(fieldname, str):
+    raise TypeError
 
   cdef bytes name = fieldname.encode('utf-8')
   try:


### PR DESCRIPTION
Several tests fail with:
```
Traceback (most recent call last):
  File "tables/tableextension.pyx", line 1507, in tables.tableextension.Row.__getitem__
KeyError: slice(None, None, 2)
During handling of the above exception, another exception occurred: Traceback (most recent call last):
  File "tables/tableextension.pyx", line 124, in tables.tableextension.get_nested_field_cache
KeyError: slice(None, None, 2)
During handling of the above exception, another exception occurred: Traceback (most recent call last):
  File "/builddir/build/BUILDROOT/python-tables-3.7.0-8.fc39.aarch64/usr/lib64/python3.12/site-packages/tables/tests/test_tables.py", line 489, in test01a_extslice
    result = [rec[::2] for rec in table.iterrows()
              ~~~^^^^^
  File "tables/tableextension.pyx", line 1511, in tables.tableextension.Row.__getitem__
  File "tables/tableextension.pyx", line 131, in tables.tableextension.get_nested_field_cache
  File "tables/utilsextension.pyx", line 838, in tables.utilsextension.get_nested_field
AttributeError: 'slice' object has no attribute 'encode'
```

It seems that `__getitem__()` expected `TypeError` from `get_nested_field_cache()` when called with a slice. `get_nested_field_cache()` calls `.encode()` on the argument, so this obviously fails with `AttributeError`. No idea how it worked before.