### PR TITLE
Build wheels against HDF5 2.2.0; fix blosc2 filter buffer-size bookkeeping

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # Keep in sync with "Prerequisites" in User's Guide.
-      HDF5_VERSION: 1.14.6  # H5Dchunk_iter needs at least 1.14.1
+      HDF5_VERSION: 2.2.0  # H5Dchunk_iter needs at least 1.14.1
       MACOSX_DEPLOYMENT_TARGET: "10.9"
     strategy:
       fail-fast: false

--- a/ci/github/get_hdf5.sh
+++ b/ci/github/get_hdf5.sh
@@ -4,14 +4,14 @@
 set -xeo pipefail
 
 PROJECT_DIR="$(pwd)"
-EXTRA_MPI_FLAGS=''
-EXTRA_SERIAL_FLAGS=""
+EXTRA_MPI_FLAGS=()
+EXTRA_SERIAL_FLAGS=()
 if [ -z ${HDF5_MPI+x} ]; then
     echo "Building serial"
-    EXTRA_SERIAL_FLAGS="--enable-threadsafe --enable-unsupported"
+    EXTRA_SERIAL_FLAGS=(-D "HDF5_ENABLE_THREADSAFE=ON" -D "HDF5_ALLOW_UNSUPPORTED=ON")
 else
     echo "Building with MPI"
-    EXTRA_MPI_FLAGS="--enable-parallel --enable-shared"
+    EXTRA_MPI_FLAGS=(-D "HDF5_ENABLE_PARALLEL=ON")
 fi
 
 mkdir -p $HDF5_DIR
@@ -34,11 +34,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     pushd /tmp
 
     brew install automake pkg-config
-    brew tap-new local/cmake
-    brew extract --version=3.31.6 cmake local/cmake
-    brew unlink cmake
-    brew update
-    brew install cmake@3.31.6
+    # Some of the dependencies built below (e.g. LZO) declare CMake minimums
+    # older than 3.5, which CMake >= 4 refuses to configure.  This is the
+    # supported escape hatch (the previous approach of pinning an old CMake
+    # via "brew extract" into a local tap is now rejected by Homebrew).
+    export CMAKE_POLICY_VERSION_MINIMUM=3.5
 
     # lzo
     curl -sLO https://www.oberhumer.com/opensource/lzo/download/lzo-$LZO_VERSION.tar.gz
@@ -109,13 +109,29 @@ fi
 
 pushd /tmp
 
-#                                   Remove trailing .*, to get e.g. '1.12' ↓
-curl -fsSLO "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
-tar -xzvf "hdf5_$HDF5_VERSION.tar.gz"
-pushd "hdf5-hdf5_$HDF5_VERSION"
-./configure --prefix="$HDF5_DIR" --with-zlib="$HDF5_DIR" $EXTRA_SERIAL_FLAGS $EXTRA_MPI_FLAGS --enable-build-mode=production
-make -j "$NPROC"
-make install
+# Releases after 2.1.0 are tagged with the plain version only (e.g. "2.2.0");
+# older releases use the "hdf5_X.Y.Z" tag convention.
+curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/${HDF5_VERSION}.tar.gz" \
+    || curl -fsSL -o "hdf5-$HDF5_VERSION.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
+mkdir -p "hdf5-$HDF5_VERSION"
+tar -xzf "hdf5-$HDF5_VERSION.tar.gz" --strip-components=1 -C "hdf5-$HDF5_VERSION"
+pushd "hdf5-$HDF5_VERSION"
+# HDF5 2.x dropped the Autotools build system, so build with CMake.
+cmake -S . -B build \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX="$HDF5_DIR" \
+    -D BUILD_TESTING=OFF \
+    -D BUILD_STATIC_LIBS=OFF \
+    -D HDF5_BUILD_EXAMPLES=OFF \
+    -D HDF5_BUILD_TOOLS=OFF \
+    -D HDF5_BUILD_UTILS=OFF \
+    -D CMAKE_INSTALL_LIBDIR=lib \
+    -D HDF5_ENABLE_ZLIB_SUPPORT=ON \
+    -D ZLIB_ROOT="$HDF5_DIR" \
+    "${EXTRA_SERIAL_FLAGS[@]}" \
+    "${EXTRA_MPI_FLAGS[@]}"
+make -C build -j "$NPROC"
+make -C build install
 
 file "$HDF5_DIR"/lib/*
 

--- a/hdf5-blosc2/src/blosc2_filter.c
+++ b/hdf5-blosc2/src/blosc2_filter.c
@@ -454,6 +454,15 @@ size_t blosc2_filter_function(unsigned flags, size_t cd_nelmts,
 
     }
 
+    if (status > 0) {
+      /* The cframe returned by Blosc2 is exactly `status` bytes long.  Report
+       * its real size instead of the precomputed guess: when the frame is
+       * larger than the guess (e.g. incompressible data), HDF5 >= 2.2.0
+       * rejects the write if the reported buffer size is smaller than the
+       * returned data size. */
+      outbuf_size = (size_t) status;
+    }
+
 #ifdef BLOSC2_DEBUG
     fprintf(stderr, "Blosc2: Compressed into %zd bytes\n", status);
 #endif


### PR DESCRIPTION
The Linux and macOS wheels currently bundle HDF5 1.14.6 (February 2025). Since then the HDF Group has shipped all security fixes on the 2.x line only — there have been no further 1.14.x releases — so the bundled library is affected by roughly 30 published CVEs. This PR moves the wheel builds to HDF5 2.2.0 (released 2026-07-29) and fixes a latent bug in the vendored `hdf5-blosc2` filter that HDF5 2.2.0's new filter-pipeline validation exposes.

## CVEs affecting HDF5 1.14.6

Fixed in 2.0.0 (~20 CVEs, all reachable by opening a crafted file):

* **CVE-2025-44905** — heap buffer overflow in `H5Z__filter_scaleoffset` (NVD rates 8.8 HIGH)
* **CVE-2025-2153**, **CVE-2025-2310**, **CVE-2025-2912** through **CVE-2025-2926**, **CVE-2025-6269**, **CVE-2025-6270**, **CVE-2025-6516**, **CVE-2025-6750**, **CVE-2025-6816** through **CVE-2025-6858**, **CVE-2025-7067** through **CVE-2025-7069** — heap/stack buffer overflows, use-after-frees, double frees, and NULL dereferences across the metadata parsers (object headers, free-space manager, local heaps, metadata cache, v1 B-trees)

Fixed in 2.1.0:

* **CVE-2025-44904** — heap buffer overflow in `H5VM_memcpyvv` via an unvalidated stored chunk size (NVD rates 8.8 HIGH)
* **CVE-2025-2308**, **CVE-2025-2309** — heap overflows in the scale-offset filter and `H5T__bit_copy`
* **CVE-2026-26197** ([GHSA-gh44-7wpq-622f](https://github.com/HDFGroup/hdf5/security/advisories/GHSA-gh44-7wpq-622f)), **CVE-2026-26199** ([GHSA-5c6x-jmgf-f5vc](https://github.com/HDFGroup/hdf5/security/advisories/GHSA-5c6x-jmgf-f5vc))

Fixed in 2.2.0:

* **CVE-2026-17572**, **CVE-2026-17573**, **CVE-2026-17574** — SOHM heap overflow, chunk-copy double free, vlen-datatype NULL dereference (HDF Group CNA lists <= 2.1.1 as affected)
* **CVE-2025-9274** — NULL callback dereference via `H5Aiterate2` (root cause fixed in the library)

The HDF Group's own CVE tracking with fix commits per version is at [HDFGroup/cve_hdf5](https://github.com/HDFGroup/cve_hdf5).

## Changes

* `HDF5_VERSION` 1.14.6 → 2.2.0 in `.github/workflows/wheels.yml`
* `ci/github/get_hdf5.sh`:
  * HDF5 2.x removed the Autotools build system, so the HDF5 build is converted to CMake (same conversion h5py did in h5py/h5py#2750). The old flags carry over directly: `--enable-threadsafe --enable-unsupported` → `HDF5_ENABLE_THREADSAFE=ON`/`HDF5_ALLOW_UNSUPPORTED=ON`, `--enable-parallel` → `HDF5_ENABLE_PARALLEL=ON`, `--enable-build-mode=production` → `CMAKE_BUILD_TYPE=Release`, `--with-zlib` → `HDF5_ENABLE_ZLIB_SUPPORT=ON`/`ZLIB_ROOT`. Two deliberate differences from the Autotools defaults, matching h5py's invocation: shared libraries now come from CMake's default (`--enable-shared` has no explicit counterpart), and tests, tools, utils, examples, and static libs — which Autotools built but the wheels never shipped — are explicitly disabled
  * Releases after 2.1.0 are tagged with the plain version only (e.g. `2.2.0`), so the download tries the plain tag first and falls back to the older `hdf5_X.Y.Z` convention
  * `-D CMAKE_INSTALL_LIBDIR=lib`: CMake defaults to `lib64` on manylinux, which broke `auditwheel repair` ("required library `libhdf5.so.320` could not be located"); this keeps installs in `hdf5_build/lib` exactly where the previous Autotools build put them
  * The Homebrew `brew extract`-based CMake 3.31 pin is replaced with `CMAKE_POLICY_VERSION_MINIMUM=3.5`: Homebrew now refuses formulas from untrusted local taps ("Refusing to load formula local/cmake/cmake@3.31.6"), and the env var is the supported escape hatch for dependencies with pre-3.5 CMake minimums (LZO 2.10). Note these two breakages were latent — the wheel workflow's native-deps cache has been hit for months, so `get_hdf5.sh` hadn't actually executed in CI until this PR changed the cache key
* `hdf5-blosc2/src/blosc2_filter.c`: report the real size of the buffer returned by the compress path (see below)
* Windows wheels get HDF5 from the micromamba (conda-forge) environment and are not affected by this pin

The minimum supported HDF5 for source builds is unchanged; this only affects what the wheels bundle.

## The blosc2 filter fix

HDF5 2.2.0 added a consistency check to `H5Z_pipeline` (absent in <= 2.1.1): after a filter callback, the reported data size must not exceed the reported buffer size ("buffer size is too small after filter callback").

The vendored blosc2 filter's compress path returns the cframe produced by `b2nd_to_cframe()`/`blosc2_schunk_to_buffer()` — a buffer allocated by Blosc2 that is exactly `status` bytes long — but sets `*buf_size` to the *precomputed guess* from `cd_values[3]`. Whenever the frame is larger than the guess (e.g. incompressible data, where Blosc2 adds format overhead), the filter reports a data size larger than the buffer size. Memory-wise this was always fine (the real allocation is `status` bytes), but the bookkeeping is wrong, and under HDF5 2.2.0 the new check turns it into a hard failure: chunk flushes fail (`HDF5ExtError: Problems appending the records`) or chunks are silently never written and read back as fill values.

Without the one-line fix, 44 test failures + 8 errors (all in `Blosc2*` test cases) occur against HDF5 2.2.0. Upstream [Blosc/HDF5-Blosc2](https://github.com/Blosc/HDF5-Blosc2) has the identical code and would benefit from the same fix.

## Testing

Built HDF5 1.14.6, 2.0.0, 2.1.1, and 2.2.0 locally on macOS arm64 (threadsafe, mirroring the flags in `ci/github/get_hdf5.sh`), built this branch against each, and ran the full test suite (`python -m tables.tests.test_all`, 6854 tests, Python 3.14, blosc2 4.9.1):

| libhdf5 | result |
|---|---|
| 1.14.6 (current pin) | OK — 6854 tests, 263 skipped |
| 2.0.0 | OK — 6854 tests, 263 skipped |
| 2.1.1 | OK — 6854 tests, 263 skipped |
| 2.2.0 (new pin) | OK — 6854 tests, 263 skipped |

For comparison, unpatched master against HDF5 2.2.0 fails 44 tests with 8 errors (all Blosc2), and passes cleanly against 1.14.6 — the failure is fully attributable to the filter size bookkeeping under the new HDF5 check.

The Linux path of `ci/github/get_hdf5.sh` was additionally verified by running it inside `quay.io/pypa/manylinux2014_aarch64` (the same invocation the wheels workflow uses): HDF5 2.2.0 builds and installs to `hdf5_build/lib`.

The filter fix has been proposed upstream as Blosc/HDF5-Blosc2#5.
