### PR TITLE
Fix B2ND compression with  Fletcher32

### DIFF
--- a/doc/source/usersguide/optimization.rst
+++ b/doc/source/usersguide/optimization.rst
@@ -236,10 +236,11 @@ performance of the HDF5 filter.
 
 Optimized b2nd slicing in PyTables has its limitations, though: it only works
 with contiguous slices (that is, with step 1 on every dimension) and on
-datasets with the same byte ordering as the host machine.  However, the
-performance gains may be worth the extra effort of choosing the right
-compression parameters and chunksizes when your use case is not affected by
-those limitations.
+datasets with the same byte ordering as the host machine and where Blosc2 is
+the only filter in the HDF5 pipeline (e.g. Fletcher32 checksumming is off).
+However, the performance gains may be worth the extra effort of choosing the
+right compression parameters and chunksizes when your use case is not affected
+by those limitations.
 
 
 .. _directChunking:

--- a/hdf5-blosc/src/example.c
+++ b/hdf5-blosc/src/example.c
@@ -72,12 +72,6 @@ int main(){
     r = H5Pset_chunk(plist, 3, chunkshape);
     if(r<0) goto failed;
 
-    /* Using the blosc filter in combination with other ones also works */
-    /*
-    r = H5Pset_fletcher32(plist);
-    if(r<0) goto failed;
-    */
-
     /* This is the easiest way to call Blosc with default values: 5
      for BloscLZ and shuffle active. */
     /* r = H5Pset_filter(plist, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 0, NULL); */
@@ -92,6 +86,13 @@ int main(){
     r = H5Pset_filter(plist, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values);
 
     if(r<0) goto failed;
+
+    /* Using the blosc filter in combination with other ones also works
+     (if they change data structure, they should come last) */
+    /*
+    r = H5Pset_fletcher32(plist);
+    if(r<0) goto failed;
+    */
 
 #if H5_USE_16_API
     dset = H5Dcreate(fid, "dset", H5T_NATIVE_FLOAT, sid, plist);

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -463,6 +463,15 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
     /* declare dummy variables */
     int32_t cbytes;
 
+    /* It would be cool to have a check to detect whether the buffer contains
+     * an unexpected amout of bytes because of the application of a previous
+     * filter (e.g. a Fletcher32 checksum), thus disabling B2ND optimizations.
+     * However, we cannot know before parsing the super-chunk, and that
+     * operation accepts trailing bytes without reporting their presence.
+     * Thus such a test can only happen outside of the filter, with more
+     * information available about the whole pipeline setup.
+     */
+
     blosc2_schunk* schunk = blosc2_schunk_from_buffer(*buf, (int64_t)nbytes, false);
     if (schunk == NULL) {
       PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot get super-chunk from buffer");

--- a/src/H5ARRAY-opt.c
+++ b/src/H5ARRAY-opt.c
@@ -346,15 +346,11 @@ hid_t H5ARRAYOmake(hid_t loc_id,
        Dataset creation property list is modified to use
     */
 
-    /* Fletcher must be first */
-    if (fletcher32) {
-      IF_NEG_OUT(H5Pset_fletcher32(plist_id));
-    }
-    /* Then shuffle (blosc shuffles inplace) */
+    /* First shuffle (blosc shuffles inplace) */
     if ((shuffle && compress) && (strncmp(complib, "blosc", 5) != 0)) {
       IF_NEG_OUT(H5Pset_shuffle(plist_id));
     }
-    /* Finally compression */
+    /* Then compression */
     if (compress) {
       cd_values[0] = compress;
       cd_values[1] = (int) (atof(obversion) * 10);
@@ -424,6 +420,10 @@ hid_t H5ARRAYOmake(hid_t loc_id,
         /* Compression library not supported */
         IF_TRUE_OUT_DO(true, fprintf(stderr, "Compression library not supported\n"));
       }
+    }
+    /* Fletcher must be last, as it alters chunk length */
+    if (fletcher32) {
+      IF_NEG_OUT(H5Pset_fletcher32(plist_id));
     }
 
     /* Create the (chunked) dataset */

--- a/src/H5ARRAY.c
+++ b/src/H5ARRAY.c
@@ -108,17 +108,12 @@ hid_t H5ARRAYmake(  hid_t loc_id,
       Dataset creation property list is modified to use
    */
 
-   /* Fletcher must be first */
-   if (fletcher32) {
-     if ( H5Pset_fletcher32( plist_id) < 0 )
-       return -1;
-   }
-   /* Then shuffle (blosc shuffles inplace) */
+   /* First shuffle (blosc shuffles inplace) */
    if ((shuffle && compress) && (strncmp(complib, "blosc", 5) != 0)) {
      if ( H5Pset_shuffle( plist_id) < 0 )
        return -1;
    }
-   /* Finally compression */
+   /* Then compression */
    if (compress) {
      cd_values[0] = compress;
      cd_values[1] = (int)(atof(obversion) * 10);
@@ -181,6 +176,11 @@ hid_t H5ARRAYmake(  hid_t loc_id,
        fprintf(stderr, "Compression library not supported\n");
        return -1;
      }
+   }
+   /* Fletcher must be last, as it alters chunk length */
+   if (fletcher32) {
+     if ( H5Pset_fletcher32( plist_id) < 0 )
+       return -1;
    }
 
    /* Create the (chunked) dataset */

--- a/src/H5TB-opt.c
+++ b/src/H5TB-opt.c
@@ -178,17 +178,12 @@ hid_t H5TBOmake_table(  const char *table_title,
   Dataset creation property list is modified to use filters
   */
 
- /* Fletcher must be first */
- if (fletcher32) {
-   if ( H5Pset_fletcher32( plist_id) < 0 )
-     return -1;
- }
- /* Then shuffle (blosc/blosc2 shuffles inplace) */
+ /* First shuffle (blosc/blosc2 shuffles inplace) */
  if ((shuffle && compress) && (strncmp(complib, "blosc", 5) != 0)) {
    if ( H5Pset_shuffle( plist_id) < 0 )
      return -1;
  }
- /* Finally compression */
+ /* Then compression */
  if ( compress )
  {
    cd_values[0] = compress;
@@ -261,6 +256,11 @@ hid_t H5TBOmake_table(  const char *table_title,
      return -1;
    }
 
+ }
+ /* Fletcher must be last, as it alters chunk length */
+ if (fletcher32) {
+   if ( H5Pset_fletcher32( plist_id) < 0 )
+     return -1;
  }
 
  /* Create the dataset. */

--- a/src/H5VLARRAY.c
+++ b/src/H5VLARRAY.c
@@ -100,17 +100,12 @@ hid_t H5VLARRAYmake(  hid_t loc_id,
     Dataset creation property list is modified to use
  */
 
- /* Fletcher must be first */
- if (fletcher32) {
-   if ( H5Pset_fletcher32( plist_id) < 0 )
-     return -1;
- }
- /* Then shuffle (blosc shuffles inplace) */
+ /* First shuffle (blosc shuffles inplace) */
  if ((shuffle && compress) && (strncmp(complib, "blosc", 5) != 0)) {
    if ( H5Pset_shuffle( plist_id) < 0 )
      return -1;
  }
- /* Finally compression */
+ /* Then compression */
  if (compress) {
    cd_values[0] = compress;
    cd_values[1] = (int)(atof(obversion) * 10);
@@ -152,6 +147,11 @@ hid_t H5VLARRAYmake(  hid_t loc_id,
      fprintf(stderr, "Compression library not supported\n");
      return -1;
    }
+ }
+ /* Fletcher must be last, as it alters chunk length */
+ if (fletcher32) {
+   if ( H5Pset_fletcher32( plist_id) < 0 )
+     return -1;
  }
 
  /* Create the dataset. */

--- a/tables/tableextension.pyx
+++ b/tables/tableextension.pyx
@@ -223,6 +223,7 @@ cdef class Table(Leaf):
     # Decide whether Blosc2 optimized operations can be used.
     self.blosc2_support_write = (
         (self.byteorder == sys.byteorder) and
+        (not self.filters.fletcher32) and
         (self.filters.complib is not None) and
         (self.filters.complib.startswith("blosc2")))
     # For reading, Windows does not support re-opening a file twice

--- a/tables/tests/test_carray.py
+++ b/tables/tests/test_carray.py
@@ -800,6 +800,13 @@ class Blosc2ComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc2_avail,
                         'BLOSC2 compression library not available')
+class Blosc2FletcherTestCase(Blosc2ComprTestCase):
+    fletcher32 = 1
+    start = 0
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
 class Blosc2CrossChunkTestCase(BasicTestCase):
     shape = (10, 10)
     compress = 1  # sss
@@ -2933,6 +2940,7 @@ def suite():
         theSuite.addTest(common.make_suite(BloscZlibTestCase))
         theSuite.addTest(common.make_suite(BloscZstdTestCase))
         theSuite.addTest(common.make_suite(Blosc2ComprTestCase))
+        theSuite.addTest(common.make_suite(Blosc2FletcherTestCase))
         theSuite.addTest(common.make_suite(Blosc2CrossChunkTestCase))
         theSuite.addTest(common.make_suite(Blosc2CrossChunkOptTestCase))
         theSuite.addTest(common.make_suite(Blosc2PastLastChunkTestCase))

--- a/tables/tests/test_earray.py
+++ b/tables/tests/test_earray.py
@@ -894,6 +894,13 @@ class Blosc2ComprTestCase(BasicTestCase):
 
 @common.unittest.skipIf(not common.blosc2_avail,
                         'BLOSC2 compression library not available')
+class Blosc2FletcherTestCase(Blosc2ComprTestCase):
+    fletcher32 = 1
+    start = 0
+
+
+@common.unittest.skipIf(not common.blosc2_avail,
+                        'BLOSC2 compression library not available')
 class Blosc2CrossChunkTestCase(BasicTestCase):
     shape = (0, 10)
     compress = 1  # sss
@@ -2903,6 +2910,7 @@ def suite():
         theSuite.addTest(common.make_suite(BloscShuffleTestCase))
         theSuite.addTest(common.make_suite(Blosc2SlicesOptEArrayTestCase))
         theSuite.addTest(common.make_suite(Blosc2ComprTestCase))
+        theSuite.addTest(common.make_suite(Blosc2FletcherTestCase))
         theSuite.addTest(common.make_suite(Blosc2CrossChunkTestCase))
         theSuite.addTest(common.make_suite(Blosc2CrossChunkOptTestCase))
         theSuite.addTest(common.make_suite(Blosc2InnerCrossChunkTestCase))


### PR DESCRIPTION
This changes the default filter order to put the Fletcher32 filter at the end of the pipeline, after compression filters. This doesn't make much difference for byte-oriented compressors, but it does for B2ND compression since it understands the structure of data in the chunk. If the Fletcher32 checksum was added before compression to the end of the buffer passed to the Blosc2 filter, it just ignored that data, which caused checksum verification issues on decompression.

By performing and adding the checksum after compression, the compressor doesn't need to worry about the checksum being there (nor does decompression). Of course, this means that enabling Fletcher32 adds 4 bytes to each chunk, but compressing them as part of the data didn't make much sense either.

Some checks have been added to the Blosc2 filter to detect the presence of extra pipeline filters or chunk bytes and disable B2ND optimized read/write in that case.

Fixes #1162.