### PR TITLE
Store cpuinfo in a cache file for performance

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -24,7 +24,6 @@ def read_cached_cpu_info():
 
 
 def write_cached_cpu_info(cpu_info_dict):
-    """ Update the cached CPU info in the rc file."""
     with open(Path.home() / '.pytables-cpuinfo.json', 'w') as f:
         return json.dump(cpu_info_dict, f, indent=4)
 

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -25,7 +25,7 @@ def read_cached_cpu_info():
 
 def write_cached_cpu_info(cpu_info_dict):
     with open(Path.home() / '.pytables-cpuinfo.json', 'w') as f:
-        return json.dump(cpu_info_dict, f, indent=4)
+        json.dump(cpu_info_dict, f, indent=4)
 
 
 @lru_cache(maxsize=1)

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -15,24 +15,18 @@ from .utils import byteorders, lazyattr, SizeType
 from .exceptions import PerformanceWarning
 
 
-def read_rc():
+def read_cached_cpu_info():
     try:
-        with open(Path.home() / '.pytablesrc.json', 'r') as f:
+        with open(Path.home() / '.pytables-cpuinfo.json', 'r') as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
 
 
-def read_cached_cpu_info():
-    return read_rc().get('cpu_info', {})
-
-
 def write_cached_cpu_info(cpu_info_dict):
     """ Update the cached CPU info in the rc file."""
-    rc = read_rc()
-    with open(Path.home() / '.pytablesrc.json', 'w') as f:
-        rc['cpu_info'] = cpu_info_dict
-        return json.dump(rc, f, indent=4)
+    with open(Path.home() / '.pytables-cpuinfo.json', 'w') as f:
+        return json.dump(cpu_info_dict, f, indent=4)
 
 
 @lru_cache(maxsize=1)

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -3,6 +3,7 @@ import warnings
 import math
 import json
 from pathlib import Path
+from functools import lru_cache
 
 import numpy as np
 
@@ -34,6 +35,7 @@ def write_cached_cpu_info(cpu_info_dict):
         return json.dump(rc, f, indent=4)
 
 
+@lru_cache(maxsize=1)
 def get_cpu_info():
     cached_info = read_cached_cpu_info()
     if cached_info:


### PR DESCRIPTION
This is yet another fix related to the discussion in issue #1081 

Benefit of this approach:
- the file cache will be available for different processes
- the cpuinfo needs to be processed only once per machine/user

Json format was the first that came to my mind. It could be changed to something else.