### PR TITLE
Fix Leaf.copy by providing the correct value to createparents parameter

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -695,7 +695,7 @@ very small/large chunksize, you may want to increase/decrease it."""
         """
 
         return self._f_copy(
-            newparent, newname, overwrite, createparents, **kwargs)
+            newparent, newname, overwrite, createparents=createparents, **kwargs)
 
     def truncate(self, size):
         """Truncate the main dimension to be size rows.


### PR DESCRIPTION
Hello,

I fixed the `Leaf.copy` method by providing `createparents` as a keyword argument as mentioned in #1125 

Best regards,
Ko