### PR TITLE
Pass EXTRA_SERIAL_FLAGS to hdf5 configure.

### DIFF
--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -113,7 +113,7 @@ pushd /tmp
 curl -fsSLO "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
 tar -xzvf "hdf5_$HDF5_VERSION.tar.gz"
 pushd "hdf5-hdf5_$HDF5_VERSION"
-./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" "$EXTRA_MPI_FLAGS" --enable-build-mode=production
+./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" $EXTRA_SERIAL_FLAGS $EXTRA_MPI_FLAGS --enable-build-mode=production
 make -j "$NPROC"
 make install
 


### PR DESCRIPTION
The commit f73a360bb522de59a649113e5835fc8847cb0f55 introduced a bug where `configure` is no longer passed the `EXTRA_SERIAL_FLAGS` variable.  That undoes the change 1d4d04f45ec678483ca13f78a9d45a9ed9ee8d2a, which added `EXTRA_SERIAL_FLAGS="--enable-threadsafe"` to the configure options.  Without the `--enable-threadsafe` build option, the hdf5 library is not thread-safe.

This bug explains the segfault that was happening in CI when building 3.14t wheels.
