### PR TITLE
Type hints: Accept IsDescription, dict, numpy.dtype as table descriptions

### DIFF
--- a/tables/description.py
+++ b/tables/description.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Any, Callable, Generator, Literal, Optional, Sequence, Type, Union
 
 import numpy as np
+import numpy.typing as npt
 
 from . import atom
 from .path import check_name_validity
@@ -847,7 +848,7 @@ class IsDescription(metaclass=MetaIsDescription):
     """
 
 
-def descr_from_dtype(dtype_: np.dtype,
+def descr_from_dtype(dtype_: npt.DTypeLike,
                      ptparams: Optional[dict[str, Any]]=None) -> tuple[Description, str]:
     """Get a description instance and byteorder from a (nested) NumPy dtype."""
 

--- a/tables/file.py
+++ b/tables/file.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Generator, Iterator, Literal, Optional, Type, 
 
 import numexpr as ne
 import numpy as np
+import numpy.typing as npt
 
 from . import hdf5extension
 from . import utilsextension
@@ -914,7 +915,7 @@ class File(hdf5extension.File):
     def create_table(self,
                      where: Union[Group, str],
                      name: str,
-                     description: Union[dict, Type[IsDescription], Description, np.dtype, None]=None,
+                     description: Union[dict, Type[IsDescription], Description, npt.DTypeLike, None]=None,
                      title: str="",
                      filters: Optional[Filters]=None,
                      expectedrows: int=10_000,

--- a/tables/file.py
+++ b/tables/file.py
@@ -15,7 +15,7 @@ import weakref
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Generator, Iterator, Literal, Optional, Union
+from typing import Any, Callable, Generator, Iterator, Literal, Optional, Type, Union
 
 import numexpr as ne
 import numpy as np
@@ -914,7 +914,7 @@ class File(hdf5extension.File):
     def create_table(self,
                      where: Union[Group, str],
                      name: str,
-                     description: Optional[Description]=None,
+                     description: Union[dict, Type[IsDescription], Description, np.dtype, None]=None,
                      title: str="",
                      filters: Optional[Filters]=None,
                      expectedrows: int=10_000,

--- a/tables/table.py
+++ b/tables/table.py
@@ -15,6 +15,7 @@ from typing import (
 
 import numexpr as ne
 import numpy as np
+import numpy.typing as npt
 
 from . import tableextension
 from .lrucacheextension import ObjectCache, NumCache
@@ -657,7 +658,7 @@ class Table(tableextension.Table, Leaf):
     def __init__(self,
                  parentnode: "Group",
                  name: str,
-                 description: Union[dict, Type[IsDescription], Description, np.dtype, None]=None,
+                 description: Union[dict, Type[IsDescription], Description, npt.DTypeLike, None]=None,
                  title: str="",
                  filters: Optional["Filters"]=None,
                  expectedrows: Optional[int]=None,


### PR DESCRIPTION
Updates the type hints on `File.create_table`'s `description` argument to allow `dict`, `numpy.dtype`, and `Type[IsDescription]` in addition to `Description`. This matches both the actual functionality, and the type hints of `Table.__init__`.