### PR TITLE
Bugfix: ExternalLink again supports relative paths.

### DIFF
--- a/tables/link.py
+++ b/tables/link.py
@@ -368,7 +368,7 @@ class ExternalLink(linkextension.ExternalLink, Link):
         if not Path(filename).is_absolute():
             # Resolve the external link with respect to the this
             # file's directory.  See #306.
-            filename = str(Path(self._v_file.filename).with_name(filename))
+            filename = str(Path(self._v_file.filename).parent / filename)
 
         if self.extfile is None or not self.extfile.isopen:
             self.extfile = tb.open_file(filename, **kwargs)


### PR DESCRIPTION
Bugfix for https://github.com/PyTables/PyTables/issues/1094

In release 3.6.1 and earlier, ExternalLink allowed for using absolute as well as relative paths to specify the target file to link to.
Since release 3.7.0, only absolute paths are still supported.
The reason for this change of behavior is the code refactoring to use pathlib in ExternalLink.__call__():

```
#### from release 3.6.1 ####
if not os.path.isabs(filename):
    # Resolve the external link with respect to the this
    # file's directory.  See #306.
    base_directory = os.path.dirname(self._v_file.filename)
    filename = os.path.join(base_directory, filename)
```
```
#### from release 3.7.0 ####
if not Path(filename).is_absolute():
    # Resolve the external link with respect to the this
    # file's directory.  See #306.
    filename = str(Path(self._v_file.filename).with_name(filename))
```
The function Path.with_name() only accepts file names and raises an error if the file name contains a ‘/’.
As a result, absolute path, relative paths, and file names were supported before release 3.7.0 but only absolute path and file names are supported since release 3.7.0.