### PR TITLE
fixes error writing cpu info to cache file

### DIFF
--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -59,11 +59,16 @@ def get_cpu_info() -> dict[str, Any]:
 
     try:
         import cpuinfo
-        cpu_info_dict = cpuinfo.get_cpu_info()
-        write_cached_cpu_info(cpu_info_dict)
-        return cpu_info_dict
     except ImportError:
         return {}
+    cpu_info_dict = cpuinfo.get_cpu_info()
+    try:
+        write_cached_cpu_info(cpu_info_dict)
+    except IOError:
+        # cpu info cannot be stored.
+        # will need to be recomputed in the next process
+        pass
+    return cpu_info_dict
 
 
 def csformula(expected_mb: int) -> int:


### PR DESCRIPTION
fixes issue #1221. 

If ~/.pytables-cpuinfo.json cannot be written (e.g. readonly), the cpu info will now simply 
be cached during the process lifespan (lru-cache) and will need to be recomputed in the next
process. 
