### PR TITLE
FIX: Pass `refcheck=False` to `np.ndarray.resize()` for PyPy compat

### DIFF
--- a/tables/tests/test_direct_chunk.py
+++ b/tables/tests/test_direct_chunk.py
@@ -252,7 +252,7 @@ class XDirectChunkingTestCase(DirectChunkingTestCase):
             self.array.truncate(self.shape[0] - 1)
 
         new_obj = self.obj.copy()
-        new_obj.resize(self.array.shape)
+        new_obj.resize(self.array.shape, refcheck=False)
         obj_slice = tuple(slice(s, s + cs) for (s, cs)
                           in zip(chunk_start, self.chunkshape))
         if not shrink_after:


### PR DESCRIPTION
Pass `refcheck=False` when resizing an `np.ndarray` in place, in order to fix a test failure on PyPy3:

```pytb
Traceback (most recent call last):
  File "/tmp/PyTables/tables/tests/test_direct_chunk.py", line 266, in test_write_chunk_missing1
    return self._test_write_chunk_missing(shrink_after=False)
  File "/tmp/PyTables/tables/tests/test_direct_chunk.py", line 255, in _test_write_chunk_missing
    new_obj.resize(self.array.shape)
ValueError: cannot resize an array with refcheck=True on PyPy.
Use the np.resize function or refcheck=False
```

Since the object is created immediately above the `.resize()` call, adding `refcheck=False` should be entirely safe.  Furthermore, unlike `np.resize()` this preserves the current behavior when new shape is larger than the original.

Fixes #1202