### PR TITLE
Replace unsafe mktemp function in code

### DIFF
--- a/bench/optimal-chunksize.py
+++ b/bench/optimal-chunksize.py
@@ -51,7 +51,7 @@ def get_db_size(filename):
 
 def bench(chunkshape, filters):
     np.random.seed(1)   # to have reproductible results
-    filename = tempfile.mktemp(suffix='.h5')
+    filename = tempfile.NamedTemporaryFile(suffix='.h5').name
     print("Doing test on the file system represented by:", filename)
 
     f = tb.open_file(filename, 'w')


### PR DESCRIPTION
### What is wrong?

In file: optimal-chunksize.py, there is a method  that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the Python_documentation. iCR suggested that a temporary file should be created using NamedTemporaryFile which is a_safe_API. iCR replaced the usage of mktemp with NamedTemporaryFile.

### What is the security issue?

It is important to note that this method is considered insecure which is also mentioned in the original documentation of tempfile package. This insecurity stems from the fact that the process of creating a file using the mktemp() function occurs in two distinct steps. Initially, a filename is generated, and subsequently, a file is created using that particular name. This process becomes insecure due to the possibility that a separate process might generate a file with the same name during the interval between the invocation of mktemp() and the subsequent attempt by the initial process to create the file.

You can find related reference [here](https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables)

### How was it fixed?

To address this security concern, another method from official documentation `NamedTemporaryFile` can be used here. Here is the code snippet with the recommended fix.

```
filename = tempfile.NamedTemporaryFile(suffix='.h5').name
```

### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.
The bug is found by running the iCR tool by [OpenRefactory, Inc.](https://openrefactory.com/) and then manually triaging the results.

---
Bug Type: Improper Method Call
Bug Summary: Deprecated method led to a security issue.
Project: PyTables
Scan Data: 2023-08-31