### PR TITLE
MAINT: Fix wheel build and use native aarch64 runner

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # Keep in sync with "Prerequisites" in User's Guide.
-      HDF5_VERSION: 1.14.3  # H5Dchunk_iter needs at least 1.14.1
+      HDF5_VERSION: 1.14.6  # H5Dchunk_iter needs at least 1.14.1
       MACOSX_DEPLOYMENT_TARGET: "10.9"
     strategy:
       fail-fast: false
@@ -91,16 +91,9 @@ jobs:
           - os: windows-latest
             arch: AMD64
             build: 'cp*'
-          # The aarch64 wheels are very slow so split into separate jobs
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: aarch64
-            build: 'cp311-*'
-          - os: ubuntu-latest
-            arch: aarch64
-            build: 'cp312-*'
-          - os: ubuntu-latest
-            arch: aarch64
-            build: 'cp313-*'
+            build: 'cp*'
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -122,10 +115,6 @@ jobs:
             python=3.12 blosc c-blosc2 bzip2 hdf5 lz4 snappy zstd zlib pkgconfig
           init-shell: bash powershell
         if: runner.os == 'Windows'
-
-      - uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
-        if: runner.os == 'Linux' && matrix.arch != 'x64_64'
-        name: Set up QEMU on Linux
 
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: deps-cache

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,6 +26,8 @@ on:
   # from scientific-python-nightly-wheels
   schedule:
     - cron:  '12 13 * * 0'
+  # Allow manual triggering of the workflow (which will release the wheels to nightly)
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -198,7 +200,7 @@ jobs:
 
       - name: Upload wheel
         uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
-        if: github.repository == 'PyTables/PyTables' && github.event_name == 'schedule'
+        if: github.repository == 'PyTables/PyTables' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           artifacts_path: wheelhouse
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_ORG_UPLOAD_TOKEN}}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,7 +130,6 @@ jobs:
         env:
           CFLAGS: -g0
           HDF5_DIR: ${{ github.workspace }}/hdf5_build
-          HDF5_VERSION: 1.14.3
           MACOSX_DEPLOYMENT_TARGET: "10.9"
         if: runner.os != 'Windows' && steps.deps-cache.outputs.cache-hit != 'true'
         run: |

--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -103,9 +103,9 @@ fi
 pushd /tmp
 
 #                                   Remove trailing .*, to get e.g. '1.12' ↓
-curl -fsSLO "https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION%.*}/hdf5-${HDF5_VERSION%-*}/src/hdf5-${HDF5_VERSION}.tar.gz"
-tar -xzvf "hdf5-$HDF5_VERSION.tar.gz"
-pushd "hdf5-$HDF5_VERSION"
+curl -fsSLO "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
+tar -xzvf "hdf5_$HDF5_VERSION.tar.gz"
+pushd "hdf5-hdf5_$HDF5_VERSION"
 ./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" "$EXTRA_MPI_FLAGS" --enable-build-mode=production
 make -j "$NPROC"
 make install


### PR DESCRIPTION
1. Fix broken URL and associated dir structure
2. Change from emulation to native building using new publicly available Ubuntu arm64 runner
3. Update to latest HDF5 release
4. Add `workflow_dispatch` trigger

Takes care of https://github.com/PyTables/PyTables/issues/1115#issuecomment-2678888676