### PR TITLE
types/doc: Start introducing types

### DIFF
--- a/tables/description.py
+++ b/tables/description.py
@@ -800,11 +800,7 @@ class IsDescription(metaclass=MetaIsDescription):
 
     .. rubric:: IsDescription attributes
 
-    .. attribute:: _v_pos
-
-        Sets the position of a possible nested column description among its
-        sibling columns.  This attribute can be specified *when declaring*
-        an IsDescription subclass to complement its *metadata*.
+    .. autoattribute:: _v_pos
 
     .. attribute:: columns
 
@@ -815,6 +811,12 @@ class IsDescription(metaclass=MetaIsDescription):
 
     """
 
+    _v_pos: int
+    """
+        Sets the position of a possible nested column description among its
+        sibling columns.  This attribute can be specified *when declaring*
+        an IsDescription subclass to complement its *metadata*.
+    """
 
 def descr_from_dtype(dtype_, ptparams=None):
     """Get a description instance and byteorder from a (nested) NumPy dtype."""


### PR DESCRIPTION
Add a type to _v_pos in descriptions.py, move doc to be under _v_pos. This does not change the sphinx output other than that the type annotation is now present.