### PR TITLE
Add type hints to node.py

### DIFF
--- a/tables/node.py
+++ b/tables/node.py
@@ -185,7 +185,7 @@ class Node(metaclass=MetaNode):
 
     # The ``_log`` argument is only meant to be used by ``_g_copy_as_child()``
     # to avoid logging the creation of children nodes of a copied sub-tree.
-    def __init__(self, parentnode: Union["Group", SoftLink], name: str,
+    def __init__(self, parentnode: Union["Group", "SoftLink"], name: str,
                  _log: bool=True) -> None:
         # Remember to assign these values in the root group constructor
         # as it does not use this method implementation!


### PR DESCRIPTION
Hello,

I added type hints to `tables/node.py`.

Note: at the beginning I used 
~~~
if TYPE_CHECKING:
    from .group import Group
    from .link import SoftLink
~~~

This is to prevent circular imports as the `tables/group.py` already imports the `tables/node.py`. 

By putting the needed imports behind a [typing.TYPE_CHECKING](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) flag (which always evaluates to `False`), we can use the full type hint support without any need for refactoring.

Best regards
Ko