### PR TITLE
BUG: Fix bug with pull_request level

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,11 @@ on:
       - 'ci/**'
     tags:
       - v*
-    pull_request:
+  pull_request:
+    branches:
+      - master
+      - 'releases/**'
+      - 'ci/**'
   release:
     types:
       - published
@@ -213,7 +217,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-          
+
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: ./wheelhouse/


### PR DESCRIPTION
This is a fairly trivial PR to make it so the wheel build runs on PRs. I think it was meant to before as well but the `pull_request:` block was indented too far.

Assuming this is okay, please merge (whatever the CI status is) and then I'll work on actually fixing the broken wheel build. (If I try to fix it in this PR, it will probably require maintainer approval with every commit which won't work well. Once this is merged GitHub will trust me enough in the next PR that I can push commits and CIs will run.)