### PR TITLE
Set Cython "freethreading_compatible" directive.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1061,8 +1061,16 @@ if __name__ == "__main__":
                 # developer should have it installed, so it should not be
                 # a hard requisite
                 from Cython.Build import cythonize
+                from Cython import __version__ as cython_version
 
-                cythonize(str(extpfile), language_level="2")
+                compiler_directives = {}
+                if Version(cython_version) >= Version("3.1.0b1"):
+                    compiler_directives["freethreading_compatible"] = True
+
+                cythonize(
+                    str(extpfile),
+                    compiler_directives=compiler_directives,
+                    language_level="2")
             extfiles[extname] = extcfile
 
         return extfiles


### PR DESCRIPTION
If the Cython version is new enough, set the "freethreading_compatible" directive.

I need to do more testing yet but building with Python 3.14t and Cython 3.2.2, running "make check" passes.