### PR TITLE
Vendor HDF5-Blosc2 v3.0.0 — fix c-blosc2 3.x compatibility properly

### DIFF
--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -29,6 +29,13 @@
 
 #define GET_FILTER(a, b, c, d, e, f, g) H5Pget_filter_by_id(a,b,c,d,e,f,g,NULL)
 
+/* BLOSC2_MAX_DIM was removed from blosc2.h in c-blosc2 3.x
+   (renamed to B2ND_MAX_DIM in b2nd.h).  Keep the pre-3.0 default
+   since hdf5-blosc2's CD-values layout assumes at most 8 dims. */
+#ifndef BLOSC2_MAX_DIM
+#define BLOSC2_MAX_DIM 8
+#endif
+
 /* Auxiliary filter values are:
  *
  * - 0: filter revision (FILTER_BLOSC2_VERSION)

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -29,13 +29,6 @@
 
 #define GET_FILTER(a, b, c, d, e, f, g) H5Pget_filter_by_id(a,b,c,d,e,f,g,NULL)
 
-/* BLOSC2_MAX_DIM was removed from blosc2.h in c-blosc2 3.x
-   (renamed to B2ND_MAX_DIM in b2nd.h).  Keep the pre-3.0 default
-   since hdf5-blosc2's CD-values layout assumes at most 8 dims. */
-#ifndef BLOSC2_MAX_DIM
-#define BLOSC2_MAX_DIM 8
-#endif
-
 /* Auxiliary filter values are:
  *
  * - 0: filter revision (FILTER_BLOSC2_VERSION)
@@ -45,14 +38,14 @@
  * - 4: compression level
  * - 5: shuffle method
  * - 6: compressor code
- * - 7: chunk rank (number of dimensions) (present if 1 < rank <= BLOSC2_MAX_DIM, for B2ND)
+ * - 7: chunk rank (number of dimensions) (present if 1 < rank <= B2ND_MAX_DIM, for B2ND)
  * - 8 + i: length of chunk dimension i (0 <= i < rank)
  *
  * If a value is specified, all values before it must be specified too.
  *
  * If the chunk rank is specified, chunk dimensions must follow.
  */
-#define MAX_FILTER_VALUES (8 + BLOSC2_MAX_DIM)
+#define MAX_FILTER_VALUES (8 + B2ND_MAX_DIM)
 /* Compression level default */
 #define DEFAULT_CLEVEL 5
 /* Shuffle default */
@@ -102,7 +95,7 @@ int register_blosc2(char **version, char **date){
 
     3. Compute the chunk size in bytes and store it in slot 3.
 
-    4. If 1 < rank <= BLOSC2_MAX_DIM, store it in slot 7, and chunk dimensions in the following slots.
+    4. If 1 < rank <= B2ND_MAX_DIM, store it in slot 7, and chunk dimensions in the following slots.
 */
 herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
 
@@ -164,7 +157,7 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
   fprintf(stderr, "Blosc2: Computed buffer size %d\n", bufsize);
 #endif
 
-  if (1 < ndim && ndim <= BLOSC2_MAX_DIM) {
+  if (1 < ndim && ndim <= B2ND_MAX_DIM) {
     if (nelements < 5) { values[4] = DEFAULT_CLEVEL; }
     if (nelements < 6) { values[5] = DEFAULT_SHUFFLE; }
     if (nelements < 7) { values[6] = DEFAULT_COMPCODE; }
@@ -179,7 +172,7 @@ herr_t blosc2_set_local(hid_t dcpl, hid_t type, hid_t space) {
     /* The user may be expecting more efficient storage than we can currently provide,
      * so convey some information when tracing. */
     BLOSC_TRACE_WARNING("Chunk rank %d exceeds B2ND build limit %d, "
-                        "using plain Blosc2 instead", ndim, BLOSC2_MAX_DIM);
+                        "using plain Blosc2 instead", ndim, B2ND_MAX_DIM);
   }
 
   r = H5Pmodify_filter(dcpl, FILTER_BLOSC2, flags, nelements, values);
@@ -304,7 +297,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
   /* Filter params that are only set for B2ND */
   int ndim = -1;
-  int32_t chunkshape[BLOSC2_MAX_DIM];
+  int32_t chunkshape[B2ND_MAX_DIM];
   size_t chunksize = typesize;
   if (cd_nelmts >= 8) {
     /* Get chunk shape for B2ND */
@@ -315,10 +308,10 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
                ndim);
       goto failed;
     }
-    if (ndim > BLOSC2_MAX_DIM) {
+    if (ndim > B2ND_MAX_DIM) {
       PUSH_ERR("blosc2_filter", H5E_CALLBACK,
                "Chunk rank %d (filter value) exceeds B2ND build limit %d",
-               ndim, BLOSC2_MAX_DIM);
+               ndim, B2ND_MAX_DIM);
       goto failed;
     }
     if (cd_nelmts < (size_t)(8 + ndim)) {
@@ -398,12 +391,12 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
         }
         blocksize = sugg_blocksize;
       }
-      int32_t blockdims[BLOSC2_MAX_DIM];
+      int32_t blockdims[B2ND_MAX_DIM];
       cparams.blocksize = compute_b2nd_block_shape(blocksize, typesize,
                                                    ndim, chunkshape,
                                                    blockdims);
 
-      int64_t chunkshape_l[BLOSC2_MAX_DIM];
+      int64_t chunkshape_l[B2ND_MAX_DIM];
       for (int i = 0; i < ndim; i++) {
         chunkshape_l[i] = chunkshape[i];
       }
@@ -511,7 +504,7 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
                  "B2ND array rank (%hhd) != filter rank (%d)", array->ndim, ndim);
         goto b2nd_decomp_out;
       }
-      int64_t start[BLOSC2_MAX_DIM], stop[BLOSC2_MAX_DIM], size = typesize;
+      int64_t start[B2ND_MAX_DIM], stop[B2ND_MAX_DIM], size = typesize;
       for (int i = 0; i < array->ndim; i++) {
         start[i] = 0;
         stop[i] = array->shape[i];

--- a/setup.py
+++ b/setup.py
@@ -1251,7 +1251,6 @@ if __name__ == "__main__":
         "include_dirs": inc_dirs,
     }
     def_macros.extend(abi3_macros)
-    def_macros.append(("BLOSC2_MAX_DIM", 8))
     extension_kwargs.update(abi3_ext_kwargs)
 
     extensions = [


### PR DESCRIPTION
C-Blosc2 3.x removed the BLOSC2_MAX_DIM macro from blosc2.h (renamed to
B2ND_MAX_DIM in b2nd.h, which always existed).  The temporary workaround
in 25b4701e added `def_macros.append(("BLOSC2_MAX_DIM", 8))` to setup.py
so the vendored hdf5-blosc2 filter could compile against 3.x headers.

This PR replaces that with the upstream fix from HDF5-Blosc2 v3.0.0:
https://github.com/Blosc/HDF5-Blosc2/releases/tag/v3.0.0

Changes:
- hdf5-blosc2/src/blosc2_filter.c: s/BLOSC2_MAX_DIM/B2ND_MAX_DIM/ (11 sites)
- setup.py: drop the `BLOSC2_MAX_DIM=8` workaround macro

Backward compatible with c-blosc2 2.x — B2ND_MAX_DIM was 8 pre-3.0,  16 in 3.x+.  No format or behavior change.