### PR TITLE
MAINT: Fix delvewheel Windows error

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           environment-name: build
           create-args: >
-            python=3.12 blosc c-blosc2 bzip2 hdf5 lz4 lzo snappy zstd zlib pkgconfig
+            python=3.12 blosc bzip2 hdf5 lz4 lzo snappy zstd zlib pkgconfig
           init-shell: bash powershell
         if: runner.os == 'Windows'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           environment-name: build
           create-args: >
-            python=3.12 blosc bzip2 hdf5 lz4 lzo snappy zstd zlib pkgconfig
+            python=3.12 blosc c-blosc2 bzip2 hdf5 lz4 lzo snappy zstd zlib pkgconfig
           init-shell: bash powershell
         if: runner.os == 'Windows'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ before-build = [
     "python -m pip install delvewheel",
 ]
 # We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
-repair-wheel-command = "delvewheel repair --no-dll libblosc2.dll -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --no-dll libblosc2.dll -v -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ before-build = [
     "python -m pip install -q --require-hashes -r requirements.txt",
     "python -m pip install delvewheel",
 ]
-repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --ignore-existing -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ before-build = [
     "python -m pip install -q --require-hashes -r requirements.txt",
     "python -m pip install delvewheel",
 ]
-repair-wheel-command = "delvewheel repair --ignore-existing -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --analyze-existing -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ before-build = [
     "python -m pip install delvewheel",
 ]
 # We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
-repair-wheel-command = "delvewheel repair --no-dll libblosc2.dll -v -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --add-dll libblosc2.dll -v -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ before-build = [
     "python -m pip install -q --require-hashes -r requirements.txt",
     "python -m pip install delvewheel",
 ]
-# We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
+# We check for "libblosc2.dll" so don't let delvewheel mangle it
 repair-wheel-command = "delvewheel repair --no-mangle libblosc2.dll -v -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,10 @@ tables = [ "*.dll", "*.so*", "*.dylib" ]
 skip = "*-musllinux_*"
 build = "cp*"
 build-verbosity = 3
-test-command = "python -m tables.tests.test_all"
+test-command = [
+    "python -c \"import tables; keys = 'zlib lzo bzip2 blosc blosc2'.split(); have = [tables.which_lib_version(key) is not None for key in keys]; assert have == [True] * 5, [key for key, has in zip(keys, have) if not has]\"",
+    "python -m tables.tests.test_all",
+]
 test-skip = "*_aarch64"
 # Keep in sync with ``build-system.requires`` above
 before-build = "python -m pip install -q --require-hashes -r .github/workflows/requirements/build-requirements.txt -r requirements.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ before-build = [
     "python -m pip install delvewheel",
 ]
 # We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
-repair-wheel-command = "delvewheel repair --analyze-existing --add-dll libblosc2.dll -v -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --no-mangle libblosc2.dll -v -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ before-build = [
     "python -m pip install delvewheel",
 ]
 # We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
-repair-wheel-command = "delvewheel repair --add-dll libblosc2.dll -v -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --analyze-existing --add-dll libblosc2.dll -v -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ skip = "*-musllinux_*"
 build = "cp*"
 build-verbosity = 3
 test-command = [
-    "python -c \"import tables; keys = 'zlib lzo bzip2 blosc blosc2'.split(); have = [tables.which_lib_version(key) is not None for key in keys]; assert have == [True] * 5, [key for key, has in zip(keys, have) if not has]\"",
+    "python -c \"import tables; keys = 'zlib lzo bzip2 blosc blosc2'.split(); missing = [key for key in keys if tables.which_lib_version(key) is None]; assert missing == [], missing\"",
     "python -m tables.tests.test_all",
 ]
 test-skip = "*_aarch64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,8 @@ before-build = [
     "python -m pip install -q --require-hashes -r requirements.txt",
     "python -m pip install delvewheel",
 ]
-repair-wheel-command = "delvewheel repair --analyze-existing -w {dest_dir} {wheel}"
+# We manually vendor libblosc2.dll in the wheel so no need for delvewheel to do it
+repair-wheel-command = "delvewheel repair --no-dll libblosc2.dll -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows.environment]
 DISABLE_AVX2 = "TRUE"

--- a/setup.py
+++ b/setup.py
@@ -955,7 +955,7 @@ if __name__ == "__main__":
                     dll_dir = f"{CONDA_PREFIX}\\Library\\bin"
                     # Copy dlls when producing the wheels in CI
                     if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
-                        # If building a wheel and Conda in use, these will be the
+                        # If building a wheel and Conda in use, these could be the
                         # same path. Indicative that the ``rundir`` check is probably
                         # not sufficient above, but easy enough to guard against
                         # trying to copy a file to its current location

--- a/setup.py
+++ b/setup.py
@@ -666,7 +666,7 @@ if __name__ == "__main__":
         # conda recently got rid of bz2.dll in favor of libbz2.dll
         # https://github.com/conda-forge/bzip2-feedstock/pull/24#pullrequestreview-2178290795
         if CONDA_PREFIX:
-            _platdep["BZ2"] = ["libbz2", "libbz2"],
+            _platdep["BZ2"] = ["libbz2", "libbz2"]
 
         # Copy the next DLL's to binaries by default.
         dll_files = [

--- a/setup.py
+++ b/setup.py
@@ -955,9 +955,15 @@ if __name__ == "__main__":
                     dll_dir = f"{CONDA_PREFIX}\\Library\\bin"
                     # Copy dlls when producing the wheels in CI
                     if "bdist_wheel" in sys.argv and os.path.exists(dll_dir):
-                        shutil.copy(
-                            libdir.parent / "bin" / "libblosc2.dll", dll_dir
-                        )
+                        # If building a wheel and Conda in use, these will be the
+                        # same path. Indicative that the ``rundir`` check is probably
+                        # not sufficient above, but easy enough to guard against
+                        # trying to copy a file to its current location
+                        # (thereby avoiding a "are the same file" shutil error).
+                        if Path(dll_dir) != libdir.parent / "bin":
+                            shutil.copy(
+                                libdir.parent / "bin" / "libblosc2.dll", dll_dir
+                            )
                     else:
                         shutil.copy(
                             libdir.parent / "bin" / "libblosc2.dll", "tables"

--- a/setup.py
+++ b/setup.py
@@ -663,6 +663,10 @@ if __name__ == "__main__":
             "BLOSC": ["blosc", "blosc"],
             "BLOSC2": ["blosc2", "blosc2"],
         }
+        # conda recently got rid of bz2.dll in favor of libbz2.dll
+        # https://github.com/conda-forge/bzip2-feedstock/pull/24#pullrequestreview-2178290795
+        if CONDA_PREFIX:
+            _platdep["BZ2"] = ["libbz2", "libbz2"],
 
         # Copy the next DLL's to binaries by default.
         dll_files = [

--- a/tables/__init__.py
+++ b/tables/__init__.py
@@ -27,6 +27,8 @@ blosc2_found = False
 blosc2_search_paths = [
     blosc2_lib_hardcoded,
     os.path.join(current_dir, blosc2_lib_hardcoded),
+    # delvewheel will put it here
+    os.path.join(os.path.dirname(current_dir), "tables.libs", blosc2_lib_hardcoded),
 ]
 if find_library("blosc2"):
     blosc2_search_paths.append(find_library("blosc2"))


### PR DESCRIPTION
Poking around I noticed `master` is failing due to a `delvewheel` problem where it can't find `libblosc2`. I think installing it from conda might be enough to fix it, but we'll see :crossed_fingers: 