### PR TITLE
Make Table.where() treat a start with no stop like a Python slice

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,7 +10,11 @@
 Changes from 3.11.1 to 3.11.2
 =============================
 
-* TBW
+* :meth:`Table.where` (and hence :meth:`Table.read_where`,
+  :meth:`Table.get_where_list` and :meth:`Table.append_where`) now treats a
+  *start* with no *stop* like a Python slice, i.e. the rows from *start* to
+  the last one are considered.  Previously only one row was considered
+  (:issue:`797`).
 
 
 Changes from 3.11.0 to 3.11.1

--- a/tables/table.py
+++ b/tables/table.py
@@ -1571,6 +1571,11 @@ very small/large chunksize, you may want to increase/decrease it.""",
         .. versionchanged:: 3.0
            The start, stop and step parameters now behave like in slice.
 
+        .. versionchanged:: 3.11.2
+           If the *start* parameter is provided and *stop* is None then the
+           rows from *start* to the last one are considered.
+           In PyTables < 3.11.2 only one row was considered.
+
         """
         return self._where(condition, condvars, start, stop, step)
 
@@ -1588,7 +1593,10 @@ very small/large chunksize, you may want to increase/decrease it.""",
         if profile:
             show_stats("Entering table._where", tref)
         # Adjust the slice to be used.
-        start, stop, step = self._process_range_read(start, stop, step)
+        # NOTE: `_process_range` (and not `_process_range_read`) is used here
+        # on purpose, so that the range is interpreted like a Python slice,
+        # i.e. a `start` with no `stop` means "up to the last row".
+        start, stop, step = self._process_range(start, stop, step)
         if start >= stop:  # empty range, reset conditions
             self._use_index = False
             self._where_condition = None

--- a/tables/tests/test_tables.py
+++ b/tables/tests/test_tables.py
@@ -7135,6 +7135,90 @@ class Issue262TestCase(common.TempFileMixin, common.PyTablesTestCase):
         self.assertEqual(len(data), 0)
 
 
+class Issue797TestCase(common.TempFileMixin, common.PyTablesTestCase):
+    nrows = 20
+
+    def setUp(self):
+        super().setUp()
+
+        class IRecord(tb.IsDescription):
+            c1 = tb.Int32Col(pos=1)
+
+        table = self.h5file.create_table("/", "table", IRecord)
+        table.nrowsinbuf = 3
+
+        for i in range(self.nrows):
+            table.row["c1"] = i
+            table.row.append()
+
+        table.flush()
+
+    def test_gh797_where(self):
+        """Regression test for gh-797 (where with start and no stop)"""
+
+        table = self.h5file.root.table
+        rows = [row.nrow for row in table.where("c1 >= 0", start=10)]
+
+        if common.verbose:
+            print()
+            print("Selected rows -->", rows)
+        self.assertEqual(rows, list(range(10, self.nrows)))
+
+    def test_gh797_where_negative_start(self):
+        """Regression test for gh-797 (where with a negative start)"""
+
+        table = self.h5file.root.table
+        rows = [row.nrow for row in table.where("c1 >= 0", start=-5)]
+
+        if common.verbose:
+            print()
+            print("Selected rows -->", rows)
+        self.assertEqual(rows, list(range(self.nrows - 5, self.nrows)))
+
+    def test_gh797_where_start_beyond_end(self):
+        """Regression test for gh-797 (where with start >= nrows)"""
+
+        table = self.h5file.root.table
+        rows = [row.nrow for row in table.where("c1 >= 0", start=self.nrows)]
+
+        if common.verbose:
+            print()
+            print("Selected rows -->", rows)
+        self.assertEqual(rows, [])
+
+    def test_gh797_read_where(self):
+        """Regression test for gh-797 (read_where with start and no stop)"""
+
+        table = self.h5file.root.table
+        data = table.read_where("c1 >= 0", field="c1", start=10)
+
+        if common.verbose:
+            print()
+            print("data -->", data)
+        self.assertEqual(list(data), list(range(10, self.nrows)))
+
+    def test_gh797_get_where_list(self):
+        """Regression test for gh-797 (get_where_list, start and no stop)"""
+
+        table = self.h5file.root.table
+        coords = table.get_where_list("c1 >= 0", start=10)
+
+        if common.verbose:
+            print()
+            print("Selected coords -->", coords)
+        self.assertEqual(list(coords), list(range(10, self.nrows)))
+
+    def test_gh797_read_is_unchanged(self):
+        """Checking that Leaf.read() keeps its own single row semantics"""
+
+        array = self.h5file.create_array("/", "array", np.arange(self.nrows))
+
+        if common.verbose:
+            print()
+            print("data -->", array.read(start=10))
+        self.assertEqual(list(array.read(start=10)), [10])
+
+
 class TruncateTestCase(common.TempFileMixin, common.PyTablesTestCase):
     def setUp(self):
         super().setUp()
@@ -8033,6 +8117,7 @@ def suite():
         theSuite.addTest(common.make_suite(ZeroSizedTestCase))
         theSuite.addTest(common.make_suite(IrregularStrideTestCase))
         theSuite.addTest(common.make_suite(Issue262TestCase))
+        theSuite.addTest(common.make_suite(Issue797TestCase))
         theSuite.addTest(common.make_suite(TruncateOpen1))
         theSuite.addTest(common.make_suite(TruncateOpen2))
         theSuite.addTest(common.make_suite(TruncateClose1))


### PR DESCRIPTION
`Table.where()` documents that "the meaning of the start, stop and step
parameters is the same as for Python slices", but when only `start` is given it
scans a single row instead of running to the end of the table.

## Reproducer

```python
import tables as tb

class Record(tb.IsDescription):
    c1 = tb.Int32Col()

with tb.open_file("t.h5", "w") as f:
    t = f.create_table("/", "t", Record)
    for i in range(20):
        t.row["c1"] = i
        t.row.append()
    t.flush()

    print([r.nrow for r in t.where("c1 >= 0", start=10)])
    print([r.nrow for r in t.iterrows(start=10)])
```

Before this change:

```
[10]
[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
```

After:

```
[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
```

The same applied to `read_where()`, `get_where_list()` and `append_where()`,
which all go through `Table._where()`.  `append_where()` was internally
inconsistent as a result: with a condition it copied one row, without a
condition it fell back to `iterrows()` and copied everything up to the end.

## Fix

`Table._where()` used `Leaf._process_range_read()`, which contains a
`read()`-specific special case that turns a lone `start` into `stop = start + 1`.
`Leaf._process_range()` is the plain Python-slice version, and it is what
`Table.read()`, `Table.iterrows()` and `Table.__getitem__()` already use.
Switching the call site is the fix; the shared helper is left alone so that
`Array.read(start=N)` and friends keep their documented single-row semantics.

This is the same one-line move that was applied to `Table.itersequence()` in
2013 (`A.V. 20130513: _process_range_read --> _process_range`) and to
`Table.iterrows()` in 3.0.  `where()` already carries a
`.. versionchanged:: 3.0  The start, stop and step parameters now behave like in
slice.` note, so this call site looks like one that was simply missed back then.

## Side effect worth calling out

`_process_range_read()` also raises `IndexError` when `start >= nrows`, and that
raise only fires on the start-only path.  With `_process_range()` the range is
clamped instead, so `table.where(cond, start=table.nrows)` now yields nothing
rather than raising, which is what `list[nrows:]`, `Table.read(start=nrows)` and
`Table.iterrows(start=nrows)` already do.  There is a test pinning this.
Passing an explicit `stop` never raised, so nothing that already worked changes.

## Verification

New `Issue797TestCase` in `tables/tests/test_tables.py`, next to the existing
`Issue262TestCase`, and registered in `suite()`.  Without the `table.py` change,
5 of its 6 tests fail:

```
FAILED tables/tests/test_tables.py::Issue797TestCase::test_gh797_get_where_list
FAILED tables/tests/test_tables.py::Issue797TestCase::test_gh797_read_where
FAILED tables/tests/test_tables.py::Issue797TestCase::test_gh797_where
FAILED tables/tests/test_tables.py::Issue797TestCase::test_gh797_where_negative_start
FAILED tables/tests/test_tables.py::Issue797TestCase::test_gh797_where_start_beyond_end
================= 5 failed, 1 passed, 1589 deselected in 1.51s =================
```

for example

```
E       AssertionError: Lists differ: [np.int64(10)] != [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
E       - [np.int64(10)]
E       + [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
```

With the change, all 6 pass.  The sixth test (`test_gh797_read_is_unchanged`)
is the guard against "fixing" this in `_process_range_read()` instead: it fails
if `Array.read(start=10)` stops returning a single row.

I also checked that the indexed-query path (with `will_query_use_indexing()`
reporting the column as usable) returns the same rows as the in-kernel path for
a start-only range, including a negative start.

Full suite, run the way CI runs it (`python -m tables.tests.test_all`, HDF5
1.14.6, NumPy 2.5.1, Python 3.13):

```
Ran 6860 tests in 333.499s

OK (skipped=253)
```

`flake8`, `isort --check` and `black --check` over `tables/` are clean.

## Not changed

* `Leaf._process_range_read()` — `Array`/`CArray`/`EArray`/`VLArray` `read()`
  keep the single-row behaviour, and `BasicRangeTestCase` in
  `tables/tests/test_tables.py` explicitly encodes that distinction.
* `Table._g_copy_with_stats()`, which also calls `_process_range_read()`.
* The `.. versionchanged::` note and the release notes entry assume 3.11.2;
  happy to retarget if the next release is numbered differently.

Heads-up on overlap: #937 (reverse `where()` iterator, negative step) edits the
same line in `_where()` for an unrelated reason, so whichever lands second will
need a trivial rebase.  It does not address this issue and I have not touched it.

Reported by @kanak in #797; @avalentino diagnosed it there and pointed at
exactly this call site.

Closes #797
