### PR TITLE
Fix bug with alignment calls

### DIFF
--- a/tables/hdf5extension.pyx
+++ b/tables/hdf5extension.pyx
@@ -934,7 +934,7 @@ cdef class AttributeSet:
       # Get the NumPy dtype from the type_id
       try:
         stype_, shape_ = hdf5_to_np_ext_type(type_id, pure_numpy_types=True, ptparams=node._v_file.params)
-        dtype_ = np.dtype(stype_, shape_)
+        dtype_ = np.dtype((stype_, shape_))
       except TypeError:
         if class_id == H5T_STRING and H5Tis_variable_str(type_id):
           nelements = H5ATTRget_attribute_vlen_string_array(dset_id, cattrname,

--- a/tables/utilsextension.pyx
+++ b/tables/utilsextension.pyx
@@ -1602,9 +1602,9 @@ cdef int load_reference(hid_t dataset_id, hobj_ref_t *refbuf, size_t item_size, 
       # read entire dataset as numpy array
       stype_, shape_ = hdf5_to_np_ext_type(reftype_id, pure_numpy_types=True, atom=True)
       if stype_ == "_ref_":
-        dtype_ = np.dtype("O", shape_)
+        dtype_ = np.dtype(("O", shape_))
       else:
-        dtype_ = np.dtype(stype_, shape_)
+        dtype_ = np.dtype((stype_, shape_))
       shape = []
       for j in range(rank):
         shape.append(<int>dims[j])


### PR DESCRIPTION
⚠️ Not 100% sure this is correct since I've never looked at these source before and I'm just working based on the variable naming. Based on that naming and the [NumPy notes about the VisibleDeprecationWarning](https://numpy.org/doc/stable//release/2.4.0-notes.html#align-must-be-passed-as-boolean-to-np-dtype), it looks to my eye that the `VisibleDeprecationWarning` is warning us about a mistake at our end that this PR fixes. ⚠️

I found these using a `git grep "dtype(" -- "*.pyx"`, it's possible there were others. But locally using a `warnings.simplefilter("error")` in the vicinity of the original warning I think it'll fix it. I'll check the wheel build by eye...