### PR TITLE
Patch to find runtime dir on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -518,7 +518,7 @@ class BasePackage:
                 else:
                     directories[idx] = Path(path).parent
             else:
-                print("Error: path is not set.")
+                print("Warning: path is not set.")
         return tuple(directories)
 
 

--- a/setup.py
+++ b/setup.py
@@ -359,16 +359,37 @@ class BasePackage:
         # (The argument is accepted for compatibility with previous
         # methods.)
 
+        # Try just library name, relying on the OS search path.
+        # This fails on macOS.
         # dlopen() won't tell us where the file is, just whether
         # success occurred, so this returns True instead of a filename
+        # Try this before the absolute path search below: A Valentino
         for prefix in self._runtime_prefixes:
             for suffix in self._runtime_suffixes:
+                path = f"{prefix}{self.runtime_name}{suffix}"
+                print("find_runtime_path() trying ", path)
+                      
                 try:
-                    ctypes.CDLL(f"{prefix}{self.runtime_name}{suffix}")
+                    ctypes.CDLL(path)
                 except OSError:
                     pass
                 else:
                     return True
+
+        # If the library was not found by name alone, try absolute pathnames.
+        # In this case, we can return the path, rather than just True.
+        for location in locations:
+            for prefix in self._runtime_prefixes:
+                for suffix in self._runtime_suffixes:
+                    abs_path = f"{location}/{prefix}{self.runtime_name}{suffix}"
+                    print("find_runtime_path() trying ", abs_path)
+                          
+                    try:
+                        ctypes.CDLL(abs_path)
+                    except OSError:
+                        pass
+                    else:
+                        return abs_path
 
     def _pkg_config(self, flags):
         try:
@@ -496,7 +517,8 @@ class BasePackage:
                     directories[idx] = Path(path[: path.rfind(name)])
                 else:
                     directories[idx] = Path(path).parent
-
+            else:
+                print("Error: path is not set.")
         return tuple(directories)
 
 

--- a/setup.py
+++ b/setup.py
@@ -389,7 +389,9 @@ class BasePackage:
                     except OSError:
                         pass
                     else:
-                        return abs_path
+                        # Might foul the logic in caller: return abs_path
+                        # Be consistent with name-only search above
+                        return True
 
     def _pkg_config(self, flags):
         try:

--- a/setup.py
+++ b/setup.py
@@ -370,7 +370,7 @@ class BasePackage:
         for prefix in self._runtime_prefixes:
             for suffix in self._runtime_suffixes:
                 path = f"{prefix}{self.runtime_name}{suffix}"
-                print("find_runtime_path() trying ", path)
+                # Debug: print("find_runtime_path() trying ", path)
                       
                 try:
                     ctypes.CDLL(path)
@@ -385,14 +385,15 @@ class BasePackage:
             for prefix in self._runtime_prefixes:
                 for suffix in self._runtime_suffixes:
                     abs_path = f"{location}/{prefix}{self.runtime_name}{suffix}"
-                    print("find_runtime_path() trying ", abs_path)
+                    # Debug: print("find_runtime_path() trying ", abs_path)
                           
                     try:
                         ctypes.CDLL(abs_path)
                     except OSError:
                         pass
                     else:
-                        # Might foul the logic in caller: return abs_path
+                        # Returning path might foul the logic in caller
+                        # return abs_path
                         # Be consistent with name-only search above
                         return True
 

--- a/setup.py
+++ b/setup.py
@@ -369,11 +369,8 @@ class BasePackage:
         # Try this before the absolute path search below: A Valentino
         for prefix in self._runtime_prefixes:
             for suffix in self._runtime_suffixes:
-                path = f"{prefix}{self.runtime_name}{suffix}"
-                # Debug: print("find_runtime_path() trying ", path)
-                      
                 try:
-                    ctypes.CDLL(path)
+                    ctypes.CDLL(f"{prefix}{self.runtime_name}{suffix}")
                 except OSError:
                     pass
                 else:
@@ -523,8 +520,8 @@ class BasePackage:
                     directories[idx] = Path(path[: path.rfind(name)])
                 else:
                     directories[idx] = Path(path).parent
-            else:
-                print("Warning: path is not set.")
+            #else:
+            #    print("Warning: path is not set.")
         return tuple(directories)
 
 


### PR DESCRIPTION
This fixes failures  of ctypes.CDLL() to find locate dylibs on macOS, per #1219.