### PR TITLE
Switch to H5_USE_110_API

### DIFF
--- a/bench/bench-pytables-ranges.sh
+++ b/bench/bench-pytables-ranges.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#export LD_LIBRARY_PATH=$HOME/computacio/hdf5-1.8.2/hdf5/lib
+#export LD_LIBRARY_PATH=$HOME/computacio/hdf5-1.10.2/hdf5/lib
 export PYTHONPATH=..${PYTHONPATH:+:$PYTHONPATH}
 
 bench="python2.7 -O -u indexed_search.py"

--- a/bench/bench-pytables.sh
+++ b/bench/bench-pytables.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export LD_LIBRARY_PATH=$HOME/computacio/hdf5-1.8.1/hdf5/lib
+export LD_LIBRARY_PATH=$HOME/computacio/hdf5-1.10.1/hdf5/lib
 #export PYTHONPATH=..${PYTHONPATH:+:$PYTHONPATH}
 
 bench="python2.7 -O -u indexed_search.py"

--- a/doc/source/cookbook/inmemory_hdf5_files.rst
+++ b/doc/source/cookbook/inmemory_hdf5_files.rst
@@ -95,8 +95,7 @@ Memory images of HDF5 files
 ===========================
 
 It is possible to get a memory image of an HDF5 file (see
-`HDF5 File Image Operations`_).  This feature is only available if PyTables
-is build against version 1.8.9 or newer of the HDF5 library.
+`HDF5 File Image Operations`_).
 
 In particular getting a memory image of an HDF5 file is possible only if the
 file has been opened with one of the following drivers: SEC2 (the default

--- a/doc/source/usersguide/installation.rst
+++ b/doc/source/usersguide/installation.rst
@@ -206,7 +206,7 @@ the relevant header files and libraries.
     :envvar:`BLOSC2_DIR` environment variables to the path to the particular
     resource.  For example::
 
-        set HDF5_DIR=c:\\stuff\\hdf5-1.8.5-32bit-VS2008-IVF101\\release
+        set HDF5_DIR=c:\\stuff\\hdf5-1.10.2-32bit-VS2008-IVF101\\release
         set BLOSC_DIR=c:\\Program Files (x86)\\Blosc
         set LZO_DIR=c:\\Program Files (x86)\\GnuWin32
         set BZIP2_DIR=c:\\Program Files (x86)\\GnuWin32
@@ -216,7 +216,7 @@ the relevant header files and libraries.
     setup.py command line.
     For example::
 
-        --hdf5=c:\\stuff\\hdf5-1.8.5-32bit-VS2008-IVF101\\release
+        --hdf5=c:\\stuff\\hdf5-1.10.1-32bit-VS2008-IVF101\\release
         --blosc=c:\\Program Files (x86)\\Blosc
         --lzo=c:\\Program Files (x86)\\GnuWin32
         --bzip2=c:\\Program Files (x86)\\GnuWin32

--- a/setup.py
+++ b/setup.py
@@ -777,6 +777,7 @@ if __name__ == "__main__":
     # 1.6.x API by default
     CFLAGS.extend([
         "-DH5_USE_110_API",
+        "-DH5Rdereference_vers=2",
     ])
 
     # H5Oget_info_by_name seems to have performance issues (see gh-402), so we

--- a/setup.py
+++ b/setup.py
@@ -827,16 +827,6 @@ if __name__ == "__main__":
                     f"required. Found version v{hdf5_version}"
                 )
 
-            if os.name == "nt" and hdf5_version < Version("1.8.10"):
-                # Change in DLL naming happened in 1.8.10
-                hdf5_old_dll_name = "hdf5dll" if not debug else "hdf5ddll"
-                package.library_name = hdf5_old_dll_name
-                package.runtime_name = hdf5_old_dll_name
-                _platdep["HDF5"] = [hdf5_old_dll_name, hdf5_old_dll_name]
-                _, libdir, rundir = package.find_directories(
-                    location, use_pkgconfig=USE_PKGCONFIG, hook=hook
-                )
-
         # check if the library is in the standard compiler paths
         if not libdir and package.target_function:
             libdir = compiler.has_function(

--- a/setup.py
+++ b/setup.py
@@ -763,7 +763,7 @@ if __name__ == "__main__":
             libdir = ctypes.util.find_library(
                 "hdf5_D.dll"
             ) or ctypes.util.find_library("hdf5ddll.dll")
-        # Like 'C:\\Program Files\\HDF Group\\HDF5\\1.8.8\\bin\\hdf5dll.dll'
+        # Like 'C:\\Program Files\\HDF Group\\HDF5\\1.10.2\\bin\\hdf5dll.dll'
         if libdir:
             # Strip off the filename and the 'bin' directory
             HDF5_DIR = Path(libdir).parent.parent
@@ -773,7 +773,7 @@ if __name__ == "__main__":
     # the Cython extensions
     CFLAGS.append("-Isrc")
 
-    # Force the 1.8.x HDF5 API even if the library as been compiled to use the
+    # Force the 1.10.x HDF5 API even if the library as been compiled to use the
     # 1.6.x API by default
     CFLAGS.extend([
         "-DH5_USE_110_API",

--- a/setup.py
+++ b/setup.py
@@ -776,30 +776,7 @@ if __name__ == "__main__":
     # Force the 1.8.x HDF5 API even if the library as been compiled to use the
     # 1.6.x API by default
     CFLAGS.extend([
-        "-DH5_USE_18_API",
-        "-DH5Acreate_vers=2",
-        "-DH5Aiterate_vers=2",
-        "-DH5Dcreate_vers=2",
-        "-DH5Dopen_vers=2",
-        "-DH5Eclear_vers=2",
-        "-DH5Eprint_vers=2",
-        "-DH5Epush_vers=2",
-        "-DH5Eset_auto_vers=2",
-        "-DH5Eget_auto_vers=2",
-        "-DH5Ewalk_vers=2",
-        "-DH5E_auto_t_vers=2",
-        "-DH5Gcreate_vers=2",
-        "-DH5Gopen_vers=2",
-        "-DH5Pget_filter_vers=2",
-        "-DH5Pget_filter_by_id_vers=2",
-        # "-DH5Pinsert_vers=2",
-        # "-DH5Pregister_vers=2",
-        # "-DH5Rget_obj_type_vers=2",
-        "-DH5Tarray_create_vers=2",
-        # "-DH5Tcommit_vers=2",
-        "-DH5Tget_array_dims_vers=2",
-        # "-DH5Topen_vers=2",
-        "-DH5Z_class_t_vers=2",
+        "-DH5_USE_110_API",
     ])
 
     # H5Oget_info_by_name seems to have performance issues (see gh-402), so we

--- a/src/utils.c
+++ b/src/utils.c
@@ -583,8 +583,8 @@ int is_complex(hid_t type_id) {
         if (class1 == H5T_FLOAT && class2 == H5T_FLOAT)
           result = 1;
       }
-      pt_H5free_memory(colname1);
-      pt_H5free_memory(colname2);
+      H5free_memory(colname1);
+      H5free_memory(colname2);
     }
   }
   /* Is an Array of Complex? */
@@ -984,26 +984,3 @@ herr_t pt_H5Pset_fapl_windows(hid_t fapl_id)
 
 #endif /* H5_HAVE_WINDOWS */
 
-
-#if (H5_HAVE_IMAGE_FILE != 1)
-/* HDF5 version < 1.8.9 */
-
-herr_t pt_H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len) {
- return -1;
-}
-
-ssize_t pt_H5Fget_file_image(hid_t file_id, void *buf_ptr, size_t buf_len) {
- return -1;
-}
-
-#endif /* (H5_HAVE_IMAGE_FILE != 1) */
-
-
-#if H5_VERSION_LE(1,8,12)
-
-herr_t pt_H5free_memory(void *buf) {
- free(buf);
- return 0;
-}
-
-#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,22 +43,7 @@
 #define H5_HAVE_DIRECT_DRIVER 0
 #endif
 
-#if (H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 8 && H5_VERS_RELEASE >= 9) || (H5_VERS_MAJOR == 1 && H5_VERS_MINOR > 8)
-/* HDF5 version >= 1.8.9 */
 #define H5_HAVE_IMAGE_FILE 1
-#else
-/* HDF5 version < 1.8.9 */
-#define H5_HAVE_IMAGE_FILE 0
-#endif
-
-/* COMAPTIBILITY: H5_VERSION_LE has been introduced in HDF5 1.8.7 */
-#ifndef H5_VERSION_LE
-#define H5_VERSION_LE(Maj,Min,Rel) \
-       (((H5_VERS_MAJOR==Maj) && (H5_VERS_MINOR==Min) && (H5_VERS_RELEASE<=Rel)) || \
-        ((H5_VERS_MAJOR==Maj) && (H5_VERS_MINOR<Min)) || \
-        (H5_VERS_MAJOR<Maj))
-#endif
-
 
 /* Use %ld to print the value because long should cover most cases. */
 /* Used to make certain a return value _is_not_ a value */
@@ -138,21 +123,3 @@ herr_t pt_H5Pset_fapl_windows(hid_t fapl_id);
 #else /* H5_HAVE_WINDOWS */
 #define pt_H5Pset_fapl_windows H5Pset_fapl_windows
 #endif /* H5_HAVE_WINDOWS */
-
-
-#if (H5_HAVE_IMAGE_FILE != 1)
-/* HDF5 version >= 1.8.9 */
-herr_t pt_H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len);
-ssize_t pt_H5Fget_file_image(hid_t file_id, void *buf_ptr, size_t buf_len);
-#else /* (H5_HAVE_IMAGE_FILE != 1) */
-/* HDF5 version < 1.8.9 */
-#define pt_H5Pset_file_image H5Pset_file_image
-#define pt_H5Fget_file_image H5Fget_file_image
-#endif /* (H5_HAVE_IMAGE_FILE != 1) */
-
-
-#if H5_VERSION_LE(1,8,12)
-herr_t pt_H5free_memory(void *buf);
-#else
-#define pt_H5free_memory H5free_memory
-#endif

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -142,36 +142,13 @@ if 'Float16Atom' in locals():
     # float16 is new in numpy 1.6.0
     __all__.extend(('Float16Atom', 'Float16Col'))
 
+if 'Float96Atom' in locals():
+    __all__.extend(('Float96Atom', 'Float96Col'))
+    __all__.extend(('Complex192Atom', 'Complex192Col'))    # XXX check
 
-from .utilsextension import _broken_hdf5_long_double
-if not _broken_hdf5_long_double():
-    if 'Float96Atom' in locals():
-        __all__.extend(('Float96Atom', 'Float96Col'))
-        __all__.extend(('Complex192Atom', 'Complex192Col'))    # XXX check
-
-    if 'Float128Atom' in locals():
-        __all__.extend(('Float128Atom', 'Float128Col'))
-        __all__.extend(('Complex256Atom', 'Complex256Col'))    # XXX check
-
-else:
-
-    from . import atom as _atom
-    from . import description as _description
-    try:
-        del _atom.Float96Atom, _atom.Complex192Col
-        del _description.Float96Col, _description.Complex192Col
-        _atom.all_types.discard('complex192')
-        _atom.ComplexAtom._isizes.remove(24)
-    except AttributeError:
-        try:
-            del _atom.Float128Atom, _atom.Complex256Atom
-            del _description.Float128Col, _description.Complex256Col
-            _atom.all_types.discard('complex256')
-            _atom.ComplexAtom._isizes.remove(32)
-        except AttributeError:
-            pass
-    del _atom, _description
-del _broken_hdf5_long_double
+if 'Float128Atom' in locals():
+    __all__.extend(('Float128Atom', 'Float128Col'))
+    __all__.extend(('Complex256Atom', 'Complex256Col'))    # XXX check
 
 
 def get_pytables_version():

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -308,7 +308,7 @@ cdef extern from "hdf5.h" nogil:
                          unsigned relnum )
 
   # misc
-  #herr_t H5free_memory(void *buf)  # new in HDF5 1.8.13
+  herr_t H5free_memory(void *buf)
 
   # Operations with files
   hid_t  H5Fcreate(char *filename, unsigned int flags,
@@ -539,9 +539,6 @@ cdef extern from "utils.h" nogil:
   herr_t pt_H5Pset_fapl_direct(hid_t fapl_id, size_t alignment,
                                size_t block_size, size_t cbuf_size)
   herr_t pt_H5Pset_fapl_windows(hid_t fapl_id)
-  herr_t pt_H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
-  ssize_t pt_H5Fget_file_image(hid_t file_id, void *buf_ptr, size_t buf_len)
-  herr_t pt_H5free_memory(void *buf)
 
   int H5_HAVE_DIRECT_DRIVER, H5_HAVE_WINDOWS_DRIVER, H5_HAVE_IMAGE_FILE
 

--- a/tables/definitions.pxd
+++ b/tables/definitions.pxd
@@ -486,7 +486,7 @@ cdef extern from "hdf5.h" nogil:
   # Operations on the references
   H5I_type_t H5Iget_type(hid_t id)
   herr_t H5Rcreate(void *reference, hid_t loc_id, const char *name, H5R_type_t type, hid_t space_id)
-  hid_t H5Rdereference(hid_t dset, H5R_type_t rtype, void *reference)
+  hid_t H5Rdereference(hid_t dset, hid_t oapl_id, H5R_type_t rtype, const void *reference)
   herr_t H5Oclose( hid_t object_id )
 
 

--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -98,7 +98,7 @@ from .definitions cimport (uintptr_t, hid_t, herr_t, hsize_t, hvl_t,
   get_len_of_range, conv_float64_timeval32, truncate_dset,
   H5_HAVE_DIRECT_DRIVER, pt_H5Pset_fapl_direct,
   H5_HAVE_WINDOWS_DRIVER, pt_H5Pset_fapl_windows,
-  H5_HAVE_IMAGE_FILE, pt_H5Pset_file_image, pt_H5Fget_file_image,
+  H5_HAVE_IMAGE_FILE, H5Pset_file_image, H5Fget_file_image,
   H5Tget_size, hobj_ref_t)
 
 cdef int H5T_CSET_DEFAULT = 16
@@ -382,9 +382,6 @@ cdef class File:
                       "the '%s' driver" % driver)
       elif not PyBytes_Check(image):
         raise TypeError("The DRIVER_CORE_IMAGE must be a string of bytes")
-      elif not H5_HAVE_IMAGE_FILE:
-        raise RuntimeError("Support for image files is only available in "
-                           "HDF5 >= 1.8.9")
 
     # After the following check we can be quite sure
     # that the file or directory exists and permissions are right.
@@ -469,7 +466,7 @@ cdef class File:
       if image:
         img_buf_len = len(image)
         img_buf_p = <void *>PyBytes_AsString(image)
-        err = pt_H5Pset_file_image(access_plist, img_buf_p, img_buf_len)
+        err = H5Pset_file_image(access_plist, img_buf_p, img_buf_len)
         if err < 0:
           H5Pclose(create_plist)
           H5Pclose(access_plist)
@@ -528,8 +525,6 @@ cdef class File:
   def get_file_image(self):
     """Retrieves an in-memory image of an existing, open HDF5 file.
 
-    .. note:: this method requires HDF5 >= 1.8.9.
-
     .. versionadded:: 3.0
 
     """
@@ -542,7 +537,7 @@ cdef class File:
     self.flush()
 
     # retrieve the size of the buffer for the file image
-    size = pt_H5Fget_file_image(self.file_id, NULL, buf_len)
+    size = H5Fget_file_image(self.file_id, NULL, buf_len)
     if size < 0:
       raise HDF5ExtError("Unable to retrieve the size of the buffer for the "
                          "file image.  Plese note that not all drivers "
@@ -555,7 +550,7 @@ cdef class File:
 
     cimage = image
     buf_len = size
-    size = pt_H5Fget_file_image(self.file_id, <void*>cimage, buf_len)
+    size = H5Fget_file_image(self.file_id, <void*>cimage, buf_len)
     if size < 0:
       raise HDF5ExtError("Unable to retrieve the file image. "
                          "Plese note that not all drivers provide support "

--- a/tables/indexesextension.pyx
+++ b/tables/indexesextension.pyx
@@ -189,7 +189,7 @@ def keysort(ndarray array1, ndarray array2):
         raise ValueError("Unknown array datatype")
 
 
-cdef inline void swap_bytes(char *x, char *y, size_t n) nogil:
+cdef inline void swap_bytes(char *x, char *y, size_t n) noexcept nogil:
     if n == 8:
         (<npy_int64*>x)[0], (<npy_int64*>y)[0] = (<npy_int64*>y)[0], (<npy_int64*>x)[0]
     elif n == 4:

--- a/tables/indexesextension.pyx
+++ b/tables/indexesextension.pyx
@@ -209,7 +209,7 @@ cdef inline int less_than(number_type* a, number_type* b) nogil:
 
 
 @cython.cdivision(True)
-cdef void _keysort(number_type* start1, char* start2, size_t elsize2, size_t n) nogil:
+cdef void _keysort(number_type* start1, char* start2, size_t elsize2, size_t n) noexcept nogil:
     cdef number_type *pl = start1
     cdef number_type *pr = start1 + (n - 1)
 
@@ -352,7 +352,7 @@ cdef void _keysort(number_type* start1, char* start2, size_t elsize2, size_t n) 
 
 
 @cython.cdivision(True)
-cdef void _keysort_string(char* start1, size_t ss, char* start2, size_t ts, size_t n) nogil:
+cdef void _keysort_string(char* start1, size_t ss, char* start2, size_t ts, size_t n) noexcept nogil:
     cdef char *pl = start1
     cdef char *pr = start1 + (n - 1) * ss
 

--- a/tables/parameters.py
+++ b/tables/parameters.py
@@ -412,8 +412,6 @@ returned file object is set up using the specified image.
 A file image can be retrieved from an existing (and opened) file object
 using the :meth:`tables.File.get_file_image` method.
 
-.. note:: requires HDF5 >= 1.8.9.
-
 .. versionadded:: 3.0
 
 """

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -61,7 +61,7 @@ from .definitions cimport (hid_t, herr_t, hsize_t, haddr_t, htri_t, hbool_t,
   H5ATTRset_attribute_string, H5ATTRset_attribute,
   get_len_of_range, get_order, set_order, is_complex,
   conv_float64_timeval32, truncate_dset,
-  pt_H5free_memory)
+  H5free_memory)
 
 from .lrucacheextension cimport ObjectCache, NumCache
 
@@ -384,7 +384,7 @@ cdef class Table(Leaf):
       # Release resources
       H5Tclose(native_member_type_id)
       H5Tclose(member_type_id)
-      pt_H5free_memory(c_colname)
+      H5free_memory(c_colname)
 
     # set the byteorder and other things (just in top level)
     if colpath == "":

--- a/tables/tests/test_create.py
+++ b/tables/tests/test_create.py
@@ -1753,8 +1753,6 @@ class DefaultDriverTestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(root.table2.cols.var2.dtype, tb.FloatCol().dtype)
 
 
-@common.unittest.skipIf(common.hdf5_version < Version("1.8.9"),
-                        "requires HDF5 >= 1.8,9")
 class Sec2DriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_SEC2"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -1765,8 +1763,6 @@ class Sec2DriverTestCase(DefaultDriverTestCase):
         self.assertEqual([i for i in image[:4]], [137, 72, 68, 70])
 
 
-@common.unittest.skipIf(common.hdf5_version < Version("1.8.9"),
-                        "requires HDF5 >= 1.8,9")
 class StdioDriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_STDIO"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -1777,8 +1773,6 @@ class StdioDriverTestCase(DefaultDriverTestCase):
         self.assertEqual([i for i in image[:4]], [137, 72, 68, 70])
 
 
-@common.unittest.skipIf(common.hdf5_version < Version("1.8.9"),
-                        "requires HDF5 >= 1.8,9")
 class CoreDriverTestCase(DefaultDriverTestCase):
     DRIVER = "H5FD_CORE"
     open_kwargs = dict(driver=DRIVER, **DefaultDriverTestCase.DRIVER_PARAMS)
@@ -2006,8 +2000,6 @@ class CoreDriverNoBackingStoreTestCase(common.PyTablesTestCase):
         # ensure that there is no change on the file on disk
         self.assertEqual(hexdigest, self._get_digest(self.h5fname))
 
-    @common.unittest.skipIf(common.hdf5_version < Version("1.8.9"),
-                            'HDF5 >= "1.8.9" required')
     def test_get_file_image(self):
         self.h5file = tb.open_file(self.h5fname, mode="w",
                                    driver=self.DRIVER,
@@ -2149,8 +2141,6 @@ class StreamDriverTestCase(NotSpportedDriverTestCase):
     DRIVER = "H5FD_STREAM"
 
 
-@common.unittest.skipIf(common.hdf5_version < Version("1.8.9"),
-                        'HDF5 >= "1.8.9" required')
 class InMemoryCoreDriverTestCase(common.PyTablesTestCase):
     DRIVER = "H5FD_CORE"
 

--- a/tables/tests/test_types.py
+++ b/tables/tests/test_types.py
@@ -210,9 +210,8 @@ class ReadFloatTestCase(common.TestFileMixin, common.PyTablesTestCase):
                     ds = getattr(self.h5file.root, dtype)
                 self.assertIsInstance(ds, tb.UnImplemented)
             except AssertionError:
-                if not tb.utilsextension._broken_hdf5_long_double():
-                    ds = getattr(self.h5file.root, dtype)
-                    self.assertEqual(ds.dtype, "float64")
+                ds = getattr(self.h5file.root, dtype)
+                self.assertEqual(ds.dtype, "float64")
 
     def test05_read_quadprecision_float(self):
         # XXX: check

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -1456,7 +1456,7 @@ cdef int load_reference(hid_t dataset_id, hobj_ref_t *refbuf, size_t item_size, 
   try:
 
     for i in range(<long>nelements):
-      refobj_id = H5Rdereference(dataset_id, H5R_OBJECT, &refbuf[i])
+      refobj_id = H5Rdereference(dataset_id, H5P_DEFAULT, H5R_OBJECT, &refbuf[i])
       if H5Iget_type(refobj_id) != H5I_DATASET:
         raise ValueError('Invalid reference type %d %d' % (H5Iget_type(refobj_id), item_size))
       disk_type_id = H5Dget_type(refobj_id)


### PR DESCRIPTION
Compatibility with HDF5 1.8.x is no longer needed, so we can switch to the newer API