### PR TITLE
Fix typos in docstrings, comments and error messages

### DIFF
--- a/tables/atom.py
+++ b/tables/atom.py
@@ -644,7 +644,7 @@ class StringAtom(Atom):  # type: ignore[misc]
 
     @property  # type: ignore[misc]
     def itemsize(self) -> int:  # type: ignore[override]
-        """Size in bytes of a sigle item in the atom."""
+        """Size in bytes of a single item in the atom."""
         return self.dtype.base.itemsize
 
     def __init__(
@@ -864,7 +864,7 @@ class ComplexAtom(Atom):
 
     @property  # type: ignore[misc]
     def itemsize(self) -> int:  # type: ignore[override]
-        """Size in bytes of a sigle item in the atom."""
+        """Size in bytes of a single item in the atom."""
         return self.dtype.base.itemsize
 
     # Only instances have a `type` attribute, so complex types must be

--- a/tables/description.py
+++ b/tables/description.py
@@ -332,7 +332,7 @@ class Description:
 
     An instance of this class is automatically bound to Table (see
     :ref:`TableClassDescr`) objects when they are created.  It provides a
-    browseable representation of the structure of the table, made of non-nested
+    browsable representation of the structure of the table, made of non-nested
     (Col - see :ref:`ColClassDescr`) and nested (Description) columns.
 
     Column definitions under a description can be accessed as attributes of it
@@ -489,7 +489,7 @@ class Description:
         if not hasattr(newdict, "_v_nestedlvl"):
             newdict["_v_nestedlvl"] = nestedlvl + 1
 
-        cols_with_pos = []  # colum (position, name) pairs
+        cols_with_pos = []  # column (position, name) pairs
         cols_no_pos = []  # just column names
         cols_offsets = []  # the offsets of the columns
         valid_offsets = False  # by default there a no valid offsets

--- a/tables/exceptions.py
+++ b/tables/exceptions.py
@@ -163,7 +163,7 @@ class HDF5ExtError(RuntimeError):
             self.h5backtrace = None
 
     def __str__(self) -> str:
-        """Return a sting representation of the exception.
+        """Return a string representation of the exception.
 
         The actual result depends on policy set in the initializer
         :meth:`HDF5ExtError.__init__`.

--- a/tables/file.py
+++ b/tables/file.py
@@ -818,8 +818,8 @@ class File(hdf5extension.File):
             """The PyTables version number of this file."""
 
         # The node manager must be initialized before the root group
-        # initialization but the node_factory attribute is set onl later
-        # because it is a bound method of the root grop itself.
+        # initialization but the node_factory attribute is set only later
+        # because it is a bound method of the root group itself.
         node_cache_slots = params["NODE_CACHE_SLOTS"]
         self._node_manager = NodeManager(nslots=node_cache_slots)
 
@@ -1091,7 +1091,7 @@ class File(hdf5extension.File):
                 != obj.dtype
             ):
                 raise TypeError(
-                    "the desctiption parameter is not consistent "
+                    "the description parameter is not consistent "
                     "with the data type of the obj parameter"
                 )
             elif description is None:
@@ -1198,7 +1198,7 @@ class File(hdf5extension.File):
                 raise TypeError(
                     "if the obj parameter is not specified "
                     "(or None) then both the atom and shape "
-                    "parametes should be provided."
+                    "parameters should be provided."
                 )
             else:
                 # Making strides=(0,...) below is a trick to create the

--- a/tables/indexes.py
+++ b/tables/indexes.py
@@ -180,7 +180,7 @@ class IndexArray(indexesextension.IndexArray, NotLoggedMixin, EArray):
         return f"IndexArray(path={self._v_pathname})"
 
     def __repr__(self) -> str:
-        """Retunr the string representation of the IndexArray object."""
+        """Return the string representation of the IndexArray object."""
         return f"""{self}
   atom = {self.atom!r}
   shape = {self.shape}

--- a/tables/leaf.py
+++ b/tables/leaf.py
@@ -683,7 +683,7 @@ class Leaf(Node):
             if isinstance(key, tuple) and len(key) > len(self.shape):
                 raise IndexError(f"Invalid index or slice: {key!r}")
             # Try to convert key to a numpy array.  If not possible,
-            # a TypeError will be issued (to be catched later on).
+            # a TypeError will be issued (to be caught later on).
             try:
                 key = toarray(key)
             except ValueError:
@@ -924,7 +924,7 @@ class Leaf(Node):
 
         Return a :class:`ChunkInfo` instance with the information.
 
-        The coordinates need not be aligined with chunk boundaries.  This
+        The coordinates need not be aligned with chunk boundaries.  This
         means that this method may be used to get the start coordinates of the
         chunk that contains the item at the given coordinates, for use with
         other direct chunking operations (see :attr:`ChunkInfo.start`).

--- a/tables/table.py
+++ b/tables/table.py
@@ -923,7 +923,7 @@ class Table(tableextension.Table, Leaf):
                     column = self.cols._g_col(colname)
                     indexobj = column.index
                     if isinstance(indexobj, OldIndex):
-                        indexed = False  # Not a vaild index
+                        indexed = False  # Not a valid index
                         oldindexes = True
                         self._listoldindexes.append(colname)
                     else:
@@ -1734,7 +1734,7 @@ very small/large chunksize, you may want to increase/decrease it.""",
         if not hasattr(sequence, "__getitem__"):
             raise TypeError(
                 "Wrong 'sequence' parameter type. Only sequences "
-                "are suported."
+                "are supported."
             )
         # start, stop and step are necessary for the new iterator for
         # coordinates, and perhaps it would be useful to add them as
@@ -3177,7 +3177,7 @@ very small/large chunksize, you may want to increase/decrease it.""",
                 f"table ``{self._v_pathname}`` is being preempted from "
                 f"alive nodes without its buffers being flushed or with some "
                 f"index being dirty.  This may lead to very "
-                f"ineficient use of resources and even to fatal "
+                f"inefficient use of resources and even to fatal "
                 f"errors in certain situations.  Please do a call "
                 f"to the .flush() or .reindex_dirty() methods on "
                 f"this table before start using other nodes.",

--- a/tables/utils.py
+++ b/tables/utils.py
@@ -398,7 +398,7 @@ class NailedDict:
     # the set of usable indexes.
 
     def clear(self) -> None:
-        """Clear teh dictionsry."""
+        """Clear the dictionary."""
         self._cache.clear()
 
     def nail(self) -> None:


### PR DESCRIPTION
Fix a set of typos found in docstrings, inline comments, and error message strings across the core module files. None of these changes affect runtime behaviour — they are documentation/readability fixes only.

Changes:

- `tables/atom.py`: `sigle` → `single` (two `itemsize` docstrings in `StringAtom` and `ComplexAtom`)
- `tables/description.py`: `browseable` → `browsable` (class docstring), `colum` → `column` (inline comment)
- `tables/exceptions.py`: `sting` → `string` (`HDF5ExtError.__str__` docstring)
- `tables/file.py`: `desctiption` → `description` (error message), `parametes` → `parameters` (error message), `onl` → `only` + `grop` → `group` (inline comment pair)
- `tables/indexes.py`: `Retunr` → `Return` (`IndexArray.__repr__` docstring)
- `tables/leaf.py`: `catched` → `caught` (inline comment), `aligined` → `aligned` (docstring)
- `tables/table.py`: `vaild` → `valid` (inline comment), `suported` → `supported` (error message), `ineficient` → `inefficient` (warning message)
- `tables/utils.py`: `teh dictionsry` → `the dictionary` (`NailedDict.clear` docstring)

Found with codespell.