### PR TITLE
Preliminaries for 3.9.1 release

### DIFF
--- a/ANNOUNCE.txt.in
+++ b/ANNOUNCE.txt.in
@@ -8,7 +8,8 @@ We are happy to announce PyTables @VERSION@.
 What's new
 ==========
 
-XXX version-specific blurb XXX
+This is a hot fix release to deprecate support for Python 3.8.
+See https://github.com/PyTables/PyTables/issues/1062.
 
 In case you want to know more in detail what has changed in this
 version, please refer to: http://www.pytables.org/release_notes.html

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,7 +11,7 @@
 Changes from 3.9.0 to 3.9.1
 ===========================
 
-XXX version-specific notes XXX
+* Minimum supported version for Python is 3.9 (see #1062).
 
 
 Changes from 3.8.0 to 3.9.0

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -59,7 +59,7 @@ If you don't, fetch and install them before proceeding.
 .. Keep entries from NumPy on in sync with ``project.dependencies`` in ``pyproject.toml``.
 .. Keep system packages in sync with build jobs in `.github/workflows/*.yml`.
 
-* Python_ >= 3.9 (Python 3.8 may work, but you may need to build/test yourself)
+* Python_ >= 3.9
 * HDF5_ >= 1.10.5 (although 1.14.0 or later is strongly recommended)
 * Cython_ >= 0.29.32
 * NumPy_ >= 1.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ description = "Hierarchical datasets for Python"
 # Keep Python versions in sync with
 # `classifiers` below,
 # `min_python_version` in `setup.py`.
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD 3-Clause License" }
 keywords = [ "hdf5" ]
 authors = [
@@ -56,7 +56,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tables/_version.py
+++ b/tables/_version.py
@@ -1,2 +1,2 @@
-__version__ = "3.9.1.dev0"
+__version__ = "3.9.1"
 """The PyTables version number."""


### PR DESCRIPTION
This is a proposal for a hot release for deprecating the support of Python 3.8.  For details, see: https://github.com/PyTables/PyTables/issues/1062 and https://github.com/PyTables/PyTables/issues/1061.  The hot release will be just a new set of wheels and sources, without regenerating docs or anything else.  The idea is that people get a quick error when they try to use PyTables 3.9.1 when using Python 3.8