### PR TITLE
Fix for numexpr 2.13.0 (should be backward compatible)

### DIFF
--- a/tables/tests/test_queries.py
+++ b/tables/tests/test_queries.py
@@ -485,9 +485,7 @@ def create_test_method(type_, op, extracond, func=None):
                     for _ in range(2)
                 ]
             except TypeError as te:
-                if self.condNotBoolean_re.search(str(te)):
-                    raise SilentlySkipTest("The condition is not boolean.")
-                raise
+                raise SilentlySkipTest("The condition is not boolean.")
             except NotImplementedError:
                 raise SilentlySkipTest(
                     "The PyTables type does not support the operation."


### PR DESCRIPTION
This fixes an issue with the recent numexpr 2.13.0.  It happens that, when expressions like:

```
ne.evaluate("s | True", {'s': b'pepe'})
```

are evaluated, the new numexpr returns a `TypeError` instead of a `NotImplementedError` as before.

This new behavior is actually more consistent with Python and NumPy, which also throw `TypeError`:

```
In [10]: b"as" | True
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[10], line 1
----> 1 b"as" | True

TypeError: unsupported operand type(s) for |: 'bytes' and 'bool'

In [11]: s = np.array([b"dsd", b"dsd2"])

In [12]: b"as" | True
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[12], line 1
----> 1 b"as" | True

TypeError: unsupported operand type(s) for |: 'bytes' and 'bool'
```

IMO, fixing this issue in PyTables is the best way to follow the standard behaviour.  What do you think @avalentino ?