### PR TITLE
MAINT: Lower verbosity in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ tables = [ "*.dll", "*.so*", "*.dylib" ]
 [tool.cibuildwheel]
 skip = "*-musllinux_* cp313*"
 build = "cp*"
-build-verbosity = 2
+build-verbosity = 1
 test-command = [
     "python -c \"import tables; keys = 'zlib bzip2 blosc blosc2'.split(); missing = [key for key in keys if tables.which_lib_version(key) is None]; assert missing == [], missing\"",
     "python -m tables.tests.test_all",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ tables = [ "*.dll", "*.so*", "*.dylib" ]
 [tool.cibuildwheel]
 skip = "*-musllinux_* cp313*"
 build = "cp*"
-build-verbosity = 3
+build-verbosity = 2
 test-command = [
     "python -c \"import tables; keys = 'zlib bzip2 blosc blosc2'.split(); missing = [key for key in keys if tables.which_lib_version(key) is None]; assert missing == [], missing\"",
     "python -m tables.tests.test_all",

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -1,6 +1,7 @@
 """Run all test cases."""
 
 import faulthandler
+import os
 import sys
 
 import numpy as np
@@ -11,7 +12,9 @@ from tables.tests import common
 from tables.tests.test_suite import suite, test
 
 
-faulthandler.enable()
+# Give people a way to opt out of enabling faulthandler
+if os.getenv("PYTABLES_DISABLE_FAULTHANDLER", "").lower() not in ("1", "true"):
+    faulthandler.enable()
 
 
 def get_tuple_version(hexversion):

--- a/tables/tests/test_all.py
+++ b/tables/tests/test_all.py
@@ -1,5 +1,6 @@
 """Run all test cases."""
 
+import faulthandler
 import sys
 
 import numpy as np
@@ -8,6 +9,9 @@ from packaging.version import Version
 import tables as tb
 from tables.tests import common
 from tables.tests.test_suite import suite, test
+
+
+faulthandler.enable()
 
 
 def get_tuple_version(hexversion):


### PR DESCRIPTION
I noticed that the scheduled `nightly` wheel build didn't finish:

https://github.com/PyTables/PyTables/actions/runs/10340087060/job/28620253697

But it's very difficult to parse the log because of the *very* long `pip` output. I want to reduce that and fix the build if necessary.